### PR TITLE
[SkipRecovery] Fix cross-batch decimal position in string_to_float

### DIFF
--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -583,7 +583,7 @@ class string_to_float {
           return {0, 0};
         }
         auto const dpos = __ffs(decimal_mask) - 1;  // 0th bit is reported as 1 by __ffs
-        decimal_pos     = (dpos + real_digits);
+        decimal_pos     = dpos + real_digits + truncated_digits;
         decimal         = true;
 
         // strip the decimal char out
@@ -604,7 +604,7 @@ class string_to_float {
 
       num_chars = min(num_chars, first_non_digit > 0 ? first_non_digit - 1 : num_chars);
 
-      if (decimal_pos > 0 && decimal_pos > num_chars + real_digits) {
+      if (decimal_pos > 0 && decimal_pos > num_chars + real_digits + truncated_digits) {
         _valid  = false;
         _except = true;
         return {0, 0};

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,11 @@
 
 #include <cast_string.hpp>
 
+#include <cstddef>
 #include <limits>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 using namespace cudf;
 
@@ -638,6 +642,47 @@ TYPED_TEST(StringToFloatTests, Simple)
     data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::get_default_stream());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected->view());
+}
+
+TYPED_TEST(StringToFloatTests, DecimalPointAfterTruncatedDigitsAcrossBatches)
+{
+  auto const make_value = [](std::size_t digits) { return std::string(digits, '9') + ".0"; };
+  std::vector<std::string> const input{make_value(31),
+                                       make_value(32),
+                                       make_value(38),
+                                       "-" + make_value(38),
+                                       std::string(38, '9') + "." + std::string(100, '0') + "1",
+                                       make_value(300),
+                                       make_value(307),
+                                       make_value(38) + "e-38"};
+  auto const in = cudf::test::strings_column_wrapper{input.begin(), input.end()};
+
+  auto const expected = []() {
+    if constexpr (std::is_same_v<TypeParam, float>) {
+      return test::fixed_width_column_wrapper<TypeParam>{static_cast<TypeParam>(1.0e31),
+                                                         static_cast<TypeParam>(1.0e32),
+                                                         static_cast<TypeParam>(1.0e38),
+                                                         static_cast<TypeParam>(-1.0e38),
+                                                         static_cast<TypeParam>(1.0e38),
+                                                         std::numeric_limits<TypeParam>::infinity(),
+                                                         std::numeric_limits<TypeParam>::infinity(),
+                                                         static_cast<TypeParam>(1.0)};
+    } else {
+      return test::fixed_width_column_wrapper<TypeParam>{static_cast<TypeParam>(1.0e31),
+                                                         static_cast<TypeParam>(1.0e32),
+                                                         static_cast<TypeParam>(1.0e38),
+                                                         static_cast<TypeParam>(-1.0e38),
+                                                         static_cast<TypeParam>(1.0e38),
+                                                         static_cast<TypeParam>(1.0e300),
+                                                         static_cast<TypeParam>(1.0e307),
+                                                         static_cast<TypeParam>(1.0)};
+    }
+  }();
+
+  auto const result = spark_rapids_jni::string_to_float(
+    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::get_default_stream());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view(), expected);
 }
 
 TYPED_TEST(StringToFloatTests, InfNaN)


### PR DESCRIPTION
Contributes to [NVIDIA/cudf-spark#10481](https://github.com/NVIDIA/cudf-spark/issues/10481).

## Summary

- Include `truncated_digits` accumulated by earlier 32-byte parser batches when `parse_digits` records and validates `decimal_pos`.
- Add typed FLOAT32/FLOAT64 regression coverage for decimal points discovered after significant-digit storage is saturated, including batch boundaries, signs, long fractional tails, exponents, and large finite/overflow magnitudes.
- Preserve the decimal exponent for values such as 38 integer nines followed by `.0`, which previously converted near `1e25` instead of `1e38`.

This is distinct from [#4559](https://github.com/NVIDIA/cudf-spark-jni/issues/4559) / [#4560](https://github.com/NVIDIA/cudf-spark-jni/pull/4560). That change corrects final IEEE-754 rounding after a large mantissa has already been parsed and the decimal exponent is correct. #10481 loses whole orders of magnitude earlier because a decimal point found in a later 32-byte batch omitted previously truncated digits from `decimal_pos`.

## Validation

- Focused typed native regression: 2/2 passed.
- Full native `CAST_STRING` suite: 66/66 passed.
- JNI Maven package: `BUILD SUCCESS`.
- cudf-spark Spark 3.3.0 shim330 dist + integration-tests package: `BUILD SUCCESS`, 13/13 reactor modules.
- cudf-spark Spark 3.5.5 shim355 dist package: `BUILD SUCCESS`, 11/11 reactor modules.
- cudf-spark Spark 4.1.1 shim411 Scala 2.13 dist + integration-tests package: `BUILD SUCCESS`, 11/11 reactor modules.
- Exact `float_formatted.json` scan/from_json x FLOAT32/FLOAT64 nodes with `--runxfail`: 4/4 passed on each of Spark 3.3.0, 3.5.5, and 4.1.1.
- Event logs on every Spark version contain two `GpuScan json` and two `gpujsontostructs` target executions; no target GPU path is missing.
- `pre-commit`, clang-format dry-run, and `git diff --check` passed.
- NT local review update: 0 must-fix, 0 should-fix, 0 suggestions; 0 recurring and 0 new findings after its include-hygiene fix.

The four cudf-spark xfails remain until this upstream artifact is consumable and the enclosing `json_matrix_test.py` recovery gate passes.

The native build used `CMAKE_CUDA_ARCHITECTURES=89` as a local validation optimization; this is not release/fatbin architecture coverage.

## Performance

No benchmark was run. The production change adds the already-maintained `truncated_digits` counter to two scalar integer expressions only when recording or validating a decimal position; it does not add a new pass, allocation, or synchronization.
