### PR TITLE
Add stricter compiler warning flags

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -94,6 +94,23 @@ rapids_find_package(CUDAToolkit REQUIRED)
 # Set a default build type if none was specified
 rapids_cmake_build_type("Release")
 
+set(SPARK_RAPIDS_JNI_STRICT_CXX_WARNING_FLAGS
+    -Wshadow
+    -Wnon-virtual-dtor
+    -Woverloaded-virtual
+)
+set(SPARK_RAPIDS_JNI_STRICT_CUDA_WARNING_FLAGS
+    -Xcompiler=-Wshadow,-Wnon-virtual-dtor,-Woverloaded-virtual
+)
+
+function(spark_rapids_jni_add_strict_warning_flags target_name)
+  target_compile_options(
+    ${target_name}
+    PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${SPARK_RAPIDS_JNI_STRICT_CXX_WARNING_FLAGS}>"
+            "$<$<COMPILE_LANGUAGE:CUDA>:${SPARK_RAPIDS_JNI_STRICT_CUDA_WARNING_FLAGS}>"
+  )
+endfunction()
+
 # ##################################################################################################
 # * dependencies ----------------------------------------------------------------------------------
 
@@ -304,6 +321,7 @@ target_compile_options(
   spark_rapids_jni PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
                            "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>"
 )
+spark_rapids_jni_add_strict_warning_flags(spark_rapids_jni)
 
 # Specify include paths for the current target and dependents
 target_include_directories(
@@ -349,6 +367,7 @@ set_target_properties(spark_rapids_jni PROPERTIES OUTPUT_NAME "cudf")
 
 add_library(cudfjnistub SHARED src/emptyfile.cpp)
 set_target_properties(cudfjnistub PROPERTIES OUTPUT_NAME "cudfjni")
+spark_rapids_jni_add_strict_warning_flags(cudfjnistub)
 target_link_libraries(cudfjnistub -Wl,--no-as-needed $<TARGET_FILE:spark_rapids_jni> -Wl,--as-needed)
 add_dependencies(cudfjnistub spark_rapids_jni)
 
@@ -374,6 +393,7 @@ target_include_directories(
           "${CUDAToolkit_INCLUDE_DIRS}"
 )
 
+spark_rapids_jni_add_strict_warning_flags(nvmljni)
 target_link_libraries(nvmljni nvidia-ml)
 
 # ##################################################################################################
@@ -406,6 +426,7 @@ if(USE_GDS)
     spark_rapids_jni
     CUDA::cuFile_static
   )
+  spark_rapids_jni_add_strict_warning_flags(cufilejni)
   rapids_cuda_set_runtime(cufilejni USE_STATIC ON)
 endif()
 

--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -21,6 +21,7 @@ target_compile_options(
   spark_rapids_jni_datagen PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
                       "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>"
 )
+spark_rapids_jni_add_strict_warning_flags(spark_rapids_jni_datagen)
 
 target_link_libraries(
   spark_rapids_jni_datagen PUBLIC cudf::cudf nvtx3::nvtx3-cpp
@@ -40,6 +41,7 @@ function(ConfigureBench CMAKE_BENCH_NAME)
     target_compile_options(${CMAKE_BENCH_NAME}
             PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
                     "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>")
+    spark_rapids_jni_add_strict_warning_flags(${CMAKE_BENCH_NAME})
 
     target_include_directories(${CMAKE_BENCH_NAME}
             PRIVATE "$<BUILD_INTERFACE:${CUDF_DIR}/cpp>"

--- a/src/main/cpp/faultinj/CMakeLists.txt
+++ b/src/main/cpp/faultinj/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(
   faultinj.cu
 )
 
+spark_rapids_jni_add_strict_warning_flags(cufaultinj)
+
 target_link_libraries(
   cufaultinj PRIVATE spdlog::spdlog_header_only
 )

--- a/src/main/cpp/profiler/CMakeLists.txt
+++ b/src/main/cpp/profiler/CMakeLists.txt
@@ -59,6 +59,8 @@ target_include_directories(
           "${SPARK_RAPIDS_JNI_SOURCE_DIR}/src"
 )
 
+spark_rapids_jni_add_strict_warning_flags(profilerjni)
+
 find_library(CUPTI_LIBRARY_PATH cupti_static PATHS
   "/usr/local/cuda/lib64"
   "/usr/local/cuda/extras/CUPTI/lib64"
@@ -93,6 +95,8 @@ target_include_directories(
   "${SPARK_RAPIDS_JNI_SOURCE_DIR}/src"
   "${SPARK_RAPIDS_JNI_GENERATED_INCLUDE_DIR}"
 )
+
+spark_rapids_jni_add_strict_warning_flags(spark_rapids_profile_converter)
 
 target_link_libraries(spark_rapids_profile_converter
   "${CUPTI_LIBRARY_PATH}"

--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(spark_rapids_jni_test_common OBJECT)
 target_compile_options(spark_rapids_jni_test_common
                 PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
                         "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>")
+spark_rapids_jni_add_strict_warning_flags(spark_rapids_jni_test_common)
 target_link_libraries(
     spark_rapids_jni_test_common
     PUBLIC cudf::cudftestutil GTest::gmock GTest::gmock_main GTest::gtest GTest::gtest_main
@@ -36,6 +37,7 @@ function(ConfigureTest CMAKE_TEST_NAME)
     target_compile_options(${CMAKE_TEST_NAME}
                 PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
                         "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>")
+    spark_rapids_jni_add_strict_warning_flags(${CMAKE_TEST_NAME})
     target_include_directories(${CMAKE_TEST_NAME}
                 PRIVATE "$<BUILD_INTERFACE:${SPARK_RAPIDS_JNI_SOURCE_DIR}>"
                         "$<BUILD_INTERFACE:${SPARK_RAPIDS_JNI_SOURCE_DIR}/src>")


### PR DESCRIPTION
## Summary

- add project-level strict warning flags for `-Wshadow`, `-Wnon-virtual-dtor`, and `-Woverloaded-virtual`
- pass the same warnings to CUDA host compilation via `-Xcompiler`
- apply the warning helper across the JNI library, test, benchmark, profiler, fault-injection, and auxiliary JNI targets

## Related Issue

Closes #4497

## Testing

- [x] `git diff --check`
- [ ] Full native/CUDA build not run locally: this Windows shell does not have `cmake`/CUDA configured, and the cuDF submodule is not initialized here.