### PR TITLE
ORC tz split 3/6: OrcTimezoneInfo runtime build and registry

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
@@ -411,4 +411,305 @@ class OrcTimezoneInfo {
     return new int[]{month, baseDayOfMonth, dayOfWeek, timeInDay, DstRuleMode.DOW_GE_DOM_MODE.value};
   }
 
+  /**
+   * Verify the extracted DST rule matches JVM getOffset() around transition boundaries
+   * and at monthly sample points for refYear +/- 1 (3 years).
+   *
+   * DST rule mismatches only manifest at transition boundaries, so we check
+   * +/- 12 hours around each computed transition plus one sample per month.
+   * This reduces ~52K getOffset() calls per verification to ~200.
+   */
+  private static boolean verifyDstRule(TimeZone tz, DstRule rule, int refYear) {
+    int rawOffsetMs = tz.getRawOffset();
+    for (int y = refYear - 1; y <= refYear + 1; y++) {
+      long dstStart = computeTransitionUtcMillis(y, rule.startMonth, rule.startDay,
+          rule.startDayOfWeek, rule.startTime, rule.startTimeMode, rule.startMode,
+          rawOffsetMs, rule.dstSavings, true);
+      long dstEnd = computeTransitionUtcMillis(y, rule.endMonth, rule.endDay,
+          rule.endDayOfWeek, rule.endTime, rule.endTimeMode, rule.endMode,
+          rawOffsetMs, rule.dstSavings, false);
+
+      // Check +/- 12 hours around each transition at hourly granularity
+      long[] boundaries = {dstStart, dstEnd};
+      for (long boundary : boundaries) {
+        long from = boundary - 12 * 3600_000L;
+        long to = boundary + 12 * 3600_000L;
+        for (long ms = from; ms <= to; ms += 3600_000L) {
+          if (tz.getOffset(ms) != computeDstOffset(ms, rawOffsetMs, rule)) {
+            return false;
+          }
+        }
+      }
+
+      // Monthly mid-period spot checks (1st of each month at noon UTC)
+      for (int m = 0; m < 12; m++) {
+        long ms = utcMillisForDate(y, m, 1) + 12 * 3600_000L;
+        if (tz.getOffset(ms) != computeDstOffset(ms, rawOffsetMs, rule)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static int computeDstOffset(long utcMs, int rawOffsetMs, DstRule rule) {
+    int year = LocalDate.ofEpochDay(Math.floorDiv(utcMs + rawOffsetMs, 86_400_000L)).getYear();
+    long dstStart = computeTransitionUtcMillis(year, rule.startMonth, rule.startDay,
+        rule.startDayOfWeek, rule.startTime, rule.startTimeMode, rule.startMode,
+        rawOffsetMs, rule.dstSavings, true);
+    long dstEnd = computeTransitionUtcMillis(year, rule.endMonth, rule.endDay,
+        rule.endDayOfWeek, rule.endTime, rule.endTimeMode, rule.endMode,
+        rawOffsetMs, rule.dstSavings, false);
+
+    boolean inDst = dstStart < dstEnd ?
+        (utcMs >= dstStart && utcMs < dstEnd) :
+        (utcMs >= dstStart || utcMs < dstEnd);
+    return inDst ? rawOffsetMs + rule.dstSavings : rawOffsetMs;
+  }
+
+  private static long computeTransitionUtcMillis(int year, int ruleMonth, int ruleDay,
+      int ruleDayOfWeek, int ruleTime, int ruleTimeMode, int ruleMode, int rawOffsetMs,
+      int dstSavingsMs, boolean isStartRule) {
+    int actualDay = computeRuleDay(ruleMode, ruleDay, ruleDayOfWeek, year, ruleMonth);
+    long utcMs = utcMillisForDate(year, ruleMonth, actualDay) + ruleTime;
+    if (ruleTimeMode == 0) {
+      utcMs -= rawOffsetMs;
+      if (!isStartRule) {
+        utcMs -= dstSavingsMs;
+      }
+    } else if (ruleTimeMode == 1) {
+      utcMs -= rawOffsetMs;
+    }
+    return utcMs;
+  }
+
+  private static int computeRuleDay(int ruleMode, int ruleDay, int ruleDayOfWeek, int year,
+      int month) {
+    LocalDate firstOfMonth = LocalDate.of(year, month + 1, 1);
+    int monthLength = firstOfMonth.lengthOfMonth();
+    int firstDayOfWeek = toCalendarDayOfWeek(firstOfMonth.getDayOfWeek().getValue());
+
+    switch (ruleMode) {
+      case 1: {
+        if (ruleDay > 0) {
+          int diff = ruleDayOfWeek - firstDayOfWeek;
+          if (diff < 0) {
+            diff += 7;
+          }
+          return 1 + diff + (ruleDay - 1) * 7;
+        } else {
+          int lastDayOfWeek = toCalendarDayOfWeek(
+              LocalDate.of(year, month + 1, monthLength).getDayOfWeek().getValue());
+          int diff = lastDayOfWeek - ruleDayOfWeek;
+          if (diff < 0) {
+            diff += 7;
+          }
+          return monthLength - diff + (ruleDay + 1) * 7;
+        }
+      }
+      case 2: {
+        int targetDayOfWeek = toCalendarDayOfWeek(
+            LocalDate.of(year, month + 1, ruleDay).getDayOfWeek().getValue());
+        int diff = ruleDayOfWeek - targetDayOfWeek;
+        if (diff < 0) {
+          diff += 7;
+        }
+        return ruleDay + diff;
+      }
+      case 3: {
+        int targetDayOfWeek = toCalendarDayOfWeek(
+            LocalDate.of(year, month + 1, ruleDay).getDayOfWeek().getValue());
+        int diff = targetDayOfWeek - ruleDayOfWeek;
+        if (diff < 0) {
+          diff += 7;
+        }
+        return ruleDay - diff;
+      }
+      default:
+        return ruleDay;
+    }
+  }
+
+  private static long utcMillisForDate(int year, int month, int day) {
+    return LocalDate.of(year, month + 1, day).toEpochDay() * 24L * 3600_000L;
+  }
+
+  @Override
+  public String toString() {
+    return "OrcTimezoneInfo{" +
+        "initialOffset=" + initialOffset +
+        ", rawOffset=" + rawOffset +
+        ", transitions=" + Arrays.toString(transitions) +
+        ", offsets=" + Arrays.toString(offsets) +
+        '}';
+  }
+
+  private static final ConcurrentMap<String, OrcTimezoneInfo> RUNTIME_TIMEZONE_INFOS =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Get timezone info for the specified timezone ID.
+   * Historical transitions are generated at runtime from public JVM APIs and cached per ID.
+   *
+   * @param timezoneId timezone Id
+   * @return timezone info with DST rules
+   */
+  public static OrcTimezoneInfo get(String timezoneId) {
+    return RUNTIME_TIMEZONE_INFOS.computeIfAbsent(
+        timezoneId,
+        OrcTimezoneInfo::buildRuntimeOrcTimezoneInfo);
+  }
+
+  /**
+   * Build ORC timezone metadata from public java.time/java.util APIs. Invalid IDs use the same
+   * validation as {@link GpuTimeZoneDB#getZoneId(String)} and fail with
+   * {@link IllegalArgumentException} (no silent fallback to GMT).
+   *
+   * <p><b>Cost:</b> this is non-trivial — it scans every historical {@link ZoneOffsetTransition}
+   * from year 1 onward, probes {@link TimeZone#getOffset(long)} hourly to extract the recurring
+   * DST rule, and then verifies the rule across multiple reference years. Measured on an Intel
+   * i7-10700K with OpenJDK 17, a cold build takes ~4 ms typical and up to ~12 ms for the worst
+   * zones (e.g. {@code ART}). Results are cached in {@link #RUNTIME_TIMEZONE_INFOS} (see
+   * {@link #get(String)}), so callers should always go through {@code get(...)} rather than
+   * invoking this directly.
+   */
+  private static OrcTimezoneInfo buildRuntimeOrcTimezoneInfo(String timezoneId) {
+    final ZoneId zoneId;
+    try {
+      zoneId = GpuTimeZoneDB.getZoneId(timezoneId);
+    } catch (DateTimeException e) {
+      throw new IllegalArgumentException("Timezone ID not found: " + timezoneId, e);
+    }
+
+    ZoneRules rules = zoneId.getRules();
+    if (rules.isFixedOffset()) {
+      // IDs like "+05:30" are valid ZoneIds but TimeZone.getTimeZone() silently
+      // maps them to GMT (offset 0). Derive the offset from ZoneRules instead so
+      // the GPU path doesn't treat them as UTC.
+      int fixedOffsetMs = rules.getOffset(Instant.EPOCH).getTotalSeconds() * 1000;
+      return new OrcTimezoneInfo(fixedOffsetMs, fixedOffsetMs, null, null, null);
+    }
+    TimeZone tz = TimeZone.getTimeZone(timezoneId);
+    int initialOffset = getInitialOffset(tz);
+    DstRule dstRule = extractDstRule(timezoneId, tz, rules);
+
+    List<ZoneOffsetTransition> transitionList = rules.getTransitions();
+    HistoricalTransitions historicalTransitions = buildHistoricalTransitions(tz, transitionList);
+    if (historicalTransitions.transitions == null) {
+      return new OrcTimezoneInfo(initialOffset, tz.getRawOffset(), null, null, dstRule);
+    }
+    return new OrcTimezoneInfo(initialOffset, tz.getRawOffset(),
+        historicalTransitions.transitions, historicalTransitions.offsets, dstRule);
+  }
+
+  public static List<String> getAllTimezoneIds() {
+
+    String[] ids = TimeZone.getAvailableIDs();
+    Arrays.sort(ids);
+    return Arrays.asList(ids);
+  }
+
+  private static int getInitialOffset(TimeZone tz) {
+    // ORC only supports timestamps from year 0001 onward. For dates before the
+    // first historical transition in that range, java.util.TimeZone can differ
+    // from ZoneRules' earliest wall offset (for example, it may use the zone's
+    // standard raw offset instead of an older LMT offset). Sample the beginning
+    // of the supported range so the GPU matches TimeZone.getOffset().
+    return tz.getOffset(MIN_SUPPORTED_ORC_UTC_MILLIS);
+  }
+
+  private static HistoricalTransitions buildHistoricalTransitions(
+      TimeZone tz,
+      List<ZoneOffsetTransition> transitionList) {
+    if (transitionList.isEmpty()) {
+      return HistoricalTransitions.EMPTY;
+    }
+
+    List<Long> transitions = new ArrayList<>();
+    List<Integer> offsets = new ArrayList<>();
+    long scanCursor = MIN_SUPPORTED_ORC_UTC_MILLIS;
+    int currentOffset = getInitialOffset(tz);
+
+    for (ZoneOffsetTransition transition : transitionList) {
+      long transitionMs = transition.getInstant().toEpochMilli();
+      if (transitionMs < MIN_SUPPORTED_ORC_UTC_MILLIS) {
+        continue;
+      }
+
+      long beforeTransitionMs = transitionMs - 1;
+      int offsetBeforeTransition = tz.getOffset(beforeTransitionMs);
+      if (beforeTransitionMs >= scanCursor && offsetBeforeTransition != currentOffset) {
+        currentOffset = collectTimeZoneTransitionsByScanning(
+            tz, scanCursor, beforeTransitionMs, currentOffset, transitions, offsets);
+      }
+
+      int offsetAtTransition = tz.getOffset(transitionMs);
+      if (offsetAtTransition != offsetBeforeTransition) {
+        transitions.add(transitionMs);
+        offsets.add(offsetAtTransition);
+        currentOffset = offsetAtTransition;
+      }
+      scanCursor = transitionMs;
+    }
+
+    if (transitions.isEmpty()) {
+      return HistoricalTransitions.EMPTY;
+    }
+    return new HistoricalTransitions(toLongArray(transitions), toIntArray(offsets));
+  }
+
+  private static int collectTimeZoneTransitionsByScanning(
+      TimeZone tz,
+      long scanStartMs,
+      long scanEndMs,
+      int startOffset,
+      List<Long> transitions,
+      List<Integer> offsets) {
+    long cursor = scanStartMs;
+    int currentOffset = startOffset;
+    while (cursor < scanEndMs) {
+      long probe = Math.min(cursor + HISTORICAL_TRANSITION_SCAN_STEP_MILLIS, scanEndMs);
+      int probeOffset = tz.getOffset(probe);
+      if (probeOffset == currentOffset) {
+        cursor = probe;
+        continue;
+      }
+
+      long exactTransition = binarySearchTransition(tz, cursor, probe);
+      int offsetAfterTransition = tz.getOffset(exactTransition);
+      transitions.add(exactTransition);
+      offsets.add(offsetAfterTransition);
+      currentOffset = offsetAfterTransition;
+      cursor = exactTransition;
+    }
+    return currentOffset;
+  }
+
+  private static long[] toLongArray(List<Long> values) {
+    long[] result = new long[values.size()];
+    for (int i = 0; i < values.size(); i++) {
+      result[i] = values.get(i);
+    }
+    return result;
+  }
+
+  private static int[] toIntArray(List<Integer> values) {
+    int[] result = new int[values.size()];
+    for (int i = 0; i < values.size(); i++) {
+      result[i] = values.get(i);
+    }
+    return result;
+  }
+
+  private static final class HistoricalTransitions {
+    static final HistoricalTransitions EMPTY = new HistoricalTransitions(null, null);
+
+    final long[] transitions;
+    final int[] offsets;
+
+    private HistoricalTransitions(long[] transitions, int[] offsets) {
+      this.transitions = transitions;
+      this.offsets = offsets;
+    }
+  }
 }


### PR DESCRIPTION
Part of the split of #4432.
Companion: https://github.com/NVIDIA/spark-rapids/pull/14544
Previous: #4546

Completes OrcTimezoneInfo by adding the runtime build pipeline and the remaining DST math helpers:

- verifyDstRule, verifyDstRuleAcrossReferenceYears: lightweight verification (~200 getOffset() calls instead of ~52K).
- computeDstOffset, computeTransitionUtcMillis, computeRuleDay, utcMillisForDate: SimpleTimeZone-compatible offset math.
- toString.
- RUNTIME_TIMEZONE_INFOS registry, get(timezoneId), buildRuntimeOrcTimezoneInfo, getAllTimezoneIds.
- getInitialOffset, buildHistoricalTransitions, collectTimeZoneTransitionsByScanning, toLongArray / toIntArray, and the HistoricalTransitions value class.

After this PR, `OrcTimezoneInfo.java` matches the version in #4432. Callers introduced in #orc-tz-1 now resolve.

Signed-off-by: Chong Gao <chongg@nvidia.com>