### PR TITLE
Keep escape-free `from_json` raw-map columns on the raw copy path

### DIFF
--- a/src/main/cpp/benchmarks/from_json.cu
+++ b/src/main/cpp/benchmarks/from_json.cu
@@ -27,6 +27,8 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/strings/split/split.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/translate.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
@@ -46,6 +48,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -55,8 +58,9 @@ namespace {
 // `generate_input`.
 constexpr auto default_value_width = 10;
 
-// Build a list of `num_keys` all-STRING column types. The raw-map engine extracts every value as a
-// raw substring, so a homogeneous all-STRING flat object is the representative input.
+// Build a list of `num_keys` all-STRING column types. A string is the only value kind the raw-map
+// engine may unescape instead of copying verbatim, so a homogeneous all-STRING flat object is the
+// worst case for the rendering work and the only shape that can reach either rendering path.
 std::vector<cudf::type_id> make_all_string_column_types(int num_keys)
 {
   return std::vector<cudf::type_id>(num_keys, cudf::type_id::STRING);
@@ -86,11 +90,16 @@ constexpr spark_rapids_jni::json_parse_options benchmark_parse_options()
 //                      chars ("k" + zero-padded i) so longer key names can be exercised.
 //   - `row_count`    : if > 0, the table is sized by row count and `size_bytes` is ignored; else
 //                      the table is sized by target byte count via `table_size_bytes`.
+//   - `escape_free`  : if true, fold every character the JSON writer escapes out of the generated
+//                      values, so the extraction stays on the verbatim raw-copy fast path. The
+//                      character count per value is preserved; the byte count shrinks where a
+//                      multi-byte character is folded away.
 struct input_options {
   int value_width       = default_value_width;
   double null_pct       = 0.0;
   int key_name_len      = 0;
   std::size_t row_count = 0;
+  bool escape_free      = false;
 };
 
 std::unique_ptr<cudf::column> generate_input(std::size_t size_bytes,
@@ -110,11 +119,30 @@ std::unique_ptr<cudf::column> generate_input(std::size_t size_bytes,
 
   // The cudf benchmark `row_count` size-tag struct selects the table-by-rows overload; name it via
   // `::row_count` to distinguish the tag type from `options.row_count` (the count value).
-  auto const input_table =
+  auto input_table =
     options.row_count > 0
       ? create_random_table(
           column_types, ::row_count{static_cast<cudf::size_type>(options.row_count)}, table_profile)
       : create_random_table(column_types, table_size_bytes{size_bytes}, table_profile);
+
+  // The random values span 32..137, which contains `"`, `/`, `\` and the multi-byte UTF-8 band --
+  // every one of which `write_json` escapes -- so a generated column is escape-free only if it is
+  // filtered to be. Without this, the value extraction always takes the transform path. The kept
+  // ranges are printable ASCII minus those three characters; every other character, including the
+  // non-ASCII band the writer emits as `\uXXXX`, folds to the replacement.
+  if (options.escape_free) {
+    std::vector<std::pair<cudf::char_utf8, cudf::char_utf8>> const keep_ranges{
+      {' ', '!'}, {'#', '.'}, {'0', '['}, {']', '~'}};
+    std::vector<std::unique_ptr<cudf::column>> filtered;
+    filtered.reserve(num_keys);
+    for (auto const& col : input_table->view()) {
+      filtered.push_back(cudf::strings::filter_characters(cudf::strings_column_view{col},
+                                                          keep_ranges,
+                                                          cudf::strings::filter_type::KEEP,
+                                                          cudf::string_scalar("x")));
+    }
+    input_table = std::make_unique<cudf::table>(std::move(filtered));
+  }
 
   // JSON object keys must match the schema column names. With the default naming the keys are
   // "col0".."colN-1"; when `key_name_len > 0` the keys become "k" + zero-padded index, padded to
@@ -193,9 +221,11 @@ __device__ inline std::uint64_t hash_index(std::uint64_t x)
 // deterministic function of its index. A value is the literal `null` (null inner list, mask #1) at
 // `value_null_stride`; an element is the literal `null` (null element, mask #2) at
 // `element_null_stride`. At `mismatch_stride` a value is instead a scalar string (a non-array,
-// non-null value) to exercise the bad-record nullification path. When `key_len > 0`, keys are
-// exactly `key_len` content characters instead of a hashed width. The same code path computes the
-// row size (when `d_chars == nullptr`) and writes the bytes, so the two passes cannot disagree.
+// non-null value) to exercise the bad-record nullification path. At `escape_stride` an element
+// carries a `\"` escape, which routes the element extraction off the verbatim fast path.
+// When `key_len > 0`, keys are exactly `key_len` content characters instead of a hashed width. The
+// same code path computes the row size (when `d_chars == nullptr`) and writes the bytes, so the two
+// passes cannot disagree.
 struct map_of_array_row_fn {
   cudf::size_type keys_per_row;
   cudf::size_type array_len;
@@ -203,6 +233,7 @@ struct map_of_array_row_fn {
   cudf::size_type element_null_stride;  // 0 disables; else element null when index % stride == 0
   cudf::size_type mismatch_stride;      // 0 disables; else scalar (non-array) value at this cadence
   cudf::size_type key_len;              // 0 = hashed key width; else exactly this many key chars
+  cudf::size_type escape_stride;        // 0 disables; else element carries a \" escape here
 
   cudf::size_type* d_sizes{};
   char* d_chars{};
@@ -229,11 +260,16 @@ struct map_of_array_row_fn {
     };
     // A quoted token seeded deterministically by `seed`. `fixed_width <= 0` selects a hashed width
     // in [1, max_string_width]; otherwise the token has exactly `fixed_width` content characters.
-    auto emit_token = [&](std::uint64_t seed, cudf::size_type fixed_width) {
+    // `escaped` prepends a `\"` escape, which makes the token classify `string_unescape`.
+    auto emit_token = [&](std::uint64_t seed, cudf::size_type fixed_width, bool escaped = false) {
       auto const width = fixed_width > 0
                            ? fixed_width
                            : static_cast<cudf::size_type>(1 + hash_index(seed) % max_string_width);
       emit('"');
+      if (escaped) {
+        emit('\\');
+        emit('"');
+      }
       for (cudf::size_type c = 0; c < width; ++c) {
         emit(static_cast<char>('a' + (seed + c) % 26));
       }
@@ -261,7 +297,8 @@ struct map_of_array_row_fn {
         if (element_null_stride != 0 && element_index % element_null_stride == 0) {
           emit_literal("null");
         } else {
-          emit_token(element_index + element_seed_salt, 0);
+          auto const escaped = escape_stride != 0 && element_index % escape_stride == 0;
+          emit_token(element_index + element_seed_salt, 0, escaped);
         }
       }
       emit(']');
@@ -277,17 +314,20 @@ struct map_of_array_row_fn {
 // in [1, max_string_width]; key widths vary likewise unless `key_name_len > 0`, which forces every
 // key to exactly that many characters. `element_null_pct` / `value_null_pct` inject literal `null`
 // elements (mask #2) / values, i.e. null inner lists (mask #1), at a fixed cadence. `mismatch_pct`
-// injects scalar (non-array, non-null) values to exercise the bad-record nullification path. The
-// column is built entirely on the GPU, so large row counts stay cheap.
+// injects scalar (non-array, non-null) values to exercise the bad-record nullification path.
+// `element_escape_pct` injects `\"` escapes into elements, which routes the element extraction from
+// the verbatim raw-copy fast path onto the unescape transform. The column is built entirely on the
+// GPU, so large row counts stay cheap.
 // Tunable inputs for `generate_map_of_array_input` (designated-initializer friendly so callers set
 // only the fields they need): each `*_pct` is a fraction in [0,1] mapped to a "1 in stride" cadence
 // (0 disables); `key_name_len` <= 0 keeps the default "col" names, > 0 uses keys of exactly that
 // many characters.
 struct map_of_array_options {
-  double element_null_pct = 0.0;
-  double value_null_pct   = 0.0;
-  double mismatch_pct     = 0.0;
-  int key_name_len        = 0;
+  double element_null_pct   = 0.0;
+  double value_null_pct     = 0.0;
+  double mismatch_pct       = 0.0;
+  int key_name_len          = 0;
+  double element_escape_pct = 0.0;
 };
 
 std::unique_ptr<cudf::column> generate_map_of_array_input(std::size_t num_rows,
@@ -305,7 +345,8 @@ std::unique_ptr<cudf::column> generate_map_of_array_input(std::size_t num_rows,
                          .value_null_stride   = to_stride(options.value_null_pct),
                          .element_null_stride = to_stride(options.element_null_pct),
                          .mismatch_stride     = to_stride(options.mismatch_pct),
-                         .key_len             = static_cast<cudf::size_type>(options.key_name_len)};
+                         .key_len             = static_cast<cudf::size_type>(options.key_name_len),
+                         .escape_stride       = to_stride(options.element_escape_pct)};
 
   auto const stream    = cudf::get_default_stream();
   auto const row_count = static_cast<cudf::size_type>(num_rows);
@@ -348,10 +389,12 @@ std::unique_ptr<cudf::column> generate_map_of_array_input(std::size_t num_rows,
 // Map engine: token-walk parser producing the LIST<STRUCT<STRING,STRING>> raw-map output.
 void BM_from_json_to_raw_map(nvbench::state& state)
 {
-  auto const size_bytes = static_cast<std::size_t>(state.get_int64("size_bytes"));
-  auto const num_keys   = static_cast<int>(state.get_int64("num_keys"));
+  auto const size_bytes  = static_cast<std::size_t>(state.get_int64("size_bytes"));
+  auto const num_keys    = static_cast<int>(state.get_int64("num_keys"));
+  auto const escape_free = state.get_int64("escape_free") != 0;
 
-  auto const json_strings = generate_input(size_bytes, make_all_string_column_types(num_keys));
+  auto const json_strings = generate_input(
+    size_bytes, make_all_string_column_types(num_keys), {.escape_free = escape_free});
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
@@ -466,7 +509,11 @@ void BM_from_json_to_raw_map_array_values(nvbench::state& state)
   auto const num_rows        = static_cast<std::size_t>(state.get_int64("num_rows"));
   constexpr int keys_per_row = 5;
 
-  auto const json_strings = generate_map_of_array_input(num_rows, keys_per_row, array_len);
+  auto const json_strings = generate_map_of_array_input(
+    num_rows,
+    keys_per_row,
+    array_len,
+    {.element_escape_pct = static_cast<double>(state.get_int64("element_escape_pct")) / 100.0});
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
@@ -574,10 +621,15 @@ void BM_from_json_to_raw_map_array_values_type_mismatch(nvbench::state& state)
 // Verification -- MAP<STRING,STRING> path: regression-guards the shared token-tree prelude so the
 // existing from_json_to_raw_map kernel is not slowed by the code now shared with the array path.
 // ============================================================================================
+// `escape_free` selects the value-rendering path: 0 keeps the random values, which the JSON writer
+// always escapes somewhere in the column, so the value extraction takes the unescape transform; 1
+// folds those characters away so it takes the verbatim raw-copy fast path. Presence, not density,
+// is the meaningful axis -- the gate is column-global, so any escape at all opens it.
 NVBENCH_BENCH(BM_from_json_to_raw_map)
   .set_name("from_json_to_raw_map")
   .add_int64_axis("size_bytes", {1'000'000, 10'000'000, 100'000'000})
-  .add_int64_axis("num_keys", {1, 8, 32, 64});
+  .add_int64_axis("num_keys", {1, 8, 32, 64})
+  .add_int64_axis("escape_free", {0, 1});
 
 NVBENCH_BENCH(BM_from_json_to_raw_map_value_width)
   .set_name("from_json_to_raw_map_value_width")
@@ -603,10 +655,15 @@ NVBENCH_BENCH(BM_from_json_to_raw_map_key_name_len)
 // num_rows tops out at 1M: the value-strings output holds num_rows * keys_per_row(5) * array_len
 // strings, which must fit cudf's 2^31 column-size limit. At 10M rows the array_len 3 and 10 cells
 // overflow it, so 1M is the largest count that keeps every array_len cell in range.
+// `element_escape_pct` sweeps the element rendering path: 0 keeps every element on the verbatim
+// raw-copy fast path, 1 is the worst case for the gate (the whole column pays the transform
+// dispatch to unescape almost nothing), and 50 measures the unescape renderer under load. Keys
+// carry no escape at any setting, so this isolates the element gate from the key gate.
 NVBENCH_BENCH(BM_from_json_to_raw_map_array_values)
   .set_name("from_json_to_raw_map_array_values")
   .add_int64_axis("array_len", {1, 3, 10})
-  .add_int64_axis("num_rows", {100'000, 1'000'000});
+  .add_int64_axis("num_rows", {100'000, 1'000'000})
+  .add_int64_axis("element_escape_pct", {0, 1, 50});
 
 // [PERF-OPTIMIZATION TARGET] Null-mask construction (value/element validity) -- tune against this.
 NVBENCH_BENCH(BM_from_json_to_raw_map_array_values_null_density)

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -754,7 +754,7 @@ struct classified_nodes {
 
 // Compute the position range and rendering category for each node.
 // The ranges identify positions to extract nodes from the unified json string; the categories
-// drive the Spark-render materializer.
+// drive the Spark-render materializer and its verbatim fast-path gate.
 classified_nodes compute_node_ranges_and_categories(
   cudf::device_span<char const> input_json,
   cudf::device_span<PdaTokenT const> tokens,
@@ -785,11 +785,35 @@ classified_nodes compute_node_ranges_and_categories(
   return {std::move(node_ranges), std::move(node_categories)};
 }
 
-// String-render materializer for every extracted node, dispatching per compacted category. It keeps
-// `make_strings_children`'s two-pass convention: a null destination sizes, a non-null one writes.
-// The stored ranges are assumed in-bounds for `d_string`; no bound check is performed. The
-// `verbatim` arm is a raw memcpy of the byte range; only a `string_unescape` node re-parses.
-struct render_node_fn {
+// Function logic for substring API.
+// This both calculates the output size and executes the substring.
+// No bound check is performed, assuming that the substring bounds are all valid.
+struct substring_fn {
+  cudf::device_span<char const> d_string;
+  cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
+
+  cudf::size_type* d_sizes;
+  char* d_chars;
+  cudf::detail::input_offsetalator d_offsets;
+
+  __device__ void operator()(cudf::size_type idx)
+  {
+    auto const range = d_ranges[idx];
+    auto const size  = range.second - range.first;
+    if (d_chars) {
+      memcpy(d_chars + d_offsets[idx], d_string.data() + range.first, size);
+    } else {
+      d_sizes[idx] = size;
+    }
+  }
+};
+
+// String-render materializer, used when the extraction holds at least one `string_unescape` node.
+// It keeps `make_strings_children`'s two-pass convention: a null destination sizes, a non-null one
+// writes. The stored ranges are assumed in-bounds for `d_string`; no bound check is performed. The
+// `verbatim` arm is a raw memcpy of the byte range, so a canonical token in a flagged column still
+// takes the raw copy; only a `string_unescape` node re-parses.
+struct transform_fn {
   cudf::device_span<char const> d_string;
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
   cudf::device_span<token_category const> d_categories;
@@ -818,29 +842,112 @@ struct render_node_fn {
   }
 };
 
+// What one extraction selects and how it renders: the nodes tagged `sentinel` in `selector`, each
+// materialized per its `categories` entry. All three are indexed by node id and must travel
+// together -- pairing a selector with another extraction's categories reads the wrong node.
+struct extraction_spec {
+  node_kind sentinel;
+  cudf::device_span<node_kind const> selector;
+  cudf::device_span<token_category const> categories;
+};
+
+// An extraction bound to the verbatim fast-path gate computed for it: `needs_transform` is true
+// when any node `spec` selects classified non-`verbatim`, so the extraction must materialize
+// through `transform_fn` rather than the raw byte-range copy. Binding the two in one value is what
+// keeps a gate from being handed to the extraction it was not computed for.
+struct gated_extraction {
+  extraction_spec spec;
+  bool needs_transform;
+};
+
+// Compute both extraction gates of one map conversion in a single fused pass and a single
+// device-to-host copy, instead of one blocking `thrust::any_of` round trip per extraction. Both
+// specs are indexed by the same node ids, and each is returned already bound to its own gate.
+cuda::std::pair<gated_extraction, gated_extraction> compute_transform_gates(
+  extraction_spec first, extraction_spec second, rmm::cuda_stream_view stream)
+{
+  auto const num_nodes = first.selector.size();
+  CUDF_EXPECTS(first.categories.size() == num_nodes && second.selector.size() == num_nodes &&
+                 second.categories.size() == num_nodes,
+               "Transform gates require equally sized node metadata.");
+  auto gates = rmm::device_uvector<int32_t>(2, stream);
+  CUDF_CUDA_TRY(cudaMemsetAsync(gates.data(), 0, 2 * sizeof(int32_t), stream));
+  auto const node_id_it = thrust::make_counting_iterator<cudf::size_type>(0);
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   node_id_it,
+                   node_id_it + num_nodes,
+                   [first, second, gates = gates.data()] __device__(auto const node_id) {
+                     // Concurrent relaxed stores of the same value: a gate only ever flips to 1.
+                     if (first.selector[node_id] == first.sentinel &&
+                         first.categories[node_id] != token_category::verbatim) {
+                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[0]}.store(
+                         1, cuda::memory_order_relaxed);
+                     }
+                     if (second.selector[node_id] == second.sentinel &&
+                         second.categories[node_id] != token_category::verbatim) {
+                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[1]}.store(
+                         1, cuda::memory_order_relaxed);
+                     }
+                   });
+
+  int32_t gates_host[2];
+  CUDF_CUDA_TRY(
+    cudaMemcpyAsync(gates_host, gates.data(), sizeof(gates_host), cudaMemcpyDeviceToHost, stream));
+  stream.synchronize();
+  return {{first, gates_host[0] != 0}, {second, gates_host[1] != 0}};
+}
+
 // Extract key-value string pairs from the input json string, with escaped strings/keys unescaped to
-// match Spark. The compaction carries each node's category alongside its range and materializes
-// through `render_node_fn`, which unescapes the `string_unescape` slots and copies the rest
-// verbatim.
+// match Spark. When every selected node classified `verbatim` (`needs_transform == false`,
+// precomputed by `compute_transform_gates` and carried on the extraction itself), this is exactly
+// the raw byte-range gather; otherwise the compaction additionally carries each node's category and
+// materializes through `transform_fn`, which unescapes the `string_unescape` slots.
 std::unique_ptr<cudf::column> extract_keys_or_values(
-  node_kind key_value_sentinel,
+  gated_extraction const& extraction,
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> node_ranges,
-  cudf::device_span<token_category const> node_categories,
-  cudf::device_span<node_kind const> key_or_value,
   cudf::device_span<char const> input_json,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  auto const& spec = extraction.spec;
+  CUDF_EXPECTS(
+    spec.selector.size() == node_ranges.size() && spec.categories.size() == node_ranges.size(),
+    "Extraction requires equally sized node metadata.");
   auto const is_key_or_value = cuda::proclaim_return_type<bool>(
-    [key_or_value, key_value_sentinel] __device__(auto const node_id) {
-      return key_or_value[node_id] == key_value_sentinel;
+    [selector = spec.selector, sentinel = spec.sentinel] __device__(auto const node_id) {
+      return selector[node_id] == sentinel;
     });
 
+  // With every selected node `verbatim` (escape-free strings/keys, or any non-string value kind),
+  // the raw copy below is already byte-identical to Spark's rendering.
+  if (!extraction.needs_transform) {
+    auto extracted_ranges = rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(
+      node_ranges.size(), stream);
+    auto const range_end = copy_if(node_ranges.begin(),
+                                   node_ranges.end(),
+                                   thrust::make_counting_iterator(0),
+                                   extracted_ranges.begin(),
+                                   is_key_or_value,
+                                   stream);
+    auto const num_extract =
+      static_cast<cudf::size_type>(cuda::std::distance(extracted_ranges.begin(), range_end));
+    if (num_extract == 0) {
+      return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
+    }
+
+    auto [offsets, chars] = cudf::strings::detail::make_strings_children(
+      substring_fn{input_json, extracted_ranges}, num_extract, stream, mr);
+    return cudf::make_strings_column(
+      num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
+  }
+
+  // Transform path: compact (range, category) with the same stencil in one pass, then materialize
+  // through the category dispatch.
   auto const num_nodes = node_ranges.size();
   auto extracted_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
   auto extracted_categories = rmm::device_uvector<token_category>(num_nodes, stream);
-  auto const zip_in = thrust::make_zip_iterator(node_ranges.begin(), node_categories.begin());
+  auto const zip_in = thrust::make_zip_iterator(node_ranges.begin(), spec.categories.begin());
   auto const zip_out =
     thrust::make_zip_iterator(extracted_ranges.begin(), extracted_categories.begin());
   auto const zip_end     = copy_if(zip_in,
@@ -853,7 +960,7 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
   if (num_extract == 0) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}); }
 
   auto [offsets, chars] = cudf::strings::detail::make_strings_children(
-    render_node_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
+    transform_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
   return cudf::make_strings_column(
     num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
 }
@@ -1102,7 +1209,8 @@ struct element_classify_fn {
 
       // Mask #2: a literal `null` element is a null element, and gets an empty byte span -- it
       // materializes as a null string with no non-empty-null payload, which the manual list
-      // assembly requires. Its category stays `verbatim`, so the empty span copies zero bytes.
+      // assembly requires. Its category stays `verbatim` (the empty span copies zero bytes),
+      // keeping all-clean-but-nulls columns on the raw fast path.
       if (token == token_t::ValueBegin &&
           is_json_null_literal(input_json.data(), range_begin, range_end)) {
         valid = false;
@@ -1149,20 +1257,15 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
-  auto extracted_keys   = extract_keys_or_values(node_kind::key,
-                                               node_ranges,
-                                               node_categories,
-                                               is_key_or_value_node,
-                                               preprocessed_input,
-                                               stream,
-                                               mr);
-  auto extracted_values = extract_keys_or_values(node_kind::value,
-                                                 node_ranges,
-                                                 node_categories,
-                                                 is_key_or_value_node,
-                                                 preprocessed_input,
-                                                 stream,
-                                                 mr);
+  // Both extractions' transform gates in one fused pass and one sync.
+  auto const [keys, values] =
+    compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
+                            {node_kind::value, is_key_or_value_node, node_categories},
+                            stream);
+
+  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
+  auto extracted_values =
+    extract_keys_or_values(values, node_ranges, preprocessed_input, stream, mr);
   CUDF_EXPECTS(extracted_keys->size() == extracted_values->size(),
                "Invalid key-value pair extraction.");
 
@@ -1235,8 +1338,8 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   auto const& node_categories = classified.categories;
 
   // Fused classification pass: per node emit the element flag, the de-quoted element byte range,
-  // element validity (mask #2), and the rendering category in one transform. Runs before the
-  // element extraction, which consumes the ranges and categories it produces.
+  // element validity (mask #2), and the rendering category in one transform. Runs before both
+  // extractions so their transform gates can be read back with a single sync.
   auto element_flag = rmm::device_uvector<node_kind>(num_nodes, stream);
   auto element_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
@@ -1259,22 +1362,17 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
                                          element_categories.begin()});
   }
 
-  auto extracted_keys = extract_keys_or_values(node_kind::key,
-                                               node_ranges,
-                                               node_categories,
-                                               is_key_or_value_node,
-                                               preprocessed_input,
-                                               stream,
-                                               mr);
+  // Both extractions' transform gates in one fused pass and one sync.
+  auto const [keys, elements] =
+    compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
+                            {node_kind::element, element_flag, element_categories},
+                            stream);
+
+  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
 
   // Extract element strings with the shared extractor (a 0-null STRING column); attach mask #2.
-  auto extracted_elements = extract_keys_or_values(node_kind::element,
-                                                   element_ranges,
-                                                   element_categories,
-                                                   element_flag,
-                                                   preprocessed_input,
-                                                   stream,
-                                                   mr);
+  auto extracted_elements =
+    extract_keys_or_values(elements, element_ranges, preprocessed_input, stream, mr);
   {
     // Mask #2 over only the selected (element-flagged) nodes, in element document order, matching
     // the order `extract_keys_or_values` emits.

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -770,8 +770,32 @@ classified_nodes compute_node_ranges_and_categories(
   return {std::move(node_ranges), std::move(node_categories)};
 }
 
-// Stored ranges are assumed in-bounds for `d_string`; no bound check is performed.
-struct render_node_fn {
+// Function logic for substring API.
+// This both calculates the output size and executes the substring.
+// No bound check is performed, assuming that the substring bounds are all valid.
+struct substring_fn {
+  cudf::device_span<char const> d_string;
+  cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
+
+  cudf::size_type* d_sizes;
+  char* d_chars;
+  cudf::detail::input_offsetalator d_offsets;
+
+  __device__ void operator()(cudf::size_type idx)
+  {
+    auto const range = d_ranges[idx];
+    auto const size  = range.second - range.first;
+    if (d_chars) {
+      memcpy(d_chars + d_offsets[idx], d_string.data() + range.first, size);
+    } else {
+      d_sizes[idx] = size;
+    }
+  }
+};
+
+// Used only when the extraction holds at least one `string_unescape` node. Stored ranges are
+// assumed in-bounds for `d_string`; a `verbatim` node here still takes the raw copy.
+struct transform_fn {
   cudf::device_span<char const> d_string;
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
   cudf::device_span<token_category const> d_categories;
@@ -800,27 +824,105 @@ struct render_node_fn {
   }
 };
 
-// The compaction carries each node's category alongside its range, so the materializer needs no
-// second classification pass.
+// All three are indexed by node id and must travel together: pairing a selector with another
+// extraction's categories reads the wrong node.
+struct extraction_spec {
+  node_kind sentinel;
+  cudf::device_span<node_kind const> selector;
+  cudf::device_span<token_category const> categories;
+};
+
+// Binding the gate to its extraction in one value is what stops a gate reaching the extraction it
+// was not computed for.
+struct gated_extraction {
+  extraction_spec spec;
+  bool needs_transform;
+};
+
+// Both gates are fused into one pass and one device-to-host copy, replacing a blocking round trip
+// per extraction.
+cuda::std::pair<gated_extraction, gated_extraction> compute_transform_gates(
+  extraction_spec first, extraction_spec second, rmm::cuda_stream_view stream)
+{
+  auto const num_nodes = first.selector.size();
+  CUDF_EXPECTS(first.categories.size() == num_nodes && second.selector.size() == num_nodes &&
+                 second.categories.size() == num_nodes,
+               "Transform gates require equally sized node metadata.");
+  auto gates = rmm::device_uvector<int32_t>(2, stream);
+  CUDF_CUDA_TRY(cudaMemsetAsync(gates.data(), 0, 2 * sizeof(int32_t), stream));
+  auto const node_id_it = thrust::make_counting_iterator<cudf::size_type>(0);
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   node_id_it,
+                   node_id_it + num_nodes,
+                   [first, second, gates = gates.data()] __device__(auto const node_id) {
+                     // Concurrent relaxed stores of the same value: a gate only ever flips to 1.
+                     if (first.selector[node_id] == first.sentinel &&
+                         first.categories[node_id] != token_category::verbatim) {
+                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[0]}.store(
+                         1, cuda::memory_order_relaxed);
+                     }
+                     if (second.selector[node_id] == second.sentinel &&
+                         second.categories[node_id] != token_category::verbatim) {
+                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[1]}.store(
+                         1, cuda::memory_order_relaxed);
+                     }
+                   });
+
+  int32_t gates_host[2];
+  CUDF_CUDA_TRY(
+    cudaMemcpyAsync(gates_host, gates.data(), sizeof(gates_host), cudaMemcpyDeviceToHost, stream));
+  stream.synchronize();
+  return {{first, gates_host[0] != 0}, {second, gates_host[1] != 0}};
+}
+
+// With `needs_transform == false` this is exactly the old raw byte-range gather; otherwise the
+// compaction also carries each node's category and materializes through `transform_fn`.
 std::unique_ptr<cudf::column> extract_keys_or_values(
-  node_kind key_value_sentinel,
+  gated_extraction const& extraction,
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> node_ranges,
-  cudf::device_span<token_category const> node_categories,
-  cudf::device_span<node_kind const> key_or_value,
   cudf::device_span<char const> input_json,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  auto const& spec = extraction.spec;
+  CUDF_EXPECTS(
+    spec.selector.size() == node_ranges.size() && spec.categories.size() == node_ranges.size(),
+    "Extraction requires equally sized node metadata.");
   auto const is_key_or_value = cuda::proclaim_return_type<bool>(
-    [key_or_value, key_value_sentinel] __device__(auto const node_id) {
-      return key_or_value[node_id] == key_value_sentinel;
+    [selector = spec.selector, sentinel = spec.sentinel] __device__(auto const node_id) {
+      return selector[node_id] == sentinel;
     });
 
+  // With every selected node `verbatim` (escape-free strings/keys, or any non-string value kind),
+  // the raw copy below is already byte-identical to Spark's rendering.
+  if (!extraction.needs_transform) {
+    auto extracted_ranges = rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(
+      node_ranges.size(), stream);
+    auto const range_end = copy_if(node_ranges.begin(),
+                                   node_ranges.end(),
+                                   thrust::make_counting_iterator(0),
+                                   extracted_ranges.begin(),
+                                   is_key_or_value,
+                                   stream);
+    auto const num_extract =
+      static_cast<cudf::size_type>(cuda::std::distance(extracted_ranges.begin(), range_end));
+    if (num_extract == 0) {
+      return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
+    }
+
+    auto [offsets, chars] = cudf::strings::detail::make_strings_children(
+      substring_fn{input_json, extracted_ranges}, num_extract, stream, mr);
+    return cudf::make_strings_column(
+      num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
+  }
+
+  // Transform path: compact (range, category) with the same stencil in one pass, then materialize
+  // through the category dispatch.
   auto const num_nodes = node_ranges.size();
   auto extracted_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
   auto extracted_categories = rmm::device_uvector<token_category>(num_nodes, stream);
-  auto const zip_in = thrust::make_zip_iterator(node_ranges.begin(), node_categories.begin());
+  auto const zip_in = thrust::make_zip_iterator(node_ranges.begin(), spec.categories.begin());
   auto const zip_out =
     thrust::make_zip_iterator(extracted_ranges.begin(), extracted_categories.begin());
   auto const zip_end     = copy_if(zip_in,
@@ -833,7 +935,7 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
   if (num_extract == 0) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}); }
 
   auto [offsets, chars] = cudf::strings::detail::make_strings_children(
-    render_node_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
+    transform_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
   return cudf::make_strings_column(
     num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
 }
@@ -1076,7 +1178,8 @@ struct element_classify_fn {
 
       // Mask #2: a literal `null` element is a null element, and gets an empty byte span -- it
       // materializes as a null string with no non-empty-null payload, which the manual list
-      // assembly requires. Its category stays `verbatim`, so the empty span copies zero bytes.
+      // assembly requires. Its category stays `verbatim` (the empty span copies zero bytes),
+      // keeping all-clean-but-nulls columns on the raw fast path.
       if (token == token_t::ValueBegin &&
           is_json_null_literal(input_json.data(), range_begin, range_end)) {
         valid = false;
@@ -1123,20 +1226,15 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
-  auto extracted_keys   = extract_keys_or_values(node_kind::key,
-                                               node_ranges,
-                                               node_categories,
-                                               is_key_or_value_node,
-                                               preprocessed_input,
-                                               stream,
-                                               mr);
-  auto extracted_values = extract_keys_or_values(node_kind::value,
-                                                 node_ranges,
-                                                 node_categories,
-                                                 is_key_or_value_node,
-                                                 preprocessed_input,
-                                                 stream,
-                                                 mr);
+  // Both extractions' transform gates in one fused pass and one sync.
+  auto const [keys, values] =
+    compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
+                            {node_kind::value, is_key_or_value_node, node_categories},
+                            stream);
+
+  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
+  auto extracted_values =
+    extract_keys_or_values(values, node_ranges, preprocessed_input, stream, mr);
   CUDF_EXPECTS(extracted_keys->size() == extracted_values->size(),
                "Invalid key-value pair extraction.");
 
@@ -1209,8 +1307,8 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   auto const& node_categories = classified.categories;
 
   // Fused classification pass: per node emit the element flag, the de-quoted element byte range,
-  // element validity (mask #2), and the rendering category in one transform. Runs before the
-  // element extraction, which consumes the ranges and categories it produces.
+  // element validity (mask #2), and the rendering category in one transform. Runs before both
+  // extractions so their transform gates can be read back with a single sync.
   auto element_flag = rmm::device_uvector<node_kind>(num_nodes, stream);
   auto element_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
@@ -1233,22 +1331,17 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
                                          element_categories.begin()});
   }
 
-  auto extracted_keys = extract_keys_or_values(node_kind::key,
-                                               node_ranges,
-                                               node_categories,
-                                               is_key_or_value_node,
-                                               preprocessed_input,
-                                               stream,
-                                               mr);
+  // Both extractions' transform gates in one fused pass and one sync.
+  auto const [keys, elements] =
+    compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
+                            {node_kind::element, element_flag, element_categories},
+                            stream);
+
+  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
 
   // Extract element strings with the shared extractor (a 0-null STRING column); attach mask #2.
-  auto extracted_elements = extract_keys_or_values(node_kind::element,
-                                                   element_ranges,
-                                                   element_categories,
-                                                   element_flag,
-                                                   preprocessed_input,
-                                                   stream,
-                                                   mr);
+  auto extracted_elements =
+    extract_keys_or_values(elements, element_ranges, preprocessed_input, stream, mr);
   {
     // Mask #2 over only the selected (element-flagged) nodes, in element document order, matching
     // the order `extract_keys_or_values` emits.

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -463,15 +463,100 @@ TEST_F(FromJsonTest, RawMapOpt_Render_UnicodeEscapes)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
-// Keys are unescaped too: an escaped key renders like an escaped string value.
+// Keys are unescaped too: an escaped key renders like an escaped string value. The first value
+// also carries an escape, so BOTH the keys gate and the values gate of the same conversion open
+// -- the two are computed in one fused pass, and this is the only test that drives both.
 TEST_F(FromJsonTest, RawMapOpt_Render_KeyEscapes)
 {
   auto const input_col =
-    cudf::test::strings_column_wrapper{R"({"k\u00e9y":"v","a\tb":"w","q\"r":"x"})"};
+    cudf::test::strings_column_wrapper{R"({"k\u00e9y":"v\tz","a\tb":"w","q\"r":"x"})"};
   auto const input = cudf::strings_column_view{input_col};
 
   auto const expected =
-    make_expected_raw_map({{{"kéy", "v"}, {"a\tb", "w"}, {"q\"r", "x"}}}, all_valid(1));
+    make_expected_raw_map({{{"kéy", "v\tz"}, {"a\tb", "w"}, {"q\"r", "x"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// All-canonical, escape-free column: every key/value classifies verbatim, so the extraction takes
+// the raw-copy fast path (the transform gate stays FALSE) and the output is byte-identical to the
+// input ranges. Covers escape-free strings, integers, booleans, an empty object, and duplicate
+// keys; the `null` literal and nested object/array values are pinned by their own tests above.
+TEST_F(FromJsonTest, RawMapOpt_Render_FastPathAllCanonical)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{R"({"s":"plain","t":"","u":"a b c"})",
+                                                            R"({"i":0,"j":-1,"k":10,"l":42})",
+                                                            R"({"b":true,"c":false})",
+                                                            R"({})",
+                                                            R"({"m":"x","m":"y"})"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"s", "plain"}, {"t", ""}, {"u", "a b c"}},
+                                               {{"i", "0"}, {"j", "-1"}, {"k", "10"}, {"l", "42"}},
+                                               {{"b", "true"}, {"c", "false"}},
+                                               {},
+                                               {{"m", "x"}, {"m", "y"}}},
+                                              all_valid(5));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Escaped and canonical values in the SAME extraction: one escaped value opens the transform gate
+// for the whole values column, so the canonical values beside it must still come out byte-identical
+// to their raw ranges. This is the only shape that runs the verbatim arm of the render dispatch --
+// an all-canonical column takes the raw-copy fast path instead and never enters it. The keys are
+// escape-free, so the keys extraction stays on the fast path.
+TEST_F(FromJsonTest, RawMapOpt_Render_MixedEscapedAndVerbatim)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":"x\"y","b":"plain","c":42,"d":true,"e":""})",
+                                       R"({"f":"clean","g":"t\tb","h":"a b c"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"a", R"(x"y)"}, {"b", "plain"}, {"c", "42"}, {"d", "true"}, {"e", ""}},
+                           {{"f", "clean"}, {"g", "t\tb"}, {"h", "a b c"}}},
+                          all_valid(2));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// The transform path across many thread blocks: 5,000 rows x 4 keys puts 20,000 values through the
+// two-pass materializer, far past the single block every other gate-opening test fits in. Every row
+// carries an escaped value beside canonical ones, so both arms of the render dispatch run at scale
+// and the per-string offsets stay aligned across block boundaries.
+TEST_F(FromJsonTest, RawMapOpt_Render_MultiBlockEscaped)
+{
+  constexpr int num_rows = 5000;
+  constexpr int num_keys = 4;
+
+  std::vector<std::string> rows;
+  std::vector<std::vector<kv>> expected_rows;
+  rows.reserve(num_rows);
+  expected_rows.reserve(num_rows);
+
+  for (int r = 0; r < num_rows; ++r) {
+    std::string obj = "{";
+    std::vector<kv> pairs;
+    pairs.reserve(static_cast<std::size_t>(num_keys));
+    for (int k = 0; k < num_keys; ++k) {
+      if (k > 0) { obj += ","; }
+      auto const key = std::format("k{}", k);
+      // Odd keys carry a `\t` escape, even keys stay canonical, so one extraction holds both.
+      if (k % 2 == 1) {
+        obj += std::format(R"("{}":"v{}\tr{}")", key, k, r);
+        pairs.emplace_back(key, std::format("v{}\tr{}", k, r));
+      } else {
+        obj += std::format(R"("{}":"v{}r{}")", key, k, r);
+        pairs.emplace_back(key, std::format("v{}r{}", k, r));
+      }
+    }
+    obj += "}";
+    rows.push_back(std::move(obj));
+    expected_rows.push_back(std::move(pairs));
+  }
+
+  auto const input_col = cudf::test::strings_column_wrapper(rows.begin(), rows.end());
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(expected_rows, all_valid(num_rows));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
@@ -962,13 +1047,29 @@ TEST_F(FromJsonTest, RawMapArray_EscapedElements)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
-// Keys of the array-valued map are unescaped too.
+// Escaped and canonical elements in the SAME extraction: one escaped element opens the transform
+// gate for the whole elements column, so the canonical ones beside it must still come out
+// byte-identical. The literal `null` element is the sharpest case -- it stays `verbatim` with an
+// EMPTY byte range, so it runs the verbatim arm on a zero-length span while mask #2 nulls the slot.
+TEST_F(FromJsonTest, RawMapArray_Render_MixedEscapedAndVerbatim)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":["x\"y","plain",null,123,true,""]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({R"(x"y)", "plain", null_elem(), "123", "true", ""})}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Keys of the array-valued map are unescaped too. The array also carries an escaped element, so
+// BOTH the keys gate and the elements gate of the same conversion open.
 TEST_F(FromJsonTest, RawMapArray_KeyEscapes)
 {
-  auto const input_col = cudf::test::strings_column_wrapper{R"({"k\u00e9":["v"]})"};
+  auto const input_col = cudf::test::strings_column_wrapper{R"({"k\u00e9":["v","x\"y"]})"};
   auto const input     = cudf::strings_column_view{input_col};
 
-  auto const expected = make_expected_raw_map_array({{{"ké", arr({"v"})}}}, all_valid(1));
+  auto const expected = make_expected_raw_map_array({{{"ké", arr({"v", R"(x"y)"})}}}, all_valid(1));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
@@ -1050,6 +1151,48 @@ TEST_F(FromJsonTest, RawMapArray_NumericLeniency)
   auto const expected =
     make_expected_raw_map_array({{{"k", arr({"007", "NaN", "Infinity"})}}}, all_valid(1));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+}
+
+// All-canonical, escape-free column (clean strings/ints/bools, an empty array): every key/element
+// classifies verbatim, so the extraction takes the raw-copy fast path (the transform gate stays
+// FALSE) and the output is byte-identical to the raw extraction.
+TEST_F(FromJsonTest, RawMapArray_Render_FastPathAllCanonical)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":["x","y"],"b":[],"c":[1,-2,true,false,0]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"a", arr({"x", "y"})}, {"b", arr({})}, {"c", arr({"1", "-2", "true", "false", "0"})}}},
+    all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// The transform path across many thread blocks on the array engine: 5,000 rows x 5 elements puts
+// 25,000 elements through the two-pass materializer, far past the single block every other
+// gate-opening test fits in. Every row mixes escaped, canonical, and null elements, so both arms of
+// the render dispatch and the zero-length null span run at scale. The keys carry no escape, so the
+// keys extraction stays on the raw-copy fast path.
+TEST_F(FromJsonTest, RawMapArray_Render_MultiBlockEscaped)
+{
+  constexpr int num_rows = 5000;
+
+  std::vector<std::string> rows;
+  std::vector<std::vector<kva>> expected_rows;
+  rows.reserve(num_rows);
+  expected_rows.reserve(num_rows);
+
+  for (int r = 0; r < num_rows; ++r) {
+    rows.emplace_back(R"({"a":["x\"y","plain"],"b":["p\\q",null,42]})");
+    expected_rows.push_back(
+      {{"a", arr({R"(x"y)", "plain"})}, {"b", arr({R"(p\q)", null_elem(), "42"})}});
+  }
+
+  auto const input_col = cudf::test::strings_column_wrapper(rows.begin(), rows.end());
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(expected_rows, all_valid(num_rows));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
 // Whitespace around values: insignificant whitespace is not part of the element bytes. The
@@ -1134,7 +1277,7 @@ TEST_F(FromJsonTest, RawMapArray_InnerOffsetAdversarialLarge)
 }
 
 // Escaped and escape-free elements mixed inside every row at 50k-row scale, so both category arms
-// of `render_node_fn` run within the same warp. Mirrors the large-input sanitizer vehicle above.
+// of `transform_fn` run within the same warp. Mirrors the large-input sanitizer vehicle above.
 TEST_F(FromJsonTest, RawMapArray_Render_MixedCategoriesLarge)
 {
   constexpr int num_rows = 50000;


### PR DESCRIPTION
Add a column-level gate that detects when nothing in an extraction of `from_json` needs rendering (unescape) and routes it back through the fast raw byte-range copy. By doing so, data that carries no escape stops paying for the category dispatch.

Example for output of type `MAP<STRING,STRING>`:

| Input column | Needs rendering? | Path before | Path with this PR | Output |
|---|---|---|---|---|
| `{"s":"plain","u":"a b c"}` | no — no backslash anywhere | category dispatch | raw byte-range copy | identical |
| `{"i":0,"b":true}` | no — non-string kinds are verbatim | category dispatch | raw byte-range copy | identical |
| `{"a":"q\"r"}` | yes — a backslash escape | category dispatch | category dispatch | identical |

Depends on `Unescape from_json raw-map string values and keys` — it reintroduces `substring_fn`, which that PR deletes, so this diff does not apply to `main` alone.

Partially contribute to https://github.com/NVIDIA/cudf-spark/issues/15240.

Depends on:
 * https://github.com/NVIDIA/cudf-spark-jni/pull/4947

### Performance

Ratio is this PR stacked on its parent, divided by the GPU time of unmodified `main` - above 1.00 is slower.

| Benchmark | Cells | Median | Best | Worst |
|---|---|---|---|---|
| `..._row_shape` | 3 | 1.081x | 0.830x | 1.363x |
| `..._key_name_len` | 3 | 1.046x | 1.033x | 1.063x |
| `..._null_density` | 4 | 1.043x | 1.031x | 1.047x |
| `from_json_to_raw_map` | 24 | 1.040x | 1.001x | 1.122x |
| `..._array_values_keys_per_row` | 3 | 1.036x | 1.033x | 1.042x |
| `..._micro_size` | 4 | 1.035x | 1.001x | 1.056x |
| `..._value_width` | 4 | 1.034x | 0.921x | 1.429x |
| `..._array_values_type_mismatch` | 3 | 1.024x | 1.021x | 1.032x |
| `..._array_values` | 18 | 1.022x | 1.004x | 1.073x |
| `..._array_values_null_density` | 9 | 1.019x | 1.007x | 1.034x |
| `..._array_values_key_name_len` | 3 | 1.006x | 1.001x | 1.031x |

**Overall: 78 cells, median 1.028x, best 0.830x, worst 1.429x slower.**

Measured directly against the parent, four of the five escape-free `array_values*` benchmarks improve, between `0.6%` and `1.6%` faster, ordered by how much of their work the gate removes; the fifth is flat within noise:

| Benchmark | Cells | vs parent | Faster by |
|---|---|---|---|
| `..._array_values_key_name_len` | 3 | 0.984x | 1.6% |
| `..._array_values_type_mismatch` | 3 | 0.985x | 1.5% |
| `..._array_values_null_density` | 9 | 0.988x | 1.2% |
| `..._array_values` | 18 | 0.994x | 0.6% |
| `..._array_values_keys_per_row` | 3 | 1.002x | flat |
