### PR TITLE
Replace Apache Thrift by cudf APIs for Parquet footer reading/writing

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -175,28 +175,9 @@ find_library(ARROW_LIB "libarrow.a" REQUIRED NO_DEFAULT_PATH
   HINTS "${CUDFJNI_BUILD_DIR}/_deps/arrow-build/release/"
 )
 
-# parquet
-find_library(PARQUET_LIB "libparquet.a" REQUIRED NO_DEFAULT_PATH
-  HINTS "${CUDFJNI_BUILD_DIR}/_deps/arrow-build/release/"
-)
-
-# Internal parquet headers
-set (GENERATED_PARQUET_INCLUDE
-    "${CUDFJNI_BUILD_DIR}/_deps/arrow-src/cpp/src/"
-    CACHE STRING "generated parquet thrift headers"
-)
-
-# thrift
-find_library(THRIFT_LIB "libthrift.a" REQUIRED NO_DEFAULT_PATH
-    HINTS "${CUDFJNI_BUILD_DIR}/lib/"
-)
-
 set(CUDFJNI_INCLUDE_DIRS
   "${CUDF_DIR}/java/src/main/native/include"
   "${CUDF_DIR}/java/src/main/native/src"
-  "${GENERATED_PARQUET_INCLUDE}"
-  "${CUDFJNI_BUILD_DIR}/_deps/thrift-build/"
-  "${CUDFJNI_BUILD_DIR}/_deps/thrift-src/lib/cpp/src/"
 )
 
 # ##################################################################################################
@@ -346,8 +327,6 @@ target_link_libraries(
     cuco::cuco
     spdlog::spdlog_header_only
     ${ARROW_LIB}
-    ${PARQUET_LIB}
-    ${THRIFT_LIB}
 )
 rapids_cuda_set_runtime(spark_rapids_jni USE_STATIC ON)
 set_target_properties(spark_rapids_jni PROPERTIES LINK_LANGUAGE "CXX")

--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -14,28 +14,24 @@
  * limitations under the License.
  */
 
-#include <cwctype>
-#include <limits>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include <vector>
-
-// TCompactProtocol requires some #defines to work right.
-// This came from the parquet code itself...
-#define SIGNED_RIGHT_SHIFT_IS  1
-#define ARITHMETIC_RIGHT_SHIFT 1
 #include "cudf_jni_apis.hpp"
 #include "jni_utils.hpp"
 #include "nvtx_ranges.hpp"
 
-#include <generated/parquet_types.h>
-#include <thrift/TApplicationException.h>
-#include <thrift/protocol/TCompactProtocol.h>
-#include <thrift/transport/TBufferTransports.h>
+#include <cudf/io/parquet_metadata.hpp>
+#include <cudf/io/parquet_schema.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <cwctype>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace rapids {
 namespace jni {
+
+namespace pq = cudf::io::parquet;
 
 /**
  * Convert a string to lower case. It uses std::tolower per character which has limitations
@@ -107,7 +103,7 @@ struct column_pruning_maps {
  * correct even when the footer contains only a subset of the file's row groups.
  */
 struct parquet_footer_with_row_group_offsets {
-  std::unique_ptr<parquet::format::FileMetaData> meta;
+  std::unique_ptr<pq::FileMetaData> meta;
   std::vector<int64_t> row_index_offsets;  // one per row group in meta
 };
 
@@ -147,7 +143,7 @@ class column_pruner {
    * Given a schema from a parquet file create a set of pruning maps to prune columns from the rest
    * of the footer
    */
-  column_pruning_maps filter_schema(std::vector<parquet::format::SchemaElement> const& schema,
+  column_pruning_maps filter_schema(std::vector<pq::SchemaElement> const& schema,
                                     bool const ignore_case) const
   {
     SRJ_FUNC_RANGE();
@@ -172,18 +168,14 @@ class column_pruner {
   }
 
  private:
-  std::string get_name(parquet::format::SchemaElement& elem,
-                       bool const normalize_case = false) const
+  std::string get_name(pq::SchemaElement& elem, bool const normalize_case = false) const
   {
     return normalize_case ? unicode_to_lower(elem.name) : elem.name;
   }
 
-  int get_num_children(parquet::format::SchemaElement& elem) const
-  {
-    return elem.__isset.num_children ? elem.num_children : 0;
-  }
+  int get_num_children(pq::SchemaElement& elem) const { return elem.num_children; }
 
-  void skip(std::vector<parquet::format::SchemaElement> const& schema,
+  void skip(std::vector<pq::SchemaElement> const& schema,
             std::size_t& current_input_schema_index,
             std::size_t& next_input_chunk_index) const
   {
@@ -192,12 +184,10 @@ class column_pruner {
     int num_to_skip = 1;
     while (num_to_skip > 0 && current_input_schema_index < schema.size()) {
       auto schema_item = schema[current_input_schema_index];
-      bool is_leaf     = schema_item.__isset.type;
+      bool is_leaf     = schema_item.type != pq::Type::UNDEFINED;
       if (is_leaf) { ++next_input_chunk_index; }
 
-      if (schema_item.__isset.num_children) {
-        num_to_skip = num_to_skip + schema_item.num_children;
-      }
+      num_to_skip = num_to_skip + schema_item.num_children;
 
       --num_to_skip;
       ++current_input_schema_index;
@@ -207,7 +197,7 @@ class column_pruner {
   /**
    * filter_schema, but specific to Tag::STRUCT.
    */
-  void filter_schema_struct(std::vector<parquet::format::SchemaElement> const& schema,
+  void filter_schema_struct(std::vector<pq::SchemaElement> const& schema,
                             bool const ignore_case,
                             std::size_t& current_input_schema_index,
                             std::size_t& next_input_chunk_index,
@@ -217,7 +207,7 @@ class column_pruner {
   {
     // First verify that we found a struct, like we expected to find.
     auto struct_schema_item = schema.at(current_input_schema_index);
-    bool is_leaf            = struct_schema_item.__isset.type;
+    bool is_leaf            = struct_schema_item.type != pq::Type::UNDEFINED;
     if (is_leaf) { throw std::runtime_error("Found a leaf node, but expected to find a struct"); }
 
     int num_children = get_num_children(struct_schema_item);
@@ -283,7 +273,7 @@ class column_pruner {
   /**
    * filter_schema, but specific to Tag::VALUE.
    */
-  void filter_schema_value(std::vector<parquet::format::SchemaElement> const& schema,
+  void filter_schema_value(std::vector<pq::SchemaElement> const& schema,
                            std::size_t& current_input_schema_index,
                            std::size_t& next_input_chunk_index,
                            std::vector<int>& chunk_map,
@@ -291,7 +281,7 @@ class column_pruner {
                            std::vector<int>& schema_num_children) const
   {
     auto schema_item = schema.at(current_input_schema_index);
-    bool is_leaf     = schema_item.__isset.type;
+    bool is_leaf     = schema_item.type != pq::Type::UNDEFINED;
     if (!is_leaf) { throw std::runtime_error("found a non-leaf entry when reading a leaf value"); }
     if (get_num_children(schema_item) != 0) {
       throw std::runtime_error("found an entry with children when reading a leaf value");
@@ -306,7 +296,7 @@ class column_pruner {
   /**
    * filter_schema, but specific to Tag::LIST.
    */
-  void filter_schema_list(std::vector<parquet::format::SchemaElement> const& schema,
+  void filter_schema_list(std::vector<pq::SchemaElement> const& schema,
                           bool const ignore_case,
                           std::size_t& current_input_schema_index,
                           std::size_t& next_input_chunk_index,
@@ -320,7 +310,7 @@ class column_pruner {
     // Under it will be a repeated element
     auto list_schema_item = schema.at(current_input_schema_index);
     std::string list_name = list_schema_item.name;
-    bool is_group         = !list_schema_item.__isset.type;
+    bool is_group         = list_schema_item.type == pq::Type::UNDEFINED;
 
     // Rules for how to parse lists from the parquet format docs
     // 1. If the repeated field is not a group, then its type is the element type and elements are
@@ -333,8 +323,7 @@ class column_pruner {
     // 4. Otherwise, the repeated field's type is the element type with the repeated field's
     // repetition.
     if (!is_group) {
-      if (!list_schema_item.__isset.repetition_type ||
-          list_schema_item.repetition_type != parquet::format::FieldRepetitionType::REPEATED) {
+      if (list_schema_item.repetition_type != pq::FieldRepetitionType::REPEATED) {
         throw std::runtime_error("expected list item to be repeating");
       }
       return filter_schema_value(schema,
@@ -346,8 +335,7 @@ class column_pruner {
     }
     auto num_list_children = get_num_children(list_schema_item);
     if (num_list_children > 1) {
-      if (!list_schema_item.__isset.repetition_type ||
-          list_schema_item.repetition_type != parquet::format::FieldRepetitionType::REPEATED) {
+      if (list_schema_item.repetition_type != pq::FieldRepetitionType::REPEATED) {
         throw std::runtime_error("expected list item to be repeating");
       }
       return found.filter_schema(schema,
@@ -369,13 +357,11 @@ class column_pruner {
     ++current_input_schema_index;
 
     auto repeated_field_schema_item = schema.at(current_input_schema_index);
-    if (!repeated_field_schema_item.__isset.repetition_type ||
-        repeated_field_schema_item.repetition_type !=
-          parquet::format::FieldRepetitionType::REPEATED) {
+    if (repeated_field_schema_item.repetition_type != pq::FieldRepetitionType::REPEATED) {
       throw std::runtime_error("the structure of the list's child is not standard (non repeating)");
     }
 
-    bool repeated_field_is_group    = !repeated_field_schema_item.__isset.type;
+    bool repeated_field_is_group    = repeated_field_schema_item.type == pq::Type::UNDEFINED;
     int repeated_field_num_children = get_num_children(repeated_field_schema_item);
     std::string repeated_field_name = repeated_field_schema_item.name;
     if (repeated_field_is_group && repeated_field_num_children == 1 &&
@@ -409,7 +395,7 @@ class column_pruner {
   /**
    * filter_schema, but specific to Tag::MAP.
    */
-  void filter_schema_map(std::vector<parquet::format::SchemaElement> const& schema,
+  void filter_schema_map(std::vector<pq::SchemaElement> const& schema,
                          bool const ignore_case,
                          std::size_t& current_input_schema_index,
                          std::size_t& next_input_chunk_index,
@@ -426,13 +412,13 @@ class column_pruner {
     // and then an inner group that has two fields a key (that is required) and a value, that is
     // optional.
 
-    bool is_map_group = !map_schema_item.__isset.type;
+    bool is_map_group = map_schema_item.type == pq::Type::UNDEFINED;
     if (!is_map_group) {
       throw std::runtime_error("expected a map item, but found a single value");
     }
-    if (!map_schema_item.__isset.converted_type ||
-        (map_schema_item.converted_type != parquet::format::ConvertedType::MAP &&
-         map_schema_item.converted_type != parquet::format::ConvertedType::MAP_KEY_VALUE)) {
+    if (!map_schema_item.converted_type.has_value() ||
+        (map_schema_item.converted_type != pq::ConvertedType::MAP &&
+         map_schema_item.converted_type != pq::ConvertedType::MAP_KEY_VALUE)) {
       throw std::runtime_error("expected a map type, but it was not found.");
     }
     if (get_num_children(map_schema_item) != 1) {
@@ -446,9 +432,7 @@ class column_pruner {
 
     // Now lets look at the repeated child.
     auto repeated_field_schema_item = schema.at(current_input_schema_index);
-    if (!repeated_field_schema_item.__isset.repetition_type ||
-        repeated_field_schema_item.repetition_type !=
-          parquet::format::FieldRepetitionType::REPEATED) {
+    if (repeated_field_schema_item.repetition_type != pq::FieldRepetitionType::REPEATED) {
       throw std::runtime_error("found non repeating map child");
     }
 
@@ -489,7 +473,7 @@ class column_pruner {
    * current_input_schema_index and next_input_chunk_index are also outputs but are state that is
    * passed to each child and returned when it consumes something.
    */
-  void filter_schema(std::vector<parquet::format::SchemaElement> const& schema,
+  void filter_schema(std::vector<pq::SchemaElement> const& schema,
                      bool const ignore_case,
                      std::size_t& current_input_schema_index,
                      std::size_t& next_input_chunk_index,
@@ -612,11 +596,11 @@ static bool invalid_file_offset(long start_index, long pre_start_index, long pre
   return invalid;
 }
 
-static int64_t get_offset(parquet::format::ColumnChunk const& column_chunk)
+static int64_t get_offset(pq::ColumnChunk const& column_chunk)
 {
   auto md        = column_chunk.meta_data;
   int64_t offset = md.data_page_offset;
-  if (md.__isset.dictionary_page_offset && offset > md.dictionary_page_offset) {
+  if (md.dictionary_page_offset != 0 && offset > md.dictionary_page_offset) {
     offset = md.dictionary_page_offset;
   }
   return offset;
@@ -630,11 +614,11 @@ static int64_t get_offset(parquet::format::ColumnChunk const& column_chunk)
  * only a subset survives.
  */
 struct row_groups {
-  std::vector<parquet::format::RowGroup> groups;
+  std::vector<pq::RowGroup> groups;
   std::vector<int64_t> row_index_offsets;
 };
 
-static row_groups filter_groups(parquet::format::FileMetaData const& meta,
+static row_groups filter_groups(pq::FileMetaData const& meta,
                                 int64_t part_offset,
                                 int64_t part_length)
 {
@@ -645,14 +629,16 @@ static row_groups filter_groups(parquet::format::FileMetaData const& meta,
   int64_t pre_compressed_size     = 0;
   bool first_column_with_metadata = true;
   if (num_row_groups > 0) {
-    first_column_with_metadata = meta.row_groups[0].columns[0].__isset.meta_data;
+    // A real data_page_offset is >= 4, and cudf's meta_data is non-optional, so a value of 0
+    // means the source footer carried no inline column metadata for the first column.
+    first_column_with_metadata = meta.row_groups[0].columns[0].meta_data.data_page_offset != 0;
   }
 
   row_groups result;
   int64_t cumulative_rows = 0;
   for (uint64_t rg_i = 0; rg_i < num_row_groups; ++rg_i) {
-    parquet::format::RowGroup const& row_group = meta.row_groups[rg_i];
-    int64_t total_size                         = 0;
+    pq::RowGroup const& row_group = meta.row_groups[rg_i];
+    int64_t total_size            = 0;
     int64_t start_index;
     auto column_chunk = row_group.columns[0];
     if (first_column_with_metadata) {
@@ -660,21 +646,21 @@ static row_groups filter_groups(parquet::format::FileMetaData const& meta,
     } else {
       // the file_offset of first block always holds the truth, while other blocks don't :
       // see PARQUET-2078 for details
-      start_index = row_group.file_offset;
+      start_index = row_group.file_offset.value_or(0);
       if (invalid_file_offset(start_index, pre_start_index, pre_compressed_size)) {
         // first row group's offset is always 4, else
         // use minStartIndex(imprecise in case of padding, but good enough for filtering)
         start_index = (pre_start_index == 0) ? 4 : pre_start_index + pre_compressed_size;
       }
       pre_start_index     = start_index;
-      pre_compressed_size = row_group.total_compressed_size;
+      pre_compressed_size = row_group.total_compressed_size.value_or(0);
     }
-    if (row_group.__isset.total_compressed_size) {
-      total_size = row_group.total_compressed_size;
+    if (row_group.total_compressed_size.has_value()) {
+      total_size = row_group.total_compressed_size.value();
     } else {
       auto num_columns = row_group.columns.size();
       for (uint64_t cc_i = 0; cc_i < num_columns; ++cc_i) {
-        parquet::format::ColumnChunk const& col = row_group.columns[cc_i];
+        pq::ColumnChunk const& col = row_group.columns[cc_i];
         total_size += col.meta_data.total_compressed_size;
       }
     }
@@ -689,43 +675,12 @@ static row_groups filter_groups(parquet::format::FileMetaData const& meta,
   return result;
 }
 
-void deserialize_parquet_footer(uint8_t* buffer, uint32_t len, parquet::format::FileMetaData* meta)
-{
-  using ThriftBuffer = apache::thrift::transport::TMemoryBuffer;
-
-  SRJ_FUNC_RANGE();
-// A lot of this came from the parquet source code...
-// Deserialize msg bytes into c++ thrift msg using memory transport.
-#if PARQUET_THRIFT_VERSION_MAJOR > 0 || PARQUET_THRIFT_VERSION_MINOR >= 14
-  auto conf = std::make_shared<apache::thrift::TConfiguration>();
-  conf->setMaxMessageSize(std::numeric_limits<int>::max());
-  auto tmem_transport = std::make_shared<ThriftBuffer>(buffer, len, ThriftBuffer::OBSERVE, conf);
-#else
-  auto tmem_transport = std::make_shared<ThriftBuffer>(buffer, len);
-#endif
-
-  apache::thrift::protocol::TCompactProtocolFactoryT<ThriftBuffer> tproto_factory;
-  // Protect against CPU and memory bombs
-  tproto_factory.setStringSizeLimit(100 * 1000 * 1000);
-  // Structs in the thrift definition are relatively large (at least 300 bytes).
-  // This limits total memory to the same order of magnitude as stringSize.
-  tproto_factory.setContainerSizeLimit(1000 * 1000);
-  std::shared_ptr<apache::thrift::protocol::TProtocol> tproto =
-    tproto_factory.getProtocol(tmem_transport);
-  try {
-    meta->read(tproto.get());
-  } catch (std::exception& e) {
-    std::stringstream ss;
-    ss << "Couldn't deserialize thrift: " << e.what() << "\n";
-    throw std::runtime_error(ss.str());
-  }
-}
-
-void filter_columns(std::vector<parquet::format::RowGroup>& groups, std::vector<int>& chunk_filter)
+void filter_columns(std::vector<pq::RowGroup>& groups, std::vector<int>& chunk_filter)
 {
   SRJ_FUNC_RANGE();
   for (auto group_it = groups.begin(); group_it != groups.end(); ++group_it) {
-    std::vector<parquet::format::ColumnChunk> new_chunks;
+    std::vector<pq::ColumnChunk> new_chunks;
+    new_chunks.reserve(chunk_filter.size());
     for (auto it = chunk_filter.begin(); it != chunk_filter.end(); ++it) {
       new_chunks.push_back(group_it->columns[*it]);
     }
@@ -754,10 +709,13 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
   SRJ_FUNC_RANGE();
   JNI_TRY
   {
-    auto meta    = std::make_unique<parquet::format::FileMetaData>();
     uint32_t len = static_cast<uint32_t>(buffer_length);
     // We don't support encrypted parquet...
-    rapids::jni::deserialize_parquet_footer(reinterpret_cast<uint8_t*>(buffer), len, meta.get());
+    // Parse leniently (throw_if_type_mismatch::NO): skip a known field whose wire type does not
+    // match cudf's schema (Thrift forward-compat) rather than rejecting real files that use it.
+    auto meta = std::make_unique<rapids::jni::pq::FileMetaData>(cudf::io::read_parquet_footer_bytes(
+      cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(buffer), len),
+      rapids::jni::pq::throw_if_type_mismatch::NO));
 
     // Get the filter for the columns first...
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -777,7 +735,7 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
 
     // start by filtering the schema and the chunks
     std::size_t new_schema_size = filter.schema_map.size();
-    std::vector<parquet::format::SchemaElement> new_schema(new_schema_size);
+    std::vector<rapids::jni::pq::SchemaElement> new_schema(new_schema_size);
     for (std::size_t i = 0; i < new_schema_size; ++i) {
       int orig_index             = filter.schema_map[i];
       int new_num_children       = filter.schema_num_children[i];
@@ -785,10 +743,10 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
       new_schema[i].num_children = new_num_children;
     }
     meta->schema = std::move(new_schema);
-    if (meta->__isset.column_orders) {
-      std::vector<parquet::format::ColumnOrder> new_order;
+    if (meta->column_orders.has_value()) {
+      std::vector<rapids::jni::pq::ColumnOrder> new_order;
       for (auto it = filter.chunk_map.begin(); it != filter.chunk_map.end(); ++it) {
-        new_order.push_back(meta->column_orders[*it]);
+        new_order.push_back((*meta->column_orders)[*it]);
       }
       meta->column_orders = std::move(new_order);
     }
@@ -852,11 +810,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumCol
   {
     auto* footer = reinterpret_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
     int ret      = 0;
-    if (footer->meta->schema.size() > 0) {
-      if (footer->meta->schema[0].__isset.num_children) {
-        ret = footer->meta->schema[0].num_children;
-      }
-    }
+    if (footer->meta->schema.size() > 0) { ret = footer->meta->schema[0].num_children; }
     return ret;
   }
   JNI_CATCH(env, -1);
@@ -869,15 +823,13 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_seriali
   JNI_TRY
   {
     auto* footer = reinterpret_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
-    std::shared_ptr<apache::thrift::transport::TMemoryBuffer> transportOut(
-      new apache::thrift::transport::TMemoryBuffer());
-    apache::thrift::protocol::TCompactProtocolFactoryT<apache::thrift::transport::TMemoryBuffer>
-      factory;
-    auto protocolOut = factory.getProtocol(transportOut);
-    footer->meta->write(protocolOut.get());
-    uint8_t* buf_ptr;
-    uint32_t buf_size;
-    transportOut->getBuffer(&buf_ptr, &buf_size);
+    // cudf's writer always emits an inline ColumnChunk.meta_data (the field is non-optional), so a
+    // chunk whose source footer omitted it (PARQUET-2078) round-trips with a default-valued
+    // meta_data instead of staying absent; downstream readers must locate those columns via the
+    // preserved RowGroup.file_offset, not this fabricated inline metadata.
+    std::vector<uint8_t> serialized = cudf::io::write_parquet_footer_bytes(*footer->meta);
+    uint8_t* buf_ptr                = serialized.data();
+    uint32_t buf_size               = static_cast<uint32_t>(serialized.size());
 
     // 12 extra is for the MAGIC thrift_footer length MAGIC
     jobject ret = cudf::jni::allocate_host_buffer(env, buf_size + 12, false, host_memory_allocator);

--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -22,6 +22,7 @@
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <cstring>
 #include <cwctype>
 #include <limits>
 #include <stdexcept>
@@ -187,7 +188,7 @@ class column_pruner {
       bool is_leaf     = schema_item.type != pq::Type::UNDEFINED;
       if (is_leaf) { ++next_input_chunk_index; }
 
-      num_to_skip = num_to_skip + schema_item.num_children;
+      num_to_skip += schema_item.num_children;
 
       --num_to_skip;
       ++current_input_schema_index;
@@ -323,6 +324,8 @@ class column_pruner {
     // 4. Otherwise, the repeated field's type is the element type with the repeated field's
     // repetition.
     if (!is_group) {
+      // cudf defaults an absent repetition_type to REQUIRED (0), never REPEATED, so this bare
+      // != REPEATED test is equivalent to the old "!__isset.repetition_type || != REPEATED" guard.
       if (list_schema_item.repetition_type != pq::FieldRepetitionType::REPEATED) {
         throw std::runtime_error("expected list item to be repeating");
       }
@@ -432,6 +435,7 @@ class column_pruner {
 
     // Now lets look at the repeated child.
     auto repeated_field_schema_item = schema.at(current_input_schema_index);
+    // An absent repetition_type defaults to REQUIRED (not REPEATED), so this bare check suffices.
     if (repeated_field_schema_item.repetition_type != pq::FieldRepetitionType::REPEATED) {
       throw std::runtime_error("found non repeating map child");
     }
@@ -600,6 +604,7 @@ static int64_t get_offset(pq::ColumnChunk const& column_chunk)
 {
   auto md        = column_chunk.meta_data;
   int64_t offset = md.data_page_offset;
+  // A real dictionary_page_offset is >= 4 (offset 0 holds the PAR1 magic), so 0 means unset.
   if (md.dictionary_page_offset != 0 && offset > md.dictionary_page_offset) {
     offset = md.dictionary_page_offset;
   }
@@ -652,6 +657,7 @@ static row_groups filter_groups(pq::FileMetaData const& meta,
         // use minStartIndex(imprecise in case of padding, but good enough for filtering)
         start_index = (pre_start_index == 0) ? 4 : pre_start_index + pre_compressed_size;
       }
+      // Absent total_compressed_size defaults to 0, preserving the legacy Thrift zero-init.
       pre_start_index     = start_index;
       pre_compressed_size = row_group.total_compressed_size.value_or(0);
     }
@@ -709,7 +715,8 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
   SRJ_FUNC_RANGE();
   JNI_TRY
   {
-    uint32_t len = static_cast<uint32_t>(buffer_length);
+    if (buffer_length < 0) { throw std::invalid_argument("buffer_length must not be negative"); }
+    std::size_t len = static_cast<std::size_t>(buffer_length);
     // We don't support encrypted parquet...
     // Parse leniently (throw_if_type_mismatch::NO): skip a known field whose wire type does not
     // match cudf's schema (Thrift forward-compat) rather than rejecting real files that use it.

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParquetFooterTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParquetFooterTest.java
@@ -16,25 +16,33 @@
 
 package com.nvidia.spark.rapids.jni;
 
+import ai.rapids.cudf.CudfException;
 import ai.rapids.cudf.HostMemoryBuffer;
 import org.apache.parquet.format.ColumnChunk;
 import org.apache.parquet.format.ColumnMetaData;
+import org.apache.parquet.format.ColumnOrder;
 import org.apache.parquet.format.CompressionCodec;
+import org.apache.parquet.format.ConvertedType;
 import org.apache.parquet.format.Encoding;
 import org.apache.parquet.format.FieldRepetitionType;
 import org.apache.parquet.format.RowGroup;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.format.Type;
+import org.apache.parquet.format.TypeDefinedOrder;
 import org.apache.parquet.format.Util;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ParquetFooterTest {
 
@@ -111,6 +119,136 @@ public class ParquetFooterTest {
       buffer.setBytes(0, footerBytes, 0, footerBytes.length);
       return ParquetFooter.readAndFilter(buffer, partOffset, partLength, makeReadSchema(), false);
     }
+  }
+
+  /**
+   * Build a leaf (primitive) SchemaElement. Leaves carry a physical type and no children.
+   */
+  private static SchemaElement leaf(String name, FieldRepetitionType rep) {
+    SchemaElement e = new SchemaElement(name);
+    e.setType(Type.INT32);
+    e.setRepetition_type(rep);
+    return e;
+  }
+
+  /**
+   * Build a group (non-leaf) SchemaElement with the given child count. Groups carry no physical
+   * type; a non-null converted type annotates the LIST / MAP wrapper groups.
+   */
+  private static SchemaElement group(String name, int numChildren, FieldRepetitionType rep,
+      ConvertedType converted) {
+    SchemaElement e = new SchemaElement(name);
+    e.setNum_children(numChildren);
+    e.setRepetition_type(rep);
+    if (converted != null) {
+      e.setConverted_type(converted);
+    }
+    return e;
+  }
+
+  /**
+   * Build a footer with four top-level columns covering every nested shape the pruner handles:
+   *   id     : INT32
+   *   names  : LIST of INT32          (3-level: names -> list -> element)
+   *   props  : MAP of INT32 to INT32  (props -> key_value -> {key, value})
+   *   nested : STRUCT of x, y (both INT32)
+   * The schema is the depth-first flattening parquet uses; the row group carries one column chunk
+   * per leaf column (id, element, key, value, x, y).
+   */
+  private static org.apache.parquet.format.FileMetaData makeNestedFooter(long numRows) {
+    SchemaElement root = new SchemaElement("schema");
+    root.setNum_children(4);
+
+    List<SchemaElement> schema = new ArrayList<>();
+    schema.add(root);
+    schema.add(leaf("id", FieldRepetitionType.OPTIONAL));
+    schema.add(group("names", 1, FieldRepetitionType.OPTIONAL, ConvertedType.LIST));
+    schema.add(group("list", 1, FieldRepetitionType.REPEATED, null));
+    schema.add(leaf("element", FieldRepetitionType.OPTIONAL));
+    schema.add(group("props", 1, FieldRepetitionType.OPTIONAL, ConvertedType.MAP));
+    schema.add(group("key_value", 2, FieldRepetitionType.REPEATED, null));
+    schema.add(leaf("key", FieldRepetitionType.REQUIRED));
+    schema.add(leaf("value", FieldRepetitionType.OPTIONAL));
+    schema.add(group("nested", 2, FieldRepetitionType.OPTIONAL, null));
+    schema.add(leaf("x", FieldRepetitionType.OPTIONAL));
+    schema.add(leaf("y", FieldRepetitionType.OPTIONAL));
+
+    // One column chunk per leaf column (6 leaves), each with a distinct data page offset.
+    List<ColumnChunk> chunks = new ArrayList<>();
+    for (int i = 0; i < 6; i++) {
+      ColumnMetaData cmd = new ColumnMetaData(
+          Type.INT32,
+          Collections.singletonList(Encoding.PLAIN),
+          Collections.singletonList("c" + i),
+          CompressionCodec.UNCOMPRESSED,
+          numRows,
+          200,
+          100,
+          100L + i);
+      ColumnChunk cc = new ColumnChunk(100L + i);
+      cc.setMeta_data(cmd);
+      chunks.add(cc);
+    }
+    RowGroup rg = new RowGroup(chunks, 600, numRows);
+    rg.setTotal_compressed_size(600);
+
+    return new org.apache.parquet.format.FileMetaData(1, schema, numRows,
+        Collections.singletonList(rg));
+  }
+
+  /**
+   * Read schema selecting all four top-level columns of makeNestedFooter.
+   */
+  private static ParquetFooter.StructElement makeNestedReadSchema() {
+    return ParquetFooter.StructElement.builder()
+        .addChild("id", new ParquetFooter.ValueElement())
+        .addChild("names", new ParquetFooter.ListElement(new ParquetFooter.ValueElement()))
+        .addChild("props", new ParquetFooter.MapElement(
+            new ParquetFooter.ValueElement(), new ParquetFooter.ValueElement()))
+        .addChild("nested", ParquetFooter.StructElement.builder()
+            .addChild("x", new ParquetFooter.ValueElement())
+            .addChild("y", new ParquetFooter.ValueElement())
+            .build())
+        .build();
+  }
+
+  /**
+   * Read schema selecting three of the four columns of makeNestedFooter (drops the MAP).
+   */
+  private static ParquetFooter.StructElement makePrunedReadSchema() {
+    return ParquetFooter.StructElement.builder()
+        .addChild("id", new ParquetFooter.ValueElement())
+        .addChild("names", new ParquetFooter.ListElement(new ParquetFooter.ValueElement()))
+        .addChild("nested", ParquetFooter.StructElement.builder()
+            .addChild("x", new ParquetFooter.ValueElement())
+            .addChild("y", new ParquetFooter.ValueElement())
+            .build())
+        .build();
+  }
+
+  /**
+   * Deserialize footer bytes with byte-range filtering and an explicit read schema.
+   */
+  private static ParquetFooter readFooter(byte[] footerBytes, long partOffset, long partLength,
+      ParquetFooter.StructElement schema) throws Exception {
+    try (HostMemoryBuffer buffer = HostMemoryBuffer.allocate(footerBytes.length)) {
+      buffer.setBytes(0, footerBytes, 0, footerBytes.length);
+      return ParquetFooter.readAndFilter(buffer, partOffset, partLength, schema, false);
+    }
+  }
+
+  /**
+   * Build a single-column row group whose column chunk omits inline meta_data, forcing the reader
+   * onto the RowGroup.file_offset path (PARQUET-2078). file_offset and total_compressed_size are
+   * the cudf-optional fields the reader must read defensively.
+   */
+  private static RowGroup makeRowGroupNoMetadata(
+      long numRows, long fileOffset, long compressedSize) {
+    ColumnChunk cc = new ColumnChunk(fileOffset);   // meta_data intentionally left unset
+    RowGroup rg = new RowGroup(Collections.singletonList(cc), compressedSize, numRows);
+    rg.setFile_offset(fileOffset);
+    rg.setTotal_compressed_size(compressedSize);
+    return rg;
   }
 
   // ---- shared test data ----
@@ -258,6 +396,254 @@ public class ParquetFooterTest {
     try (ParquetFooter footer = readFooter(bytes, 400, 800)) {
       assertArrayEquals(new long[]{100, 300, 600}, footer.getRowIndexOffsets());
       assertEquals(900, footer.getNumRows());
+    }
+  }
+
+  @Test
+  void testColumnPruningNestedSchemas() throws Exception {
+    byte[] bytes = serialize(makeNestedFooter(1234));
+
+    // Select all four top-level columns (INT32, LIST, MAP, STRUCT).
+    try (ParquetFooter footer = readFooter(bytes, 0, -1, makeNestedReadSchema())) {
+      assertEquals(4, footer.getNumColumns());
+      assertEquals(1234, footer.getNumRows());
+    }
+
+    // Prune away the MAP column; three top-level columns survive.
+    try (ParquetFooter footer = readFooter(bytes, 0, -1, makePrunedReadSchema())) {
+      assertEquals(3, footer.getNumColumns());
+      assertEquals(1234, footer.getNumRows());
+    }
+  }
+
+  @Test
+  void testSerializeThriftFileRoundTripThroughParquetMr() throws Exception {
+    byte[] bytes = serialize(makeFooter(
+        makeRowGroup(1000, 100, 200),
+        makeRowGroup(2000, 400, 200)));
+    try (ParquetFooter footer = readFooter(bytes, 0, -1);
+         HostMemoryBuffer out = footer.serializeThriftFile()) {
+      // Framed layout written by serializeThriftFile: "PAR1" + thrift + 4-byte LE length + "PAR1".
+      int total = (int) out.getLength();
+      byte[] framed = new byte[total];
+      out.getBytes(framed, 0, 0, total);
+      assertEquals('P', framed[0]);
+      assertEquals('1', framed[3]);
+      assertEquals('P', framed[total - 4]);
+      assertEquals('1', framed[total - 1]);
+      // Re-parse the embedded footer with parquet-mr -- the real cross-library contract.
+      org.apache.parquet.format.FileMetaData reparsed =
+          Util.readFileMetaData(new ByteArrayInputStream(framed, 4, total - 12));
+      assertEquals(3000, reparsed.getNum_rows());
+      assertEquals(2, reparsed.getRow_groups().size());
+      assertEquals(1000, reparsed.getRow_groups().get(0).getNum_rows());
+      assertEquals(2000, reparsed.getRow_groups().get(1).getNum_rows());
+    }
+  }
+
+  @Test
+  void testRepetitionTypeRoundTrip() throws Exception {
+    byte[] bytes = serialize(makeFooter(makeRowGroup(1000, 100, 200)));
+    try (ParquetFooter footer = readFooter(bytes, 0, -1);
+         HostMemoryBuffer out = footer.serializeThriftFile()) {
+      int total = (int) out.getLength();
+      byte[] framed = new byte[total];
+      out.getBytes(framed, 0, 0, total);
+      org.apache.parquet.format.FileMetaData reparsed =
+          Util.readFileMetaData(new ByteArrayInputStream(framed, 4, total - 12));
+      // makeFooter's data column "a" is OPTIONAL INT32; both must survive the cudf read/write.
+      SchemaElement col = reparsed.getSchema().get(1);
+      assertEquals(COL_NAME, col.getName());
+      assertEquals(FieldRepetitionType.OPTIONAL, col.getRepetition_type());
+      assertEquals(Type.INT32, col.getType());
+    }
+  }
+
+  @Test
+  void testCorruptFooterThrowsCleanException() throws Exception {
+    byte[] bytes = serialize(makeFooter(makeRowGroup(1000, 100, 200)));
+    // A truncated thrift stream is unparseable; the reader must surface a clean Java exception
+    // (CudfException) rather than crashing the JVM.
+    byte[] truncated = Arrays.copyOf(bytes, bytes.length / 2);
+    assertThrows(CudfException.class, () -> readFooter(truncated, 0, -1));
+  }
+
+  @Test
+  void testMetadataAbsentColumnChunk() throws Exception {
+    // Two row groups without inline column meta_data; offsets come from RowGroup.file_offset.
+    //   RG0: file_offset=4,   compressed=100 -> start=4,   midpoint=54
+    //   RG1: file_offset=104, compressed=100 -> start=104, midpoint=154
+    org.apache.parquet.format.FileMetaData meta = makeFooter(
+        makeRowGroupNoMetadata(1000, 4, 100),
+        makeRowGroupNoMetadata(2000, 104, 100));
+    byte[] bytes = serialize(meta);
+
+    // Byte range [0, 1000) covers both midpoints, so both row groups survive.
+    try (ParquetFooter footer = readFooter(bytes, 0, 1000)) {
+      assertArrayEquals(new long[]{0, 1000}, footer.getRowIndexOffsets());
+      assertEquals(3000, footer.getNumRows());
+
+      // The reader fabricates default meta_data for the absent chunks; parquet-mr must accept it
+      // when the footer is written back out.
+      try (HostMemoryBuffer out = footer.serializeThriftFile()) {
+        int total = (int) out.getLength();
+        byte[] framed = new byte[total];
+        out.getBytes(framed, 0, 0, total);
+        org.apache.parquet.format.FileMetaData reparsed =
+            Util.readFileMetaData(new ByteArrayInputStream(framed, 4, total - 12));
+        assertEquals(3000, reparsed.getNum_rows());
+        assertEquals(2, reparsed.getRow_groups().size());
+      }
+    }
+  }
+
+  @Test
+  void testMapWithoutConvertedTypeThrowsCleanException() throws Exception {
+    // A group shaped like a MAP (props -> repeated key_value -> {key, value}) but with no
+    // converted_type annotation. The pruner's map handler must reject it with a clean CudfException
+    // rather than crashing the JVM.
+    SchemaElement root = new SchemaElement("schema");
+    root.setNum_children(1);
+    List<SchemaElement> schema = Arrays.asList(
+        root,
+        group("props", 1, FieldRepetitionType.OPTIONAL, null),   // converted_type intentionally unset
+        group("key_value", 2, FieldRepetitionType.REPEATED, null),
+        leaf("key", FieldRepetitionType.REQUIRED),
+        leaf("value", FieldRepetitionType.OPTIONAL));
+    List<ColumnChunk> chunks = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {   // one chunk per leaf (key, value)
+      ColumnMetaData cmd = new ColumnMetaData(Type.INT32,
+          Collections.singletonList(Encoding.PLAIN), Collections.singletonList("c" + i),
+          CompressionCodec.UNCOMPRESSED, 10, 200, 100, 100L + i);
+      ColumnChunk cc = new ColumnChunk(100L + i);
+      cc.setMeta_data(cmd);
+      chunks.add(cc);
+    }
+    RowGroup rg = new RowGroup(chunks, 200, 10);
+    rg.setTotal_compressed_size(200);
+    byte[] bytes = serialize(new org.apache.parquet.format.FileMetaData(
+        1, schema, 10, Collections.singletonList(rg)));
+    ParquetFooter.StructElement readSchema = ParquetFooter.StructElement.builder()
+        .addChild("props", new ParquetFooter.MapElement(
+            new ParquetFooter.ValueElement(), new ParquetFooter.ValueElement()))
+        .build();
+    assertThrows(CudfException.class, () -> readFooter(bytes, 0, -1, readSchema));
+  }
+
+  @Test
+  void testEmptyFooterNoRowGroups() throws Exception {
+    // Zero row groups exercises filter_groups' `num_row_groups > 0` guard: the byte-range filter
+    // must produce an empty result (no crash, no rows) rather than indexing row_groups[0].
+    byte[] bytes = serialize(makeFooter());   // no row groups
+    try (ParquetFooter footer = readFooter(bytes, 0, 1000)) {
+      assertArrayEquals(new long[]{}, footer.getRowIndexOffsets());
+      assertEquals(0, footer.getNumRows());
+    }
+  }
+
+  @Test
+  void testFileOffsetAbsentFallsBackToDefaultStartIndex() throws Exception {
+    // A row group with no inline meta_data AND no file_offset: start_index = file_offset.value_or(0)
+    // == 0, which invalid_file_offset() then corrects to the documented first-row-group offset of 4.
+    ColumnChunk cc = new ColumnChunk(0L);   // meta_data and file_offset intentionally unset
+    RowGroup rg = new RowGroup(Collections.singletonList(cc), 100, 1000);
+    rg.setTotal_compressed_size(100);       // file_offset intentionally left unset
+    byte[] bytes = serialize(makeFooter(rg));
+    // start_index corrected to 4, total_size 100 -> midpoint 54, inside [0, 1000).
+    try (ParquetFooter footer = readFooter(bytes, 0, 1000)) {
+      assertArrayEquals(new long[]{0}, footer.getRowIndexOffsets());
+      assertEquals(1000, footer.getNumRows());
+    }
+  }
+
+  @Test
+  void testTotalCompressedSizeAbsentSumsFromColumnChunks() throws Exception {
+    // A row group whose total_compressed_size is unset forces filter_groups to sum the per-column
+    // total_compressed_size (60 + 40 = 100) instead. Two INT32 leaf columns carry the sizes.
+    SchemaElement root = new SchemaElement("schema");
+    root.setNum_children(2);
+    ColumnMetaData cmd0 = new ColumnMetaData(Type.INT32,
+        Collections.singletonList(Encoding.PLAIN), Collections.singletonList("c0"),
+        CompressionCodec.UNCOMPRESSED, 1000, 120, 60, 100);   // total_compressed_size=60, offset=100
+    ColumnChunk cc0 = new ColumnChunk(100L);
+    cc0.setMeta_data(cmd0);
+    ColumnMetaData cmd1 = new ColumnMetaData(Type.INT32,
+        Collections.singletonList(Encoding.PLAIN), Collections.singletonList("c1"),
+        CompressionCodec.UNCOMPRESSED, 1000, 80, 40, 110);    // total_compressed_size=40, offset=110
+    ColumnChunk cc1 = new ColumnChunk(110L);
+    cc1.setMeta_data(cmd1);
+    RowGroup rg = new RowGroup(Arrays.asList(cc0, cc1), 100, 1000);
+    // total_compressed_size intentionally left unset on the row group.
+    byte[] bytes = serialize(new org.apache.parquet.format.FileMetaData(
+        1, Arrays.asList(root, leaf("c0", FieldRepetitionType.OPTIONAL),
+            leaf("c1", FieldRepetitionType.OPTIONAL)), 1000, Collections.singletonList(rg)));
+    ParquetFooter.StructElement readSchema = ParquetFooter.StructElement.builder()
+        .addChild("c0", new ParquetFooter.ValueElement())
+        .addChild("c1", new ParquetFooter.ValueElement())
+        .build();
+    // start_index = get_offset(columns[0]) = 100; total_size = 60+40 = 100; midpoint = 150.
+    // Range [140, 160) contains 150 only if BOTH chunk sizes were summed.
+    try (ParquetFooter footer = readFooter(bytes, 140, 20, readSchema)) {
+      assertArrayEquals(new long[]{0}, footer.getRowIndexOffsets());
+      assertEquals(1000, footer.getNumRows());
+    }
+  }
+
+  @Test
+  void testColumnOrdersSurvivePruning() throws Exception {
+    // column_orders (one TYPE_ORDER per leaf column) must be reindexed through the prune map when
+    // columns are dropped. makeNestedFooter has 6 leaves; pruning the MAP drops 2, leaving 4.
+    org.apache.parquet.format.FileMetaData meta = makeNestedFooter(1234);
+    List<ColumnOrder> orders = new ArrayList<>();
+    for (int i = 0; i < 6; i++) {
+      orders.add(ColumnOrder.TYPE_ORDER(new TypeDefinedOrder()));
+    }
+    meta.setColumn_orders(orders);
+    byte[] bytes = serialize(meta);
+    try (ParquetFooter footer = readFooter(bytes, 0, -1, makePrunedReadSchema());
+         HostMemoryBuffer out = footer.serializeThriftFile()) {
+      assertEquals(3, footer.getNumColumns());
+      // Round-trip the pruned footer through parquet-mr; the 4 surviving leaf column_orders remain.
+      int total = (int) out.getLength();
+      byte[] framed = new byte[total];
+      out.getBytes(framed, 0, 0, total);
+      org.apache.parquet.format.FileMetaData reparsed =
+          Util.readFileMetaData(new ByteArrayInputStream(framed, 4, total - 12));
+      assertEquals(4, reparsed.getColumn_orders().size());
+    }
+  }
+
+  @Test
+  void testReadAndFilterToleratesTrailingLengthBytes() throws Exception {
+    // spark-rapids hands readAndFilter the thrift footer plus a trailing 4-byte little-endian
+    // footer-length word (its "footer + footerLen" slice, PAR1 magic stripped from both ends).
+    // The facade parses buffer.getLength() bytes, so it must tolerate that tail, not reject it.
+    byte[] footerBytes = serialize(threeRowGroupFooter());
+
+    // Baseline parse of the exact-size footer, with no trailing bytes.
+    long[] expectedOffsets;
+    long expectedRows;
+    int expectedColumns;
+    try (ParquetFooter footer = readFooter(footerBytes, 0, -1)) {
+      expectedOffsets = footer.getRowIndexOffsets();
+      expectedRows = footer.getNumRows();
+      expectedColumns = footer.getNumColumns();
+    }
+
+    // Append the 4-byte little-endian footer length, reproducing the real footer + footerLen tail.
+    int footerLen = footerBytes.length;
+    byte[] padded = Arrays.copyOf(footerBytes, footerLen + 4);
+    padded[footerLen]     = (byte) footerLen;
+    padded[footerLen + 1] = (byte) (footerLen >>> 8);
+    padded[footerLen + 2] = (byte) (footerLen >>> 16);
+    padded[footerLen + 3] = (byte) (footerLen >>> 24);
+
+    // The trailing length word must not perturb the parse: same row offsets, row count, and
+    // column count as the un-padded footer.
+    try (ParquetFooter footer = readFooter(padded, 0, -1)) {
+      assertArrayEquals(expectedOffsets, footer.getRowIndexOffsets());
+      assertEquals(expectedRows, footer.getNumRows());
+      assertEquals(expectedColumns, footer.getNumColumns());
     }
   }
 }


### PR DESCRIPTION
Rewrite `NativeParquetJni` to use cudf public APIs for Parquet footer reading/writing instead of using Apache Thrift. This effectively drops `libthrift` and `libparquet` build dependency completely.

Depends on:
 * https://github.com/rapidsai/cudf/pull/23345
 * https://github.com/rapidsai/cudf/pull/23346

This PR and its dependencies have been tested and validated against cudf-spark plugin integration tests (Spark 3.5.5):
```
┌────────────────────────────────────┬────────────────────────┐
│                Test                │         Result         │
├────────────────────────────────────┼────────────────────────┤
│ parquet_test.py                    │ ✅ 3240 / 0 / 479-skip │
├────────────────────────────────────┼────────────────────────┤
│ parquet_testing_test.py            │ ✅ 88 / 0 / 8-skip     │
├────────────────────────────────────┼────────────────────────┤
│ parquet_test.py — field_id subset  │ ✅ 17 / 0 / 1-skip     │
├────────────────────────────────────┼────────────────────────┤
│ delta_lake_test.py — native_footer │ ✅ 24 / 24 PASSED      │
└────────────────────────────────────┴────────────────────────┘
```