### PR TITLE
Canonicalize `from_json` raw-map numbers and nulls

### DIFF
--- a/src/main/cpp/benchmarks/from_json.cu
+++ b/src/main/cpp/benchmarks/from_json.cu
@@ -58,9 +58,10 @@ namespace {
 // `generate_input`.
 constexpr auto default_value_width = 10;
 
-// Build a list of `num_keys` all-STRING column types. A string is the only value kind the raw-map
-// engine may unescape instead of copying verbatim, so a homogeneous all-STRING flat object is the
-// worst case for the rendering work and the only shape that can reach either rendering path.
+// Build a list of `num_keys` all-STRING column types: string values are the dominant raw-map
+// workload, so a homogeneous flat object is the default input shape. It reaches only the string
+// rendering categories -- the integer, float, and non-numeric canonicalization paths need a
+// mixed-type input.
 std::vector<cudf::type_id> make_all_string_column_types(int num_keys)
 {
   return std::vector<cudf::type_id>(num_keys, cudf::type_id::STRING);

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -15,6 +15,7 @@
  */
 
 #include "from_json_to_raw_map_debug.cuh"
+#include "ftos_converter.cuh"
 #include "json_parser.cuh"
 #include "json_utils.hpp"
 #include "nvtx_ranges.hpp"
@@ -411,11 +412,16 @@ __device__ inline bool is_key_node(node_kind const k) { return k == node_kind::k
 __device__ inline bool is_value_node(node_kind const k) { return k == node_kind::value; }
 __device__ inline bool is_element_node(node_kind const k) { return k == node_kind::element; }
 
-// How the materializer emits a selected node. Every non-string value kind is `verbatim` here
-// because this layer renders string escapes only.
+// How the materializer emits a selected node. Anything but `verbatim` re-renders to match Spark's
+// `from_json` StringType conversion.
 enum class token_category : int8_t {
-  verbatim = 0,    // bytes already match (escape-free string/key, or any non-string value kind)
-  string_unescape  // string or key containing a backslash: JSON-unescape
+  verbatim = 0,     // bytes already match (escape-free string/key, canonical int, bool)
+  string_unescape,  // string or key containing a backslash: JSON-unescape
+  int_strip,        // integer with leading zeros or -0: textual strip
+  float_norm,       // float: parse and re-render via Java `Double.toString` semantics
+  nonnumeric,       // NaN/Infinity spelling: fixed quoted canonical form
+  rejected,         // number past the parser's digit cap: renders 0 bytes and nullifies its row
+  null_value        // JSON `null` value in the string map: SQL NULL (empty span)
 };
 
 // Per-token nesting weights for the nested-range balance scan. libcudf bounds JSON tree depth to
@@ -644,6 +650,21 @@ __device__ inline bool is_json_null_literal(char const* json,
   return p[0] == 'n' && p[1] == 'u' && p[2] == 'l' && p[3] == 'l';
 }
 
+__device__ inline bool is_ascii_digit(char const c) { return c >= '0' && c <= '9'; }
+
+// Advance past leading zero digits in [digits_begin, end); a '0' is skipped only while another
+// digit follows, so the returned position is the first byte the caller keeps.
+__device__ inline SymbolOffsetT skip_leading_zeros(char const* json,
+                                                   SymbolOffsetT const digits_begin,
+                                                   SymbolOffsetT const end)
+{
+  auto pos = digits_begin;
+  while (pos + 1 < end && json[pos] == '0' && is_ascii_digit(json[pos + 1])) {
+    ++pos;
+  }
+  return pos;
+}
+
 // A string/key without a backslash is byte-identical to Jackson's unescaped text (the range is
 // already de-quoted); one with a backslash needs the JSON unescape.
 __device__ inline bool contains_backslash(char const* json,
@@ -656,7 +677,64 @@ __device__ inline bool contains_backslash(char const* json,
   return false;
 }
 
-// Only a string or key holding a backslash needs work; every other kind already matches Spark.
+// Mirrors the private `json_parser::check_max_num_len`, reusing its `max_num_len` so the threshold
+// has one definition. Digits MUST be counted the way `try_unsigned_number` counts them, which the
+// 1000/1001 boundary test pins.
+__device__ inline bool within_max_num_len(int const number_digits_length)
+{
+  return max_num_len <= 0 || number_digits_length <= max_num_len;
+}
+
+// First-byte dispatch is total here: strict validation already reduced a `ValueBegin` scalar to a
+// `null`/`true`/`false` literal, one of the six non-numeric spellings, or a valid number.
+__device__ token_category classify_value_bytes(char const* json,
+                                               SymbolOffsetT const begin,
+                                               SymbolOffsetT const end)
+{
+  char const c0 = json[begin];
+  // `true`/`false` render as their own text.
+  if (c0 == 't' || c0 == 'f') { return token_category::verbatim; }
+  if (is_json_null_literal(json, begin, end)) { return token_category::null_value; }
+  // Non-numeric spellings: 'N'/'I'/'+' can only start NaN/Infinity/+INF/+Infinity, and a '-' is
+  // non-numeric exactly when followed by 'I' (-INF/-Infinity); otherwise it starts a number.
+  if (c0 == 'N' || c0 == 'I' || c0 == '+' ||
+      (c0 == '-' && begin + 1 < end && json[begin + 1] == 'I')) {
+    return token_category::nonnumeric;
+  }
+  // A number. Both the parser and Jackson skip the sign and the leading zeros before counting
+  // digits, so the tally below starts where they start.
+  auto const digits_begin = begin + (c0 == '-' ? 1 : 0);
+  auto const digits_pos   = skip_leading_zeros(json, digits_begin, end);
+  // One pass decides float-ness and the digit tally. The tally must stay in step with
+  // `json_parser::try_unsigned_number`: every ASCII digit counts, no sign, '.' or 'e'/'E'.
+  bool is_float            = false;
+  int number_digits_length = 0;
+  for (auto p = digits_pos; p < end; ++p) {
+    char const c = json[p];
+    if (c == '.' || c == 'e' || c == 'E') {
+      is_float = true;
+    } else if (is_ascii_digit(c)) {
+      ++number_digits_length;
+    }
+  }
+  // Past the cap the parser refuses the number, which makes the record a Spark bad record: the
+  // value renders nothing and nullifies its whole row. Integers reject as well as floats -- Jackson
+  // length-checks both token kinds against the same limit.
+  if (!within_max_num_len(number_digits_length)) { return token_category::rejected; }
+  if (is_float) { return token_category::float_norm; }
+  // An integer: re-render (strip) when it has leading zeros (tokenizer-valid only with
+  // `allow_leading_zeros`) or is `-0` (Jackson renders it as `0`).
+  if (json[digits_begin] == '0' && (digits_begin + 1 < end || c0 == '-')) {
+    return token_category::int_strip;
+  }
+  return token_category::verbatim;
+}
+
+// Rendering category of a selected node/element from its begin token and de-quoted byte range.
+// A string or key carrying a backslash escape needs JSON-unescaping, and a value's bytes decide
+// whether it needs number canonicalization or SQL NULL (`classify_value_bytes`); everything else --
+// an escape-free string/key, a bool, or a nested object/array -- is `verbatim` and copies its raw
+// byte range unchanged.
 __device__ inline token_category classify_token(char const* json,
                                                 PdaTokenT const token,
                                                 SymbolOffsetT const range_begin,
@@ -667,12 +745,13 @@ __device__ inline token_category classify_token(char const* json,
     case token_t::FieldNameBegin:
       return contains_backslash(json, range_begin, range_end) ? token_category::string_unescape
                                                               : token_category::verbatim;
+    case token_t::ValueBegin: return classify_value_bytes(json, range_begin, range_end);
     default: return token_category::verbatim;
   }
 }
 
-// The two-pass write convention of the renderer below (and `make_strings_children`): a null
-// destination means the sizing pass -- compute and return the byte count, write nothing.
+// The two-pass write convention shared by all renderers below (and `make_strings_children`):
+// a null destination means the sizing pass -- compute and return the byte count, write nothing.
 
 // Re-parses the QUOTED token, so the range is widened by the one quote byte on each side. A single
 // quote is always 1 byte here because single quotes are normalized to double before tokenizing.
@@ -690,8 +769,84 @@ __device__ inline cudf::size_type render_unescaped_string(char const* json,
   return parser.write_unescaped_text(out);
 }
 
-// Range and category are fused into one pass because classifying re-reads the same token and the
-// byte range it just computed. Unselected nodes keep `{0, 0}`/`verbatim` and are never scanned.
+// Strip integer leading zeros and `-0` textually. Jackson re-renders integers from the parsed
+// value (BigInteger beyond int64), which equals dropping zeros while another digit follows and
+// collapsing an all-zero run to `0` with the sign dropped. Textual stripping stays exact where an
+// int64 parse would overflow; a run past the parser's digit cap never arrives here, because
+// `classify_value_bytes` gives it `token_category::rejected` and nullifies its row instead.
+__device__ cudf::size_type render_stripped_int(char const* json,
+                                               SymbolOffsetT const begin,
+                                               SymbolOffsetT const end,
+                                               char* out)
+{
+  bool const negative = json[begin] == '-';
+  auto const pos      = skip_leading_zeros(json, begin + (negative ? 1 : 0), end);
+  if (json[pos] == '0' && pos + 1 == end) {  // 0, -0, 000, -000, ...: all render as plain `0`.
+    if (out != nullptr) { *out = '0'; }
+    return 1;
+  }
+  auto const num_digits = static_cast<cudf::size_type>(end - pos);
+  if (out != nullptr) {
+    if (negative) { *out++ = '-'; }
+    memcpy(out, json + pos, num_digits);
+  }
+  return num_digits + (negative ? 1 : 0);
+}
+
+// Re-render a float via the in-tree `json_parser` float path (`stod` + Java `Double.toString`
+// rendering, NaN/Infinity results quoted). The strict parser rejects leading zeros, so those are
+// stripped first (reachable only with `allow_leading_zeros`); a clean float, sign included, parses
+// whole. When zeros were stripped from a NEGATIVE float the sign is re-applied to the rendered
+// text, landing INSIDE the quote for a quoted special (`-007e309` renders `"-Infinity"`).
+__device__ cudf::size_type render_normalized_float(char const* json,
+                                                   SymbolOffsetT const begin,
+                                                   SymbolOffsetT const end,
+                                                   char* out)
+{
+  bool const negative     = json[begin] == '-';
+  auto const digits_begin = begin + (negative ? 1 : 0);
+  auto const pos          = skip_leading_zeros(json, digits_begin, end);
+  if (pos == digits_begin) {
+    json_parser parser(char_range(json + begin, static_cast<cudf::size_type>(end - begin)));
+    parser.next_token();
+    return parser.write_unescaped_text(out);
+  }
+  json_parser parser(char_range(json + pos, static_cast<cudf::size_type>(end - pos)));
+  parser.next_token();
+  if (!negative) { return parser.write_unescaped_text(out); }
+  // The parser was handed the digits without their sign, so it renders the POSITIVE value and the
+  // answer is always exactly one byte longer. Sizing therefore only needs the parser's own length,
+  // and writing renders one byte in and fills the prefix -- no staging buffer to bound.
+  if (out == nullptr) { return parser.write_unescaped_text(nullptr) + 1; }
+  auto const len = parser.write_unescaped_text(out + 1);
+  // `out[1]` is the parser's first byte; the only quoted special reachable from digits is
+  // `"Infinity"`, whose sign belongs inside the quote. A zero-length render means the parser
+  // refused the token, which `classify_value_bytes` reproduces as `rejected` before it can arrive
+  // here; the guard keeps that drift from reading a byte the parser never wrote.
+  if (len > 0 && out[1] == '"') {
+    out[1] = '-';
+    out[0] = '"';
+  } else {
+    out[0] = '-';
+  }
+  return len + 1;
+}
+
+// Render a non-numeric spelling as its fixed quoted canonical form, selected by the first byte:
+// 'N' -> "NaN"; '-' -> "-Infinity"; '+'/'I' -> "Infinity". Emitting through
+// `double_normalization` reuses the exact bytes the float path produces for the same values.
+__device__ cudf::size_type render_nonnumeric(char const* json, SymbolOffsetT const begin, char* out)
+{
+  char const c0      = json[begin];
+  double const value = c0 == 'N'   ? cuda::std::numeric_limits<double>::quiet_NaN()
+                       : c0 == '-' ? -cuda::std::numeric_limits<double>::infinity()
+                                   : cuda::std::numeric_limits<double>::infinity();
+  return ftos_converter::double_normalization(value, out);
+}
+
+// Convert token positions to node ranges and rendering categories for each valid node, fused in
+// one pass (the category classification reads the same token and, for strings/scalars, scans the
+// just-computed byte range). Unselected nodes stay `{0, 0}`/`verbatim` and are never scanned.
 struct node_classify_fn {
   cudf::device_span<char const> input_json;
   cudf::device_span<PdaTokenT const> tokens;
@@ -793,8 +948,12 @@ struct substring_fn {
   }
 };
 
-// Used only when the extraction holds at least one `string_unescape` node. Stored ranges are
-// assumed in-bounds for `d_string`; a `verbatim` node here still takes the raw copy.
+// Spark-render materializer used when the extraction holds at least one non-verbatim node. Same
+// two-pass sizing/write convention as `substring_fn`, dispatching per compacted category. The
+// stored ranges are assumed in-bounds for `d_string`; no bound check is performed. The `verbatim`
+// arm keeps `substring_fn`'s zero-read sizing and raw memcpy, so canonical tokens in a flagged
+// column still take the raw copy; a `null_value` slot writes nothing (its null mask is attached by
+// the caller from the same categories).
 struct transform_fn {
   cudf::device_span<char const> d_string;
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
@@ -819,13 +978,33 @@ struct transform_fn {
       case token_category::string_unescape:
         size = render_unescaped_string(json, range.first, range.second, out);
         break;
+      case token_category::int_strip:
+        size = render_stripped_int(json, range.first, range.second, out);
+        break;
+      case token_category::float_norm:
+        size = render_normalized_float(json, range.first, range.second, out);
+        break;
+      case token_category::nonnumeric: size = render_nonnumeric(json, range.first, out); break;
+      // The parser refuses this number, so the whole row is nullified: write nothing, in BOTH
+      // passes, and never invoke the parser on bytes it already rejected.
+      case token_category::rejected: break;
+      case token_category::null_value: break;  // SQL NULL: empty span, write nothing
     }
     if (out == nullptr) { d_sizes[idx] = size; }
   }
 };
 
-// All three are indexed by node id and must travel together: pairing a selector with another
-// extraction's categories reads the wrong node.
+// Raise a sticky flag that only ever goes 0 -> 1. Re-reading before the store keeps every node
+// after the first from serializing a redundant atomic onto the same 4-byte address.
+__device__ inline void raise_gate(int32_t* gate)
+{
+  cuda::atomic_ref<int32_t, cuda::thread_scope_device> ref{*gate};
+  if (ref.load(cuda::memory_order_relaxed) == 0) { ref.store(1, cuda::memory_order_relaxed); }
+}
+
+// What one extraction selects and how it renders: the nodes tagged `sentinel` in `selector`, each
+// materialized per its `categories` entry. All three are indexed by node id and must travel
+// together -- pairing a selector with another extraction's categories reads the wrong node.
 struct extraction_spec {
   node_kind sentinel;
   cudf::device_span<node_kind const> selector;
@@ -839,48 +1018,78 @@ struct gated_extraction {
   bool needs_transform;
 };
 
-// Both gates are fused into one pass and one device-to-host copy, replacing a blocking round trip
-// per extraction.
-cuda::std::pair<gated_extraction, gated_extraction> compute_transform_gates(
-  extraction_spec first, extraction_spec second, rmm::cuda_stream_view stream)
+// Every host flag of one map conversion, read back in one transfer: each extraction already bound
+// to the gate computed for it, plus the two conversion-level flags that only a number-rejecting or
+// `null`-valued input raises. `any_rejected` is true when either extraction selected a `rejected`
+// number, and gates the row-nullification work that only such an input needs.
+// `second_has_null_value` is true when the SECOND extraction selected a JSON `null` value, and
+// gates building that column's validity.
+struct conversion_gates {
+  gated_extraction first;
+  gated_extraction second;
+  bool any_rejected;
+  bool second_has_null_value;
+};
+
+// Compute all host flags of one map conversion in a single fused pass and a single device-to-host
+// copy, instead of one blocking `thrust::any_of` round trip per flag. Both specs are indexed by the
+// same node ids, and each is returned already bound to its own gate.
+conversion_gates compute_transform_gates(extraction_spec first,
+                                         extraction_spec second,
+                                         rmm::cuda_stream_view stream)
 {
   auto const num_nodes = first.selector.size();
   CUDF_EXPECTS(first.categories.size() == num_nodes && second.selector.size() == num_nodes &&
                  second.categories.size() == num_nodes,
                "Transform gates require equally sized node metadata.");
-  auto gates = rmm::device_uvector<int32_t>(2, stream);
-  CUDF_CUDA_TRY(cudaMemsetAsync(gates.data(), 0, 2 * sizeof(int32_t), stream));
+  static constexpr int num_gates = 4;
+  auto gates                     = rmm::device_uvector<int32_t>(num_gates, stream);
+  CUDF_CUDA_TRY(cudaMemsetAsync(gates.data(), 0, num_gates * sizeof(int32_t), stream));
   auto const node_id_it = thrust::make_counting_iterator<cudf::size_type>(0);
   thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    node_id_it,
                    node_id_it + num_nodes,
                    [first, second, gates = gates.data()] __device__(auto const node_id) {
-                     // Concurrent relaxed stores of the same value: a gate only ever flips to 1.
-                     if (first.selector[node_id] == first.sentinel &&
-                         first.categories[node_id] != token_category::verbatim) {
-                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[0]}.store(
-                         1, cuda::memory_order_relaxed);
+                     // Each selected node's category is loaded once and answers every question.
+                     bool rejected = false;
+                     if (first.selector[node_id] == first.sentinel) {
+                       auto const category = first.categories[node_id];
+                       if (category != token_category::verbatim) { raise_gate(&gates[0]); }
+                       rejected = category == token_category::rejected;
                      }
-                     if (second.selector[node_id] == second.sentinel &&
-                         second.categories[node_id] != token_category::verbatim) {
-                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[1]}.store(
-                         1, cuda::memory_order_relaxed);
+                     if (second.selector[node_id] == second.sentinel) {
+                       auto const category = second.categories[node_id];
+                       if (category != token_category::verbatim) { raise_gate(&gates[1]); }
+                       rejected = rejected || category == token_category::rejected;
+                       if (category == token_category::null_value) { raise_gate(&gates[3]); }
                      }
+                     if (rejected) { raise_gate(&gates[2]); }
                    });
 
-  int32_t gates_host[2];
+  int32_t gates_host[num_gates];
   CUDF_CUDA_TRY(
     cudaMemcpyAsync(gates_host, gates.data(), sizeof(gates_host), cudaMemcpyDeviceToHost, stream));
   stream.synchronize();
-  return {{first, gates_host[0] != 0}, {second, gates_host[1] != 0}};
+  return {{first, gates_host[0] != 0},
+          {second, gates_host[1] != 0},
+          gates_host[2] != 0,
+          gates_host[3] != 0};
 }
 
-// With `needs_transform == false` this is exactly the old raw byte-range gather; otherwise the
-// compaction also carries each node's category and materializes through `transform_fn`.
+// Extract key-value string pairs from the input json string, rendered to match Spark. When every
+// selected node classified `verbatim` (`needs_transform == false`, precomputed by
+// `compute_transform_gates` and carried on the extraction itself), the extraction is exactly the
+// raw byte-range gather; otherwise the compaction additionally carries each node's category and
+// materializes through `transform_fn`. `attach_null_value_mask` turns each `null_value` slot into a
+// null entry of the returned strings column (the compacted categories provide the validity); the
+// caller passes it for the string-map VALUES extraction, and only when the gate pass actually found
+// such a value -- an all-valid mask would cost an allocation, a pass, and a `bools_to_mask` only to
+// be discarded.
 std::unique_ptr<cudf::column> extract_keys_or_values(
   gated_extraction const& extraction,
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> node_ranges,
   cudf::device_span<char const> input_json,
+  bool attach_null_value_mask,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -893,8 +1102,8 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
       return selector[node_id] == sentinel;
     });
 
-  // With every selected node `verbatim` (escape-free strings/keys, or any non-string value kind),
-  // the raw copy below is already byte-identical to Spark's rendering.
+  // With every selected node `verbatim` (escape-free strings/keys, canonical numbers, bools), the
+  // raw copy below is already byte-identical to Spark's rendering.
   if (!extraction.needs_transform) {
     auto extracted_ranges = rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(
       node_ranges.size(), stream);
@@ -916,8 +1125,8 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
       num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
   }
 
-  // Transform path: compact (range, category) with the same stencil in one pass, then materialize
-  // through the category dispatch.
+  // Transform path: compact (range, category) with the same stencil in one pass, then
+  // materialize through the category dispatch.
   auto const num_nodes = node_ranges.size();
   auto extracted_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
@@ -936,8 +1145,25 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
 
   auto [offsets, chars] = cudf::strings::detail::make_strings_children(
     transform_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
-  return cudf::make_strings_column(
+  auto output = cudf::make_strings_column(
     num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
+
+  if (attach_null_value_mask) {
+    // Validity is derivable from the compacted categories: exactly the `null_value` slots are
+    // null. The raw path never reaches here -- a `null_value` node forces the transform gate.
+    auto validity = rmm::device_uvector<bool>(num_extract, stream);
+    thrust::transform(rmm::exec_policy_nosync(stream),
+                      extracted_categories.begin(),
+                      extracted_categories.begin() + num_extract,
+                      validity.begin(),
+                      cuda::proclaim_return_type<bool>([] __device__(token_category const cat) {
+                        return cat != token_category::null_value;
+                      }));
+    auto [null_mask, null_count] =
+      cudf::bools_to_mask(cudf::device_span<bool const>(validity), stream, mr);
+    if (null_count > 0) { output->set_null_mask(std::move(*null_mask), null_count); }
+  }
+  return output;
 }
 
 // Compute the offsets for the final lists of Struct<String,String>.
@@ -1042,6 +1268,17 @@ struct is_line_begin {
            parent_node_ids[node_idx] < 0;
   }
 };
+
+// The input row an arbitrary node belongs to: the last line-begin `StructBegin` id not exceeding
+// it. `line_begin` holds one such id per row, sorted by construction (see `is_line_begin`). Every
+// row-nullifying fold shares this one lookup so they cannot drift apart.
+__device__ inline cudf::size_type row_of_node(NodeIndexT const* line_begin,
+                                              cudf::size_type const num_rows,
+                                              NodeIndexT const node_id)
+{
+  return static_cast<cudf::size_type>(
+    thrust::upper_bound(thrust::seq, line_begin, line_begin + num_rows, node_id) - line_begin - 1);
+}
 
 std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
   cudf::size_type num_rows,
@@ -1226,15 +1463,20 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
-  // Both extractions' transform gates in one fused pass and one sync.
-  auto const [keys, values] =
+  // Both extractions' transform gates, plus the reject and null-value flags, in one fused pass and
+  // one sync.
+  auto const [keys, values, any_rejected, values_have_null_value] =
     compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
                             {node_kind::value, is_key_or_value_node, node_categories},
                             stream);
 
-  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
-  auto extracted_values =
-    extract_keys_or_values(values, node_ranges, preprocessed_input, stream, mr);
+  auto extracted_keys = extract_keys_or_values(
+    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  // A JSON `null` VALUE keeps its pair but nulls the values-child entry (SQL NULL), so the values
+  // extraction attaches the null mask derived from its `null_value` categories -- only when the
+  // gate pass saw such a value, since otherwise the mask would be all-valid and thrown away.
+  auto extracted_values = extract_keys_or_values(
+    values, node_ranges, preprocessed_input, values_have_null_value, stream, mr);
   CUDF_EXPECTS(extracted_keys->size() == extracted_values->size(),
                "Invalid key-value pair extraction.");
 
@@ -1253,11 +1495,58 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
   auto structs_col = cudf::make_structs_column(
     num_pairs, std::move(out_keys_vals), 0, rmm::device_buffer{}, stream, mr);
 
-  // Do not use `cudf::make_lists_column` since we do not need to call `purge_nonempty_nulls`
-  // on the children columns as they do not have non-empty nulls.
+  // The children need no `purge_nonempty_nulls` sanitization: their only nulls are the SQL-NULL
+  // value slots, written with empty byte spans by construction. The one row shape that can leave a
+  // NON-empty null is a row nullified for a rejected number, and the outer list is sanitized for
+  // that case after assembly below.
   std::vector<std::unique_ptr<cudf::column>> list_children;
   list_children.emplace_back(std::move(list_offsets));
   list_children.emplace_back(std::move(structs_col));
+
+  // Row-level bad-record semantics (Spark `from_json`): a value the JSON parser refuses -- a number
+  // past its digit cap -- makes the whole record a bad record, so the entire output row is
+  // nullified. Folding this into `should_be_nullified` before `create_null_mask` lets the shared
+  // row null-mask computation absorb it with the correct `null_count`. Every step is behind
+  // `any_rejected`, so an input that rejects nothing launches nothing extra here.
+  rmm::device_uvector<NodeIndexT> line_begin_indices(0, stream);
+  // Stays empty unless the fold runs, in which case `create_null_mask` computes the list itself.
+  auto line_begin_span = cudf::device_span<NodeIndexT const>{};
+  if (any_rejected) {
+    auto const num_nodes  = node_token_ids.size();
+    auto const node_id_it = thrust::counting_iterator<NodeIndexT>(0);
+
+    // Line-begin `StructBegin` node ids, one per input row, sorted by construction. Also handed to
+    // `create_null_mask` below so it skips its own identical scan.
+    line_begin_indices.resize(num_nodes, stream);
+    auto const line_begin_copy_end = copy_if(node_id_it,
+                                             node_id_it + num_nodes,
+                                             line_begin_indices.begin(),
+                                             is_line_begin{tokens, node_token_ids, parent_node_ids},
+                                             stream);
+    auto const num_line_begin =
+      cuda::std::distance(line_begin_indices.begin(), line_begin_copy_end);
+    CUDF_EXPECTS(num_line_begin == input.size(), "Incorrect count of JSON objects.");
+    line_begin_span = cudf::device_span<NodeIndexT const>{line_begin_indices.data(),
+                                                          static_cast<std::size_t>(input.size())};
+
+    // A rejected value's row is the last line-begin `StructBegin` id not exceeding it.
+    thrust::for_each(
+      rmm::exec_policy_nosync(stream),
+      node_id_it,
+      node_id_it + num_nodes,
+      [key_or_value       = is_key_or_value_node.begin(),
+       node_categories    = node_categories.begin(),
+       line_begin_indices = line_begin_indices.begin(),
+       num_rows           = input.size(),
+       should_be_nullified =
+         should_be_nullified->mutable_view().begin<bool>()] __device__(NodeIndexT const node_id) {
+        if (!is_value_node(key_or_value[node_id]) ||
+            node_categories[node_id] != token_category::rejected) {
+          return;
+        }
+        should_be_nullified[row_of_node(line_begin_indices, num_rows, node_id)] = true;
+      });
+  }
 
   auto [null_mask, null_count] = create_null_mask(input.size(),
                                                   should_be_nullified,
@@ -1265,16 +1554,25 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
                                                   token_positions,
                                                   node_token_ids,
                                                   parent_node_ids,
-                                                  /*precomputed_line_begin*/ {},
+                                                  line_begin_span,
                                                   stream,
                                                   mr);
 
-  return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::LIST},
-                                        input.size(),
-                                        rmm::device_buffer{},
-                                        std::move(null_mask),
-                                        null_count,
-                                        std::move(list_children));
+  auto result = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::LIST},
+                                               input.size(),
+                                               rmm::device_buffer{},
+                                               std::move(null_mask),
+                                               null_count,
+                                               std::move(list_children));
+
+  // A row nulled for a rejected number is a well-formed object whose pairs were already
+  // materialized, so the outer list can carry non-empty nulls and must be sanitized here. No other
+  // row shape this path nullifies has any pairs, which is what keeps the check behind
+  // `any_rejected` and the common paths at zero cost.
+  if (any_rejected && null_count > 0 && cudf::has_nonempty_nulls(result->view(), stream)) {
+    return cudf::purge_nonempty_nulls(result->view(), stream, mr);
+  }
+  return result;
 }
 
 std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
@@ -1331,17 +1629,23 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
                                          element_categories.begin()});
   }
 
-  // Both extractions' transform gates in one fused pass and one sync.
-  auto const [keys, elements] =
+  // Both extractions' transform gates, plus the reject and null-value flags, in one fused pass and
+  // one sync.
+  auto const [keys, elements, any_rejected, elements_have_null_value] =
     compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
                             {node_kind::element, element_flag, element_categories},
                             stream);
+  // `element_classify_fn` records a `null` element in `element_valid` and leaves its category
+  // `verbatim`, so the element categories carry no `null_value` and mask #2 below is the only
+  // element validity source.
+  CUDF_EXPECTS(!elements_have_null_value, "Unexpected null-value category on the element path.");
 
-  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
+  auto extracted_keys = extract_keys_or_values(
+    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
 
   // Extract element strings with the shared extractor (a 0-null STRING column); attach mask #2.
-  auto extracted_elements =
-    extract_keys_or_values(elements, element_ranges, preprocessed_input, stream, mr);
+  auto extracted_elements = extract_keys_or_values(
+    elements, element_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
   {
     // Mask #2 over only the selected (element-flagged) nodes, in element document order, matching
     // the order `extract_keys_or_values` emits.
@@ -1499,9 +1803,12 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
 
   // Row-level bad-record semantics (Spark `from_json`): a row is nullified if any of its value
   // nodes is a hard type mismatch -- a value that is neither a `ListBegin` (valid array) nor the
-  // JSON `null` literal (kept, with a null inner list). Folding this into `should_be_nullified`
-  // before `create_null_mask` lets the shared row null-mask computation absorb it with the correct
-  // `null_count`. A value node's row is the last line-begin `StructBegin` id not exceeding it.
+  // JSON `null` literal (kept, with a null inner list) -- or if any of its ARRAY ELEMENTS is a
+  // number the JSON parser refuses, which makes the whole record a bad record. Folding both into
+  // `should_be_nullified` before `create_null_mask` lets the shared row null-mask computation
+  // absorb them with the correct `null_count`. A node's row is the last line-begin `StructBegin`
+  // id not exceeding it. A rejected number sitting directly as a scalar map VALUE needs no case of
+  // its own: it is already a hard type mismatch, and both rules store the same `true`.
   {
     auto const node_id_it = thrust::counting_iterator<NodeIndexT>(0);
     thrust::for_each(
@@ -1515,8 +1822,19 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
        input_json         = preprocessed_input.data(),
        line_begin_indices = line_begin_indices.begin(),
        num_rows           = input.size(),
+       // Init-capture, not a plain capture: `any_rejected` is a structured binding, which not
+       // every supported compiler lets a lambda capture directly.
+       any_rejected       = any_rejected,
+       element_flag       = element_flag.begin(),
+       element_categories = element_categories.begin(),
        should_be_nullified =
          should_be_nullified->mutable_view().begin<bool>()] __device__(NodeIndexT const node_id) {
+        // `any_rejected` is a host flag, uniform across every thread, so this costs nothing but a
+        // predicted branch on the far more common input that rejects no number at all.
+        if (any_rejected && is_element_node(element_flag[node_id]) &&
+            element_categories[node_id] == token_category::rejected) {
+          should_be_nullified[row_of_node(line_begin_indices, num_rows, node_id)] = true;
+        }
         if (!is_value_node(key_or_value[node_id])) { return; }
         auto const token = tokens[node_token_ids[node_id]];
         if (token == token_t::ListBegin) { return; }  // valid array.
@@ -1528,12 +1846,8 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
           if (is_json_null_literal(input_json, range.first, range.second)) { return; }
         }
         // Hard type mismatch (scalar string/number/bool, object, or any non-array, non-null value):
-        // nullify the entire row. Row = last line-begin id not exceeding `node_id`.
-        auto const row_idx =
-          thrust::upper_bound(
-            thrust::seq, line_begin_indices, line_begin_indices + num_rows, node_id) -
-          line_begin_indices - 1;
-        should_be_nullified[row_idx] = true;
+        // nullify the entire row.
+        should_be_nullified[row_of_node(line_begin_indices, num_rows, node_id)] = true;
       });
   }
 
@@ -1556,11 +1870,11 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
                                                null_count,
                                                std::move(list_children));
 
-  // A row nulled for a hard value type mismatch still spans the key/value pairs that were
-  // materialized before the mismatch was detected, so the outer list can carry non-empty nulls.
-  // This manual assembly skips the factory's `purge_nonempty_nulls` scan, so sanitize the outer
-  // list here (the children are already empty under their nulls by construction). Gated on a cheap
-  // check so the common all-valid / empty-null paths keep the zero-copy build.
+  // A row nulled for a hard value type mismatch, or for a rejected number in one of its arrays,
+  // still spans the key/value pairs that were materialized before the fold ran, so the outer list
+  // can carry non-empty nulls and must be sanitized here (the children are already empty under
+  // their nulls by construction). Gated on a cheap check so the common all-valid / empty-null paths
+  // keep the zero-copy build.
   if (null_count > 0 && cudf::has_nonempty_nulls(result->view(), stream)) {
     return cudf::purge_nonempty_nulls(result->view(), stream, mr);
   }

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -15,6 +15,7 @@
  */
 
 #include "from_json_to_raw_map_debug.cuh"
+#include "ftos_converter.cuh"
 #include "json_parser.cuh"
 #include "json_utils.hpp"
 #include "nvtx_ranges.hpp"
@@ -411,15 +412,19 @@ __device__ inline bool is_key_node(node_kind const k) { return k == node_kind::k
 __device__ inline bool is_value_node(node_kind const k) { return k == node_kind::value; }
 __device__ inline bool is_element_node(node_kind const k) { return k == node_kind::element; }
 
-// Rendering category of a selected key/value/element node, derived from its token kind and bytes.
-// Drives the materializer: a `verbatim` node is byte-identical to Spark's output and takes the raw
-// memcpy of its byte range; a `string_unescape` node is a string or key carrying a backslash escape
-// and is JSON-unescaped to match Spark's `getText`. Every non-string value kind (number, bool,
-// non-numeric spelling, nested object/array, or the JSON `null` literal) classifies `verbatim`: its
-// raw JSON byte range is copied unchanged.
+// Fine-grained rendering category of a selected key/value/element node, derived from its token
+// kind and bytes. Drives the Spark-render materializer: `verbatim` nodes are byte-identical to
+// Spark's output and take the raw memcpy; every other category re-renders to match Spark's
+// `from_json` StringType conversion (Jackson `getText` for strings, `copyCurrentStructure` with
+// quoted non-numeric numbers for everything else).
 enum class token_category : int8_t {
-  verbatim = 0,    // bytes already match (escape-free string/key, or any non-string value kind)
-  string_unescape  // string or key containing a backslash: JSON-unescape
+  verbatim = 0,     // bytes already match (escape-free string/key, canonical int, bool)
+  string_unescape,  // string or key containing a backslash: JSON-unescape
+  int_strip,        // integer with leading zeros or -0: textual strip
+  float_norm,       // float: parse and re-render via Java `Double.toString` semantics
+  nonnumeric,       // NaN/Infinity spelling: fixed quoted canonical form
+  rejected,         // number past the parser's digit cap: renders 0 bytes and nullifies its row
+  null_value        // JSON `null` value in the string map: SQL NULL (empty span)
 };
 
 // Per-token nesting weights for the nested-range balance scan. libcudf bounds JSON tree depth to
@@ -648,6 +653,21 @@ __device__ inline bool is_json_null_literal(char const* json,
   return p[0] == 'n' && p[1] == 'u' && p[2] == 'l' && p[3] == 'l';
 }
 
+__device__ inline bool is_ascii_digit(char const c) { return c >= '0' && c <= '9'; }
+
+// Advance past leading zero digits in [digits_begin, end); a '0' is skipped only while another
+// digit follows, so the returned position is the first byte the caller keeps.
+__device__ inline SymbolOffsetT skip_leading_zeros(char const* json,
+                                                   SymbolOffsetT const digits_begin,
+                                                   SymbolOffsetT const end)
+{
+  auto pos = digits_begin;
+  while (pos + 1 < end && json[pos] == '0' && is_ascii_digit(json[pos + 1])) {
+    ++pos;
+  }
+  return pos;
+}
+
 // A string/key without a backslash is byte-identical to Jackson's unescaped text (the range is
 // already de-quoted); one with a backslash needs the JSON unescape.
 __device__ inline bool contains_backslash(char const* json,
@@ -660,10 +680,70 @@ __device__ inline bool contains_backslash(char const* json,
   return false;
 }
 
+// Mirror of `json_parser::check_max_num_len`, which is private. Reuses the parser's own
+// `max_num_len` so the threshold has one definition; `<= 0` disables the cap, as there. The digit
+// count MUST be counted the way `try_unsigned_number` counts it -- the 1000/1001 boundary test is
+// what keeps the two from drifting apart.
+__device__ inline bool within_max_num_len(int const number_digits_length)
+{
+  return max_num_len <= 0 || number_digits_length <= max_num_len;
+}
+
+// Classify a `ValueBegin` scalar from its bytes. The tokenizer's strict validation already
+// constrained the byte set: such a scalar is exactly one of the `null`/`true`/`false` literals,
+// one of the six non-numeric spellings (`NaN`, `[+-]INF`, `[+-]?Infinity` -- reachable only with
+// `allow_nonnumeric_numbers`), or a number accepted by the validation FSM; anything else became an
+// error token and nullified its row upstream. First-byte dispatch is therefore total.
+__device__ token_category classify_value_bytes(char const* json,
+                                               SymbolOffsetT const begin,
+                                               SymbolOffsetT const end)
+{
+  char const c0 = json[begin];
+  // `true`/`false` render as their own text.
+  if (c0 == 't' || c0 == 'f') { return token_category::verbatim; }
+  if (is_json_null_literal(json, begin, end)) { return token_category::null_value; }
+  // Non-numeric spellings: 'N'/'I'/'+' can only start NaN/Infinity/+INF/+Infinity, and a '-' is
+  // non-numeric exactly when followed by 'I' (-INF/-Infinity); otherwise it starts a number.
+  if (c0 == 'N' || c0 == 'I' || c0 == '+' ||
+      (c0 == '-' && begin + 1 < end && json[begin + 1] == 'I')) {
+    return token_category::nonnumeric;
+  }
+  // A number. Both the parser and Jackson skip the sign and the leading zeros before counting
+  // digits, so the tally below starts where they start.
+  auto const digits_begin = begin + (c0 == '-' ? 1 : 0);
+  auto const digits_pos   = skip_leading_zeros(json, digits_begin, end);
+  // One pass decides both facts. Any '.', 'e', or 'E' makes it a float; digits contain none and
+  // the spellings above were already excluded, so this scan cannot misfire. The digit tally must
+  // stay in step with `json_parser::try_unsigned_number`: it counts every ASCII digit of the
+  // integer, fraction, and exponent parts and never the signs, '.' or 'e'/'E'.
+  bool is_float            = false;
+  int number_digits_length = 0;
+  for (auto p = digits_pos; p < end; ++p) {
+    char const c = json[p];
+    if (c == '.' || c == 'e' || c == 'E') {
+      is_float = true;
+    } else if (is_ascii_digit(c)) {
+      ++number_digits_length;
+    }
+  }
+  // Past the cap the parser refuses the number, which makes the record a Spark bad record: the
+  // value renders nothing and nullifies its whole row. Integers reject as well as floats -- Jackson
+  // length-checks both token kinds against the same limit.
+  if (!within_max_num_len(number_digits_length)) { return token_category::rejected; }
+  if (is_float) { return token_category::float_norm; }
+  // An integer: re-render (strip) when it has leading zeros (tokenizer-valid only with
+  // `allow_leading_zeros`) or is `-0` (Jackson renders it as `0`).
+  if (json[digits_begin] == '0' && (digits_begin + 1 < end || c0 == '-')) {
+    return token_category::int_strip;
+  }
+  return token_category::verbatim;
+}
+
 // Rendering category of a selected node/element from its begin token and de-quoted byte range.
-// Only a string or key carrying a backslash escape needs rendering (JSON-unescape); every other
-// node -- an escape-free string/key, any scalar value (number/bool/non-numeric/`null` literal), or
-// a nested object/array -- is `verbatim` and copies its raw byte range unchanged.
+// A string or key carrying a backslash escape needs JSON-unescaping, and a value's bytes decide
+// whether it needs number canonicalization or SQL NULL (`classify_value_bytes`); everything else --
+// an escape-free string/key, a bool, or a nested object/array -- is `verbatim` and copies its raw
+// byte range unchanged.
 __device__ inline token_category classify_token(char const* json,
                                                 PdaTokenT const token,
                                                 SymbolOffsetT const range_begin,
@@ -674,12 +754,13 @@ __device__ inline token_category classify_token(char const* json,
     case token_t::FieldNameBegin:
       return contains_backslash(json, range_begin, range_end) ? token_category::string_unescape
                                                               : token_category::verbatim;
+    case token_t::ValueBegin: return classify_value_bytes(json, range_begin, range_end);
     default: return token_category::verbatim;
   }
 }
 
-// The two-pass write convention of the renderer below (and `make_strings_children`): a null
-// destination means the sizing pass -- compute and return the byte count, write nothing.
+// The two-pass write convention shared by all renderers below (and `make_strings_children`):
+// a null destination means the sizing pass -- compute and return the byte count, write nothing.
 
 // Unescape a string/key: re-parse the QUOTED token as a root scalar and write its unescaped text.
 // The stored range is de-quoted and the surrounding quote is exactly 1 byte on each side (single
@@ -698,10 +779,84 @@ __device__ inline cudf::size_type render_unescaped_string(char const* json,
   return parser.write_unescaped_text(out);
 }
 
+// Strip integer leading zeros and `-0` textually. Jackson re-renders integers from the parsed
+// value (BigInteger beyond int64), which equals dropping zeros while another digit follows and
+// collapsing an all-zero run to `0` with the sign dropped. Textual stripping stays exact where an
+// int64 parse would overflow; a run past the parser's digit cap never arrives here, because
+// `classify_value_bytes` gives it `token_category::rejected` and nullifies its row instead.
+__device__ cudf::size_type render_stripped_int(char const* json,
+                                               SymbolOffsetT const begin,
+                                               SymbolOffsetT const end,
+                                               char* out)
+{
+  bool const negative = json[begin] == '-';
+  auto const pos      = skip_leading_zeros(json, begin + (negative ? 1 : 0), end);
+  if (json[pos] == '0' && pos + 1 == end) {  // 0, -0, 000, -000, ...: all render as plain `0`.
+    if (out != nullptr) { *out = '0'; }
+    return 1;
+  }
+  auto const num_digits = static_cast<cudf::size_type>(end - pos);
+  if (out != nullptr) {
+    if (negative) { *out++ = '-'; }
+    memcpy(out, json + pos, num_digits);
+  }
+  return num_digits + (negative ? 1 : 0);
+}
+
+// Re-render a float via the in-tree `json_parser` float path (`stod` + Java `Double.toString`
+// rendering, NaN/Infinity results quoted). The strict parser rejects leading zeros, so those are
+// stripped first (reachable only with `allow_leading_zeros`); a clean float, sign included, parses
+// whole. When zeros were stripped from a NEGATIVE float the sign is re-applied to the rendered
+// text, landing INSIDE the quote for a quoted special (`-007e309` renders `"-Infinity"`).
+__device__ cudf::size_type render_normalized_float(char const* json,
+                                                   SymbolOffsetT const begin,
+                                                   SymbolOffsetT const end,
+                                                   char* out)
+{
+  bool const negative     = json[begin] == '-';
+  auto const digits_begin = begin + (negative ? 1 : 0);
+  auto const pos          = skip_leading_zeros(json, digits_begin, end);
+  if (pos == digits_begin) {
+    json_parser parser(char_range(json + begin, static_cast<cudf::size_type>(end - begin)));
+    parser.next_token();
+    return parser.write_unescaped_text(out);
+  }
+  json_parser parser(char_range(json + pos, static_cast<cudf::size_type>(end - pos)));
+  parser.next_token();
+  if (!negative) { return parser.write_unescaped_text(out); }
+  // The parser was handed the digits without their sign, so it renders the POSITIVE value and the
+  // answer is always exactly one byte longer. Sizing therefore only needs the parser's own length,
+  // and writing renders one byte in and fills the prefix -- no staging buffer to bound.
+  if (out == nullptr) { return parser.write_unescaped_text(nullptr) + 1; }
+  auto const len = parser.write_unescaped_text(out + 1);
+  // `out[1]` is the parser's first byte; the only quoted special reachable from digits is
+  // `"Infinity"`, whose sign belongs inside the quote. A zero-length render means the parser
+  // refused the token, which `classify_value_bytes` reproduces as `rejected` before it can arrive
+  // here; the guard keeps that drift from reading a byte the parser never wrote.
+  if (len > 0 && out[1] == '"') {
+    out[1] = '-';
+    out[0] = '"';
+  } else {
+    out[0] = '-';
+  }
+  return len + 1;
+}
+
+// Render a non-numeric spelling as its fixed quoted canonical form, selected by the first byte:
+// 'N' -> "NaN"; '-' -> "-Infinity"; '+'/'I' -> "Infinity". Emitting through
+// `double_normalization` reuses the exact bytes the float path produces for the same values.
+__device__ cudf::size_type render_nonnumeric(char const* json, SymbolOffsetT const begin, char* out)
+{
+  char const c0      = json[begin];
+  double const value = c0 == 'N'   ? cuda::std::numeric_limits<double>::quiet_NaN()
+                       : c0 == '-' ? -cuda::std::numeric_limits<double>::infinity()
+                                   : cuda::std::numeric_limits<double>::infinity();
+  return ftos_converter::double_normalization(value, out);
+}
+
 // Convert token positions to node ranges and rendering categories for each valid node, fused in
-// one pass (the category classification reads the same token and, for a string/key, scans the
-// just-computed byte range for a backslash). Unselected nodes stay `{0, 0}`/`verbatim` and are
-// never scanned.
+// one pass (the category classification reads the same token and, for strings/scalars, scans the
+// just-computed byte range). Unselected nodes stay `{0, 0}`/`verbatim` and are never scanned.
 struct node_classify_fn {
   cudf::device_span<char const> input_json;
   cudf::device_span<PdaTokenT const> tokens;
@@ -808,11 +963,12 @@ struct substring_fn {
   }
 };
 
-// String-render materializer, used when the extraction holds at least one `string_unescape` node.
-// It keeps `make_strings_children`'s two-pass convention: a null destination sizes, a non-null one
-// writes. The stored ranges are assumed in-bounds for `d_string`; no bound check is performed. The
-// `verbatim` arm is a raw memcpy of the byte range, so a canonical token in a flagged column still
-// takes the raw copy; only a `string_unescape` node re-parses.
+// Spark-render materializer used when the extraction holds at least one non-verbatim node. Same
+// two-pass sizing/write convention as `substring_fn`, dispatching per compacted category. The
+// stored ranges are assumed in-bounds for `d_string`; no bound check is performed. The `verbatim`
+// arm keeps `substring_fn`'s zero-read sizing and raw memcpy, so canonical tokens in a flagged
+// column still take the raw copy; a `null_value` slot writes nothing (its null mask is attached by
+// the caller from the same categories).
 struct transform_fn {
   cudf::device_span<char const> d_string;
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
@@ -837,10 +993,29 @@ struct transform_fn {
       case token_category::string_unescape:
         size = render_unescaped_string(json, range.first, range.second, out);
         break;
+      case token_category::int_strip:
+        size = render_stripped_int(json, range.first, range.second, out);
+        break;
+      case token_category::float_norm:
+        size = render_normalized_float(json, range.first, range.second, out);
+        break;
+      case token_category::nonnumeric: size = render_nonnumeric(json, range.first, out); break;
+      // The parser refuses this number, so the whole row is nullified: write nothing, in BOTH
+      // passes, and never invoke the parser on bytes it already rejected.
+      case token_category::rejected: break;
+      case token_category::null_value: break;  // SQL NULL: empty span, write nothing
     }
     if (out == nullptr) { d_sizes[idx] = size; }
   }
 };
+
+// Raise a sticky flag that only ever goes 0 -> 1. Re-reading before the store keeps every node
+// after the first from serializing a redundant atomic onto the same 4-byte address.
+__device__ inline void raise_gate(int32_t* gate)
+{
+  cuda::atomic_ref<int32_t, cuda::thread_scope_device> ref{*gate};
+  if (ref.load(cuda::memory_order_relaxed) == 0) { ref.store(1, cuda::memory_order_relaxed); }
+}
 
 // What one extraction selects and how it renders: the nodes tagged `sentinel` in `selector`, each
 // materialized per its `categories` entry. All three are indexed by node id and must travel
@@ -860,52 +1035,78 @@ struct gated_extraction {
   bool needs_transform;
 };
 
-// Compute both extraction gates of one map conversion in a single fused pass and a single
-// device-to-host copy, instead of one blocking `thrust::any_of` round trip per extraction. Both
-// specs are indexed by the same node ids, and each is returned already bound to its own gate.
-cuda::std::pair<gated_extraction, gated_extraction> compute_transform_gates(
-  extraction_spec first, extraction_spec second, rmm::cuda_stream_view stream)
+// Every host flag of one map conversion, read back in one transfer: each extraction already bound
+// to the gate computed for it, plus the two conversion-level flags that only a number-rejecting or
+// `null`-valued input raises. `any_rejected` is true when either extraction selected a `rejected`
+// number, and gates the row-nullification work that only such an input needs.
+// `second_has_null_value` is true when the SECOND extraction selected a JSON `null` value, and
+// gates building that column's validity.
+struct conversion_gates {
+  gated_extraction first;
+  gated_extraction second;
+  bool any_rejected;
+  bool second_has_null_value;
+};
+
+// Compute all host flags of one map conversion in a single fused pass and a single device-to-host
+// copy, instead of one blocking `thrust::any_of` round trip per flag. Both specs are indexed by the
+// same node ids, and each is returned already bound to its own gate.
+conversion_gates compute_transform_gates(extraction_spec first,
+                                         extraction_spec second,
+                                         rmm::cuda_stream_view stream)
 {
   auto const num_nodes = first.selector.size();
   CUDF_EXPECTS(first.categories.size() == num_nodes && second.selector.size() == num_nodes &&
                  second.categories.size() == num_nodes,
                "Transform gates require equally sized node metadata.");
-  auto gates = rmm::device_uvector<int32_t>(2, stream);
-  CUDF_CUDA_TRY(cudaMemsetAsync(gates.data(), 0, 2 * sizeof(int32_t), stream));
+  static constexpr int num_gates = 4;
+  auto gates                     = rmm::device_uvector<int32_t>(num_gates, stream);
+  CUDF_CUDA_TRY(cudaMemsetAsync(gates.data(), 0, num_gates * sizeof(int32_t), stream));
   auto const node_id_it = thrust::make_counting_iterator<cudf::size_type>(0);
   thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    node_id_it,
                    node_id_it + num_nodes,
                    [first, second, gates = gates.data()] __device__(auto const node_id) {
-                     // Concurrent relaxed stores of the same value: a gate only ever flips to 1.
-                     if (first.selector[node_id] == first.sentinel &&
-                         first.categories[node_id] != token_category::verbatim) {
-                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[0]}.store(
-                         1, cuda::memory_order_relaxed);
+                     // Each selected node's category is loaded once and answers every question.
+                     bool rejected = false;
+                     if (first.selector[node_id] == first.sentinel) {
+                       auto const category = first.categories[node_id];
+                       if (category != token_category::verbatim) { raise_gate(&gates[0]); }
+                       rejected = category == token_category::rejected;
                      }
-                     if (second.selector[node_id] == second.sentinel &&
-                         second.categories[node_id] != token_category::verbatim) {
-                       cuda::atomic_ref<int32_t, cuda::thread_scope_device>{gates[1]}.store(
-                         1, cuda::memory_order_relaxed);
+                     if (second.selector[node_id] == second.sentinel) {
+                       auto const category = second.categories[node_id];
+                       if (category != token_category::verbatim) { raise_gate(&gates[1]); }
+                       rejected = rejected || category == token_category::rejected;
+                       if (category == token_category::null_value) { raise_gate(&gates[3]); }
                      }
+                     if (rejected) { raise_gate(&gates[2]); }
                    });
 
-  int32_t gates_host[2];
+  int32_t gates_host[num_gates];
   CUDF_CUDA_TRY(
     cudaMemcpyAsync(gates_host, gates.data(), sizeof(gates_host), cudaMemcpyDeviceToHost, stream));
   stream.synchronize();
-  return {{first, gates_host[0] != 0}, {second, gates_host[1] != 0}};
+  return {{first, gates_host[0] != 0},
+          {second, gates_host[1] != 0},
+          gates_host[2] != 0,
+          gates_host[3] != 0};
 }
 
-// Extract key-value string pairs from the input json string, with escaped strings/keys unescaped to
-// match Spark. When every selected node classified `verbatim` (`needs_transform == false`,
-// precomputed by `compute_transform_gates` and carried on the extraction itself), this is exactly
-// the raw byte-range gather; otherwise the compaction additionally carries each node's category and
-// materializes through `transform_fn`, which unescapes the `string_unescape` slots.
+// Extract key-value string pairs from the input json string, rendered to match Spark. When every
+// selected node classified `verbatim` (`needs_transform == false`, precomputed by
+// `compute_transform_gates` and carried on the extraction itself), the extraction is exactly the
+// raw byte-range gather; otherwise the compaction additionally carries each node's category and
+// materializes through `transform_fn`. `attach_null_value_mask` turns each `null_value` slot into a
+// null entry of the returned strings column (the compacted categories provide the validity); the
+// caller passes it for the string-map VALUES extraction, and only when the gate pass actually found
+// such a value -- an all-valid mask would cost an allocation, a pass, and a `bools_to_mask` only to
+// be discarded.
 std::unique_ptr<cudf::column> extract_keys_or_values(
   gated_extraction const& extraction,
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> node_ranges,
   cudf::device_span<char const> input_json,
+  bool attach_null_value_mask,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -918,8 +1119,8 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
       return selector[node_id] == sentinel;
     });
 
-  // With every selected node `verbatim` (escape-free strings/keys, or any non-string value kind),
-  // the raw copy below is already byte-identical to Spark's rendering.
+  // With every selected node `verbatim` (escape-free strings/keys, canonical numbers, bools), the
+  // raw copy below is already byte-identical to Spark's rendering.
   if (!extraction.needs_transform) {
     auto extracted_ranges = rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(
       node_ranges.size(), stream);
@@ -941,8 +1142,8 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
       num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
   }
 
-  // Transform path: compact (range, category) with the same stencil in one pass, then materialize
-  // through the category dispatch.
+  // Transform path: compact (range, category) with the same stencil in one pass, then
+  // materialize through the category dispatch.
   auto const num_nodes = node_ranges.size();
   auto extracted_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
@@ -961,8 +1162,25 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
 
   auto [offsets, chars] = cudf::strings::detail::make_strings_children(
     transform_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
-  return cudf::make_strings_column(
+  auto output = cudf::make_strings_column(
     num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
+
+  if (attach_null_value_mask) {
+    // Validity is derivable from the compacted categories: exactly the `null_value` slots are
+    // null. The raw path never reaches here -- a `null_value` node forces the transform gate.
+    auto validity = rmm::device_uvector<bool>(num_extract, stream);
+    thrust::transform(rmm::exec_policy_nosync(stream),
+                      extracted_categories.begin(),
+                      extracted_categories.begin() + num_extract,
+                      validity.begin(),
+                      cuda::proclaim_return_type<bool>([] __device__(token_category const cat) {
+                        return cat != token_category::null_value;
+                      }));
+    auto [null_mask, null_count] =
+      cudf::bools_to_mask(cudf::device_span<bool const>(validity), stream, mr);
+    if (null_count > 0) { output->set_null_mask(std::move(*null_mask), null_count); }
+  }
+  return output;
 }
 
 // Compute the offsets for the final lists of Struct<String,String>.
@@ -1067,6 +1285,17 @@ struct is_line_begin {
            parent_node_ids[node_idx] < 0;
   }
 };
+
+// The input row an arbitrary node belongs to: the last line-begin `StructBegin` id not exceeding
+// it. `line_begin` holds one such id per row, sorted by construction (see `is_line_begin`). Every
+// row-nullifying fold shares this one lookup so they cannot drift apart.
+__device__ inline cudf::size_type row_of_node(NodeIndexT const* line_begin,
+                                              cudf::size_type const num_rows,
+                                              NodeIndexT const node_id)
+{
+  return static_cast<cudf::size_type>(
+    thrust::upper_bound(thrust::seq, line_begin, line_begin + num_rows, node_id) - line_begin - 1);
+}
 
 std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
   cudf::size_type num_rows,
@@ -1257,15 +1486,20 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
-  // Both extractions' transform gates in one fused pass and one sync.
-  auto const [keys, values] =
+  // Both extractions' transform gates, plus the reject and null-value flags, in one fused pass and
+  // one sync.
+  auto const [keys, values, any_rejected, values_have_null_value] =
     compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
                             {node_kind::value, is_key_or_value_node, node_categories},
                             stream);
 
-  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
-  auto extracted_values =
-    extract_keys_or_values(values, node_ranges, preprocessed_input, stream, mr);
+  auto extracted_keys = extract_keys_or_values(
+    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  // A JSON `null` VALUE keeps its pair but nulls the values-child entry (SQL NULL), so the values
+  // extraction attaches the null mask derived from its `null_value` categories -- only when the
+  // gate pass saw such a value, since otherwise the mask would be all-valid and thrown away.
+  auto extracted_values = extract_keys_or_values(
+    values, node_ranges, preprocessed_input, values_have_null_value, stream, mr);
   CUDF_EXPECTS(extracted_keys->size() == extracted_values->size(),
                "Invalid key-value pair extraction.");
 
@@ -1284,11 +1518,58 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
   auto structs_col = cudf::make_structs_column(
     num_pairs, std::move(out_keys_vals), 0, rmm::device_buffer{}, stream, mr);
 
-  // Do not use `cudf::make_lists_column` since we do not need to call `purge_nonempty_nulls`
-  // on the children columns as they do not have non-empty nulls.
+  // The children need no `purge_nonempty_nulls` sanitization: their only nulls are the SQL-NULL
+  // value slots, written with empty byte spans by construction. The one row shape that can leave a
+  // NON-empty null is a row nullified for a rejected number, and the outer list is sanitized for
+  // that case after assembly below.
   std::vector<std::unique_ptr<cudf::column>> list_children;
   list_children.emplace_back(std::move(list_offsets));
   list_children.emplace_back(std::move(structs_col));
+
+  // Row-level bad-record semantics (Spark `from_json`): a value the JSON parser refuses -- a number
+  // past its digit cap -- makes the whole record a bad record, so the entire output row is
+  // nullified. Folding this into `should_be_nullified` before `create_null_mask` lets the shared
+  // row null-mask computation absorb it with the correct `null_count`. Every step is behind
+  // `any_rejected`, so an input that rejects nothing launches nothing extra here.
+  rmm::device_uvector<NodeIndexT> line_begin_indices(0, stream);
+  // Stays empty unless the fold runs, in which case `create_null_mask` computes the list itself.
+  auto line_begin_span = cudf::device_span<NodeIndexT const>{};
+  if (any_rejected) {
+    auto const num_nodes  = node_token_ids.size();
+    auto const node_id_it = thrust::counting_iterator<NodeIndexT>(0);
+
+    // Line-begin `StructBegin` node ids, one per input row, sorted by construction. Also handed to
+    // `create_null_mask` below so it skips its own identical scan.
+    line_begin_indices.resize(num_nodes, stream);
+    auto const line_begin_copy_end = copy_if(node_id_it,
+                                             node_id_it + num_nodes,
+                                             line_begin_indices.begin(),
+                                             is_line_begin{tokens, node_token_ids, parent_node_ids},
+                                             stream);
+    auto const num_line_begin =
+      cuda::std::distance(line_begin_indices.begin(), line_begin_copy_end);
+    CUDF_EXPECTS(num_line_begin == input.size(), "Incorrect count of JSON objects.");
+    line_begin_span = cudf::device_span<NodeIndexT const>{line_begin_indices.data(),
+                                                          static_cast<std::size_t>(input.size())};
+
+    // A rejected value's row is the last line-begin `StructBegin` id not exceeding it.
+    thrust::for_each(
+      rmm::exec_policy_nosync(stream),
+      node_id_it,
+      node_id_it + num_nodes,
+      [key_or_value       = is_key_or_value_node.begin(),
+       node_categories    = node_categories.begin(),
+       line_begin_indices = line_begin_indices.begin(),
+       num_rows           = input.size(),
+       should_be_nullified =
+         should_be_nullified->mutable_view().begin<bool>()] __device__(NodeIndexT const node_id) {
+        if (!is_value_node(key_or_value[node_id]) ||
+            node_categories[node_id] != token_category::rejected) {
+          return;
+        }
+        should_be_nullified[row_of_node(line_begin_indices, num_rows, node_id)] = true;
+      });
+  }
 
   auto [null_mask, null_count] = create_null_mask(input.size(),
                                                   should_be_nullified,
@@ -1296,16 +1577,25 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
                                                   token_positions,
                                                   node_token_ids,
                                                   parent_node_ids,
-                                                  /*precomputed_line_begin*/ {},
+                                                  line_begin_span,
                                                   stream,
                                                   mr);
 
-  return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::LIST},
-                                        input.size(),
-                                        rmm::device_buffer{},
-                                        std::move(null_mask),
-                                        null_count,
-                                        std::move(list_children));
+  auto result = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::LIST},
+                                               input.size(),
+                                               rmm::device_buffer{},
+                                               std::move(null_mask),
+                                               null_count,
+                                               std::move(list_children));
+
+  // A row nulled for a rejected number is a well-formed object whose pairs were already
+  // materialized, so the outer list can carry non-empty nulls and must be sanitized here. No other
+  // row shape this path nullifies has any pairs, which is what keeps the check behind
+  // `any_rejected` and the common paths at zero cost.
+  if (any_rejected && null_count > 0 && cudf::has_nonempty_nulls(result->view(), stream)) {
+    return cudf::purge_nonempty_nulls(result->view(), stream, mr);
+  }
+  return result;
 }
 
 std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
@@ -1362,17 +1652,23 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
                                          element_categories.begin()});
   }
 
-  // Both extractions' transform gates in one fused pass and one sync.
-  auto const [keys, elements] =
+  // Both extractions' transform gates, plus the reject and null-value flags, in one fused pass and
+  // one sync.
+  auto const [keys, elements, any_rejected, elements_have_null_value] =
     compute_transform_gates({node_kind::key, is_key_or_value_node, node_categories},
                             {node_kind::element, element_flag, element_categories},
                             stream);
+  // `element_classify_fn` records a `null` element in `element_valid` and leaves its category
+  // `verbatim`, so the element categories carry no `null_value` and mask #2 below is the only
+  // element validity source.
+  CUDF_EXPECTS(!elements_have_null_value, "Unexpected null-value category on the element path.");
 
-  auto extracted_keys = extract_keys_or_values(keys, node_ranges, preprocessed_input, stream, mr);
+  auto extracted_keys = extract_keys_or_values(
+    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
 
   // Extract element strings with the shared extractor (a 0-null STRING column); attach mask #2.
-  auto extracted_elements =
-    extract_keys_or_values(elements, element_ranges, preprocessed_input, stream, mr);
+  auto extracted_elements = extract_keys_or_values(
+    elements, element_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
   {
     // Mask #2 over only the selected (element-flagged) nodes, in element document order, matching
     // the order `extract_keys_or_values` emits.
@@ -1530,9 +1826,12 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
 
   // Row-level bad-record semantics (Spark `from_json`): a row is nullified if any of its value
   // nodes is a hard type mismatch -- a value that is neither a `ListBegin` (valid array) nor the
-  // JSON `null` literal (kept, with a null inner list). Folding this into `should_be_nullified`
-  // before `create_null_mask` lets the shared row null-mask computation absorb it with the correct
-  // `null_count`. A value node's row is the last line-begin `StructBegin` id not exceeding it.
+  // JSON `null` literal (kept, with a null inner list) -- or if any of its ARRAY ELEMENTS is a
+  // number the JSON parser refuses, which makes the whole record a bad record. Folding both into
+  // `should_be_nullified` before `create_null_mask` lets the shared row null-mask computation
+  // absorb them with the correct `null_count`. A node's row is the last line-begin `StructBegin`
+  // id not exceeding it. A rejected number sitting directly as a scalar map VALUE needs no case of
+  // its own: it is already a hard type mismatch, and both rules store the same `true`.
   {
     auto const node_id_it = thrust::counting_iterator<NodeIndexT>(0);
     thrust::for_each(
@@ -1546,8 +1845,19 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
        input_json         = preprocessed_input.data(),
        line_begin_indices = line_begin_indices.begin(),
        num_rows           = input.size(),
+       // Init-capture, not a plain capture: `any_rejected` is a structured binding, which not
+       // every supported compiler lets a lambda capture directly.
+       any_rejected       = any_rejected,
+       element_flag       = element_flag.begin(),
+       element_categories = element_categories.begin(),
        should_be_nullified =
          should_be_nullified->mutable_view().begin<bool>()] __device__(NodeIndexT const node_id) {
+        // `any_rejected` is a host flag, uniform across every thread, so this costs nothing but a
+        // predicted branch on the far more common input that rejects no number at all.
+        if (any_rejected && is_element_node(element_flag[node_id]) &&
+            element_categories[node_id] == token_category::rejected) {
+          should_be_nullified[row_of_node(line_begin_indices, num_rows, node_id)] = true;
+        }
         if (!is_value_node(key_or_value[node_id])) { return; }
         auto const token = tokens[node_token_ids[node_id]];
         if (token == token_t::ListBegin) { return; }  // valid array.
@@ -1559,12 +1869,8 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
           if (is_json_null_literal(input_json, range.first, range.second)) { return; }
         }
         // Hard type mismatch (scalar string/number/bool, object, or any non-array, non-null value):
-        // nullify the entire row. Row = last line-begin id not exceeding `node_id`.
-        auto const row_idx =
-          thrust::upper_bound(
-            thrust::seq, line_begin_indices, line_begin_indices + num_rows, node_id) -
-          line_begin_indices - 1;
-        should_be_nullified[row_idx] = true;
+        // nullify the entire row.
+        should_be_nullified[row_of_node(line_begin_indices, num_rows, node_id)] = true;
       });
   }
 
@@ -1587,11 +1893,11 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
                                                null_count,
                                                std::move(list_children));
 
-  // A row nulled for a hard value type mismatch still spans the key/value pairs that were
-  // materialized before the mismatch was detected, so the outer list can carry non-empty nulls.
-  // This manual assembly skips the factory's `purge_nonempty_nulls` scan, so sanitize the outer
-  // list here (the children are already empty under their nulls by construction). Gated on a cheap
-  // check so the common all-valid / empty-null paths keep the zero-copy build.
+  // A row nulled for a hard value type mismatch, or for a rejected number in one of its arrays,
+  // still spans the key/value pairs that were materialized before the fold ran, so the outer list
+  // can carry non-empty nulls and must be sanitized here (the children are already empty under
+  // their nulls by construction). Gated on a cheap check so the common all-valid / empty-null paths
+  // keep the zero-copy build.
   if (null_count > 0 && cudf::has_nonempty_nulls(result->view(), stream)) {
     return cudf::purge_nonempty_nulls(result->view(), stream, mr);
   }

--- a/src/main/cpp/src/json_utils.hpp
+++ b/src/main/cpp/src/json_utils.hpp
@@ -40,10 +40,18 @@ struct json_parse_options {
 /**
  * @brief Extract a map column from the JSON strings given by an input strings column.
  *
- * Targets the Spark schema `MapType[StringType, StringType]`. String keys and values are de-quoted
- * and JSON-unescaped (`\"` -> `"`, `\uXXXX` -> UTF-8, ...) to match Spark's `getText`; every other
- * value kind (number, boolean, `NaN`/`Infinity` spelling, nested object/array, and the JSON `null`
- * literal) keeps its verbatim raw JSON bytes.
+ * Keys and values are rendered to match Spark's `from_json` for the schema
+ * `MapType[StringType, StringType]` (Jackson semantics): string keys/values are de-quoted and
+ * JSON-unescaped; floats re-render via Java `Double.toString`; integer leading zeros and `-0` are
+ * stripped; the `NaN`/`Infinity` spellings become their quoted canonical forms; a nested
+ * object/array value keeps its verbatim raw JSON bytes. A value that is the JSON `null` literal
+ * keeps its pair but nulls the corresponding entry of the values child.
+ *
+ * A row is nullified when the input row is null, empty, whitespace only, or not a valid JSON
+ * object, or when any of its values is a number the JSON parser refuses. The parser caps a number's
+ * digit count -- signs, `.`, `e`/`E`, and leading zeros excluded -- and applies that cap to
+ * integers and floats alike; a number past it makes the record a Spark bad record, so the whole row
+ * becomes null instead of that value rendering.
  */
 std::unique_ptr<cudf::column> from_json_to_raw_map(
   cudf::strings_column_view const& input,
@@ -62,9 +70,11 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(
  * A value that is the JSON `null` literal produces a null inner list (the map row is kept). A value
  * that is non-null but not a JSON array (a scalar or an object) is a row-level bad record: the
  * entire outer map row is nullified, matching Spark `from_json`. An array element that is the
- * literal `null` produces a null element; a string element is de-quoted and JSON-unescaped like the
- * `from_json_to_raw_map` values, and every other element kind keeps its verbatim raw JSON bytes.
- * Row-level null/empty/invalid handling is otherwise identical to `from_json_to_raw_map`.
+ * literal `null` produces a null element; every other element is rendered like the
+ * `from_json_to_raw_map` values (strings de-quoted and unescaped, numbers re-rendered, nested
+ * objects/arrays keep their verbatim raw JSON bytes). A number the JSON parser refuses nullifies
+ * the whole row as an array element just as it does as a direct value. Row-level
+ * null/empty/invalid handling is otherwise identical to `from_json_to_raw_map`.
  */
 std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   cudf::strings_column_view const& input,

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -47,19 +47,21 @@ struct FromJsonTest : public cudf::test::BaseFixture {};
 namespace {
 
 // One (key, value) entry of a raw-map row, in the exact textual content the raw-map engine emits.
-// A string value (or key) is stored WITHOUT surrounding quotes and JSON-unescaped; every other
-// value kind carries its verbatim raw JSON bytes (see the RawMapOpt_* contract block below).
-using kv = std::pair<std::string, std::string>;
+// A string value (or key) is stored WITHOUT surrounding quotes and JSON-unescaped; a non-string
+// value carries its Spark-rendered text (see the RawMapOpt_* contract block below). A
+// `std::nullopt` value models a SQL NULL value slot: a JSON `null` value keeps the pair but nulls
+// the corresponding entry of the values child.
+using kv = std::pair<std::string, std::optional<std::string>>;
 
 // Build the expected `LIST<STRUCT<STRING,STRING>>` raw-map column directly from host data.
 //
 // `rows[r]` is the ordered list of (key, value) pairs that row `r` must contain (already in the
-// exact byte content the engine emits: keys and string values de-quoted and unescaped, every other
-// value kind its verbatim raw bytes). `row_valid[r] == false` makes row `r` a NULL list row
-// (its pairs, if any, are ignored and contribute nothing to the children). The keys child and
-// values child are flat STRING columns concatenated in row-major order; the structs child wraps
-// them; the list offsets are the running per-row pair counts of the valid rows; the row null mask
-// comes from `row_valid`.
+// exact byte content the engine emits). `row_valid[r] == false` makes row `r` a NULL list row (its
+// pairs, if any, are ignored and contribute nothing to the children). The keys child and values
+// child are flat STRING columns concatenated in row-major order; a `std::nullopt` value makes its
+// values-child entry null (the pair itself is kept). The structs child wraps them; the list
+// offsets are the running per-row pair counts of the valid rows; the row null mask comes from
+// `row_valid`.
 std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>> const& rows,
                                                     std::vector<bool> const& row_valid)
 {
@@ -69,7 +71,8 @@ std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>>
   auto const num_rows = rows.size();
 
   std::vector<std::string> flat_keys;
-  std::vector<std::string> flat_values;
+  std::vector<std::string> flat_values;  // Content (empty placeholder for a NULL value).
+  std::vector<bool> flat_value_valid;    // SQL-NULL value slots (a JSON `null` value) are false.
   std::vector<cudf::size_type> offsets{0};
   offsets.reserve(num_rows + 1);
 
@@ -79,15 +82,23 @@ std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>>
     if (row_valid[r]) {
       for (auto const& [k, v] : rows[r]) {
         flat_keys.push_back(k);
-        flat_values.push_back(v);
+        flat_values.push_back(v.value_or(""));
+        flat_value_valid.push_back(v.has_value());
         ++running;
       }
     }
     offsets.push_back(running);
   }
 
-  auto keys_child    = cudf::test::strings_column_wrapper(flat_keys.begin(), flat_keys.end());
-  auto values_child  = cudf::test::strings_column_wrapper(flat_values.begin(), flat_values.end());
+  auto keys_child = cudf::test::strings_column_wrapper(flat_keys.begin(), flat_keys.end());
+
+  bool const any_value_null = std::any_of(
+    flat_value_valid.begin(), flat_value_valid.end(), [](bool value) { return !value; });
+  auto values_child =
+    any_value_null ? cudf::test::strings_column_wrapper(
+                       flat_values.begin(), flat_values.end(), flat_value_valid.begin())
+                   : cudf::test::strings_column_wrapper(flat_values.begin(), flat_values.end());
+
   auto structs_child = cudf::test::structs_column_wrapper{{keys_child, values_child}}.release();
 
   auto offsets_col =
@@ -237,16 +248,21 @@ TEST_F(FromJsonTest, RawMapOpt_UnquotedControlCharactersStrict)
 
 // ===========================================================================
 // RawMapOpt_* : pin the exact LIST<STRUCT<STRING,STRING>> output of `from_json_to_raw_map`.
-// Value semantics (this layer renders string keys/values only; every other value kind is verbatim):
+// Value semantics match Spark's `from_json` StringType conversion (Jackson):
 //   * String VALUES/KEYS are emitted WITHOUT surrounding quotes and JSON-UNESCAPED (`\"` -> `"`,
 //     `\uXXXX` -> UTF-8, ...); escape-free strings are byte-identical to the raw extraction.
-//   * Every non-string value kind keeps its VERBATIM raw JSON bytes: a number (e.g. `1.00000`,
-//     `007`), a `NaN`/`Infinity` spelling, a nested object/array value, and the JSON `null` literal
-//     are all copied unchanged; `true`/`false` and already-canonical scalars are byte-identical.
+//   * Numbers are re-rendered: floats via Java `Double.toString`; integer leading zeros and `-0`
+//     are stripped; `NaN`/`Infinity` spellings become their QUOTED canonical forms.
+//   * A nested object/array value keeps its VERBATIM raw JSON bytes (copied unchanged).
+//   * A JSON `null` VALUE keeps the pair but nulls the values-child entry (SQL NULL).
+//   * `true`/`false` and already-canonical scalars are byte-identical to the input.
 //   * A populated object yields a non-null list of its (key, value) pairs in INPUT TEXTUAL order;
 //     a duplicate key is emitted once PER OCCURRENCE (no collapsing).
 //   * An empty object `{}` yields an EMPTY, NON-NULL list row.
 //   * A true-null / empty / whitespace-only / invalid row yields a NULL list row.
+//   * A value that is a number past the JSON parser's digit cap (`json_parser.cuh`'s
+//     `max_num_len`, counting digits only, after leading zeros) is a Spark BAD RECORD: the WHOLE
+//     row is nullified, integers and floats alike, even when its other pairs are fine.
 // ===========================================================================
 
 // Single key, single row.
@@ -406,17 +422,18 @@ void expect_raw_map_shape(cudf::column_view const& col, cudf::size_type num_rows
 
 }  // namespace
 
-// JSON `null` literal value `{"k":null}` -- this layer keeps the literal text "null" as the value
-// (the value node range is copied verbatim; SQL-NULL handling is a later layer). The whole row
-// stays valid.
+// JSON `null` literal value `{"k":null}` -- the pair is KEPT and its values-child entry is SQL
+// NULL, matching Spark (JacksonParser's map conversion nulls the value slot). The whole row stays
+// valid, and sibling pairs of the same row are unaffected.
 TEST_F(FromJsonTest, RawMapOpt_Char_NullLiteralValue)
 {
-  auto const input_col =
-    cudf::test::strings_column_wrapper{R"({"a":"x"})", R"({"k":null})", R"({"b":"y"})"};
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":"x"})", R"({"k":null})", R"({"b":"y"})", R"({"c":null,"d":"z"})"};
   auto const input = cudf::strings_column_view{input_col};
 
-  auto const expected =
-    make_expected_raw_map({{{"a", "x"}}, {{"k", "null"}}, {{"b", "y"}}}, all_valid(3));
+  auto const expected = make_expected_raw_map(
+    {{{"a", "x"}}, {{"k", std::nullopt}}, {{"b", "y"}}, {{"c", std::nullopt}, {"d", "z"}}},
+    all_valid(4));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
@@ -474,6 +491,247 @@ TEST_F(FromJsonTest, RawMapOpt_Render_KeyEscapes)
 
   auto const expected =
     make_expected_raw_map({{{"kéy", "v\tz"}, {"a\tb", "w"}, {"q\"r", "x"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Float values re-render via Java `Double.toString` semantics (exactly-parseable literals only:
+// the device float parse is not correctly-rounded for adversarial long mantissas).
+TEST_F(FromJsonTest, RawMapOpt_Render_FloatCanonical)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":1.00000,"b":1e2,"c":351.980,"d":1E308,"e":0.0003,"f":0.003})",
+    R"({"g":12345678900000000000.0,"h":-2.5,"i":-0.5,"j":-0.0})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"a", "1.0"},
+                            {"b", "100.0"},
+                            {"c", "351.98"},
+                            {"d", "1.0E308"},
+                            {"e", "3.0E-4"},
+                            {"f", "0.003"}},
+                           {{"g", "1.23456789E19"}, {"h", "-2.5"}, {"i", "-0.5"}, {"j", "-0.0"}}},
+                          all_valid(2));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Float overflow/underflow: out-of-range magnitudes parse to +/-Infinity (rendered QUOTED) or
+// +/-0.0, matching Java `Double.parseDouble` + `Double.toString`.
+TEST_F(FromJsonTest, RawMapOpt_Render_FloatOverflow)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":1e309,"b":-1e309,"c":1e-999,"d":-1e-999})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"a", R"("Infinity")"}, {"b", R"("-Infinity")"}, {"c", "0.0"}, {"d", "-0.0"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Integer leading zeros (`allow_leading_zeros`) and `-0` are stripped textually, so digit runs far
+// beyond int64 range keep every significant digit (matching Jackson's BigInteger re-render).
+TEST_F(FromJsonTest, RawMapOpt_Render_IntLeadingZeros)
+{
+  auto const huge_digits = std::string(26, '9');
+  auto const input_col   = cudf::test::strings_column_wrapper{
+    R"({"a":007,"b":-007,"c":-0,"d":0,"e":42})",
+    "{\"f\":00" + huge_digits + ",\"g\":0000000000000000000000000000007}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"a", "7"}, {"b", "-7"}, {"c", "0"}, {"d", "0"}, {"e", "42"}},
+                           {{"f", huge_digits}, {"g", "7"}}},
+                          all_valid(2));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Floats carrying leading zeros (`allow_leading_zeros`) re-render from the parsed value, including
+// a negative overflow whose sign must land INSIDE the quoted special form.
+TEST_F(FromJsonTest, RawMapOpt_Render_FloatLeadingZeros)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":007.5,"b":-007.5,"c":00.5,"d":-000e1,"e":-007e309})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"a", "7.5"}, {"b", "-7.5"}, {"c", "0.5"}, {"d", "-0.0"}, {"e", R"("-Infinity")"}}},
+    all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+namespace {
+
+// The JSON parser's number digit cap (`max_num_len` in `json_parser.cuh`, which also matches
+// Jackson's `StreamReadConstraints.DEFAULT_MAX_NUM_LEN`). A number is refused once its digit count
+// EXCEEDS this, so exactly this many digits is still accepted. Spelled out here rather than
+// included: `json_parser.cuh` is device-only, and an independent literal is what makes these tests
+// catch the classifier drifting away from the parser.
+constexpr int max_num_digits = 1000;
+
+// `n` copies of one digit -- the building block for a number with an exact digit count.
+std::string digits(int n, char d = '7') { return std::string(static_cast<std::size_t>(n), d); }
+
+// A float carrying exactly `n` counted digits: `n - 1` nines and a one-digit exponent. Its
+// magnitude overflows double by such a margin that it renders as the quoted `Infinity` special
+// whatever the mantissa rounds to, so the expectation does not depend on float parsing detail.
+std::string huge_float(int n) { return digits(n - 1, '9') + "e9"; }
+
+// True iff OUTPUT ROW `row` is a null list row. Asserts the OUTER row's validity specifically --
+// an empty or degenerate row is not a null row, and only slicing distinguishes them.
+bool row_is_null(cudf::column_view const& result, cudf::size_type row)
+{
+  return cudf::slice(result, {row, row + 1})[0].null_count() == 1;
+}
+
+}  // namespace
+
+// Digit-cap boundary for INTEGERS, on both classification arms: a canonical integer (verbatim, the
+// raw fast path) and one carrying leading zeros or a sign (textually stripped). Exactly
+// `max_num_digits` digits renders; one more makes the record a Spark bad record and nulls the whole
+// row. This boundary is what pins the classifier's digit count to the parser's own, so it must
+// break loudly if either side moves.
+TEST_F(FromJsonTest, RawMapOpt_Reject_IntDigitCapBoundary)
+{
+  auto const at_cap    = digits(max_num_digits);
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    // Row 0: every arm exactly AT the cap -> all render.
+    R"({"plain":)" + at_cap + R"(,"zeros":00)" + at_cap + R"(,"neg":-00)" + at_cap + "}",
+    // Rows 1-3: one digit OVER, one arm each -> whole row null.
+    R"({"plain":)" + over + "}",
+    R"({"zeros":00)" + over + "}",
+    R"({"neg":-00)" + over + "}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"plain", at_cap}, {"zeros", at_cap}, {"neg", "-" + at_cap}}, {}, {}, {}},
+    {true, false, false, false});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_TRUE(row_is_null(result->view(), 2));
+  EXPECT_TRUE(row_is_null(result->view(), 3));
+}
+
+// Digit-cap boundary for FLOATS, on both rendering arms of `render_normalized_float`: the plain arm
+// (no leading zeros, parsed whole) and the negative-with-stripped-zeros arm that renders the
+// positive value one byte in and re-applies the sign INSIDE the quoted special. The over-cap
+// negative case is the crash repro: the parser refuses it and writes nothing, which used to be read
+// back as a rendered byte and turned into a `memcpy` of length `0 - 1`.
+TEST_F(FromJsonTest, RawMapOpt_Reject_FloatDigitCapBoundary)
+{
+  auto const at_cap    = huge_float(max_num_digits);
+  auto const over      = huge_float(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    // Row 0: both arms exactly AT the cap -> both render as the quoted special.
+    R"({"plain":)" + at_cap + R"(,"negzeros":-00)" + at_cap + "}",
+    // Rows 1-2: one digit OVER, one arm each -> whole row null.
+    R"({"plain":)" + over + "}",
+    R"({"negzeros":-00)" + over + "}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"plain", R"("Infinity")"}, {"negzeros", R"("-Infinity")"}}, {}, {}}, {true, false, false});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_TRUE(row_is_null(result->view(), 2));
+}
+
+// Leading zeros are NOT counted toward the cap -- both the parser and Jackson skip them before
+// counting. These tokens are far longer than the cap in raw bytes yet carry only two counted
+// digits, so they must render normally. A digit count taken over the raw range would reject every
+// one of them.
+TEST_F(FromJsonTest, RawMapOpt_Reject_LeadingZerosNotCounted)
+{
+  auto const zeros = digits(max_num_digits + 5, '0');
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":)" + zeros + R"(.5,"b":-)" + zeros + R"(.5,"c":)" +
+                                       zeros + R"(7,"d":-)" + zeros + "7}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  // `a`/`b` keep one zero before the point (a zero is dropped only while another DIGIT follows);
+  // `c`/`d` strip the whole run down to the single significant digit.
+  auto const expected =
+    make_expected_raw_map({{{"a", "0.5"}, {"b", "-0.5"}, {"c", "7"}, {"d", "-7"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// A refused number nullifies its ENTIRE row, not merely its own value slot, and touches no other
+// row: the neighbours keep every pair. Also pins that a rejected value nulls the row even when the
+// object is otherwise well formed and its other pairs already rendered.
+TEST_F(FromJsonTest, RawMapOpt_Reject_NullsWholeRowNotJustValue)
+{
+  auto const over = digits(max_num_digits + 1);
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":"keep","b":1})",
+                                       R"({"a":"drop","b":)" + over + R"(,"c":"drop too"})",
+                                       R"({"a":"keep2"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"a", "keep"}, {"b", "1"}}, {}, {{"a", "keep2"}}}, {true, false, true});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 1);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_FALSE(row_is_null(result->view(), 2));
+}
+
+// Every value in the column renders zero bytes -- one refused number and one SQL NULL -- so the
+// VALUES extraction's total size is zero and `make_strings_children` skips its write pass entirely.
+// The reject must therefore already be settled at classification time: a signal raised only while
+// writing chars would never run here. The surviving `null` row keeps the case non-degenerate.
+TEST_F(FromJsonTest, RawMapOpt_Reject_ZeroTotalValueBytesSkipsWritePass)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"k":)" + digits(max_num_digits + 1) + "}", R"({"n":null})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{}, {{"n", std::nullopt}}}, {false, true});
+  auto const result   = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+  EXPECT_TRUE(row_is_null(result->view(), 0));
+  EXPECT_FALSE(row_is_null(result->view(), 1));
+}
+
+// A row nulled for a refused number is a well-formed object whose earlier pairs were already
+// materialized, so its outer list slot would be a NON-EMPTY null. The hand-assembled list must be
+// sanitized: `CUDF_TEST_EXPECT_COLUMNS_EQUAL` compares offsets, so an unpurged row fails here.
+TEST_F(FromJsonTest, RawMapOpt_Reject_AfterValidPairsPurgesNonEmptyNull)
+{
+  auto const over      = huge_float(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"p":"one","q":"two","r":"three","s":)" + over + "}", R"({"p":"kept"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{}, {{"p", "kept"}}}, {false, true});
+  auto const result   = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+  EXPECT_TRUE(row_is_null(result->view(), 0));
+}
+
+// All six tokenizer-accepted non-numeric spellings (`allow_nonnumeric_numbers`) render as their
+// QUOTED canonical forms, exactly as Jackson writes them with QUOTE_NON_NUMERIC_NUMBERS.
+TEST_F(FromJsonTest, RawMapOpt_Render_NonNumeric)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":NaN,"b":Infinity,"c":+INF,"d":+Infinity,"e":-INF,"f":-Infinity})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"a", R"("NaN")"},
+                                                {"b", R"("Infinity")"},
+                                                {"c", R"("Infinity")"},
+                                                {"d", R"("Infinity")"},
+                                                {"e", R"("-Infinity")"},
+                                                {"f", R"("-Infinity")"}}},
+                                              all_valid(1));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
@@ -573,20 +831,6 @@ TEST_F(FromJsonTest, RawMapOpt_Render_VerbatimScalarValues)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
-// Lenient number spellings keep their verbatim raw JSON bytes at this layer: `allow_leading_zeros`
-// keeps `007`, `allow_nonnumeric_numbers` keeps `NaN`/`Infinity`, and a non-canonical float is not
-// normalized. Number canonicalization arrives in a later layer, which must flip this expectation.
-TEST_F(FromJsonTest, RawMapOpt_Render_VerbatimLenientNumbers)
-{
-  auto const input_col =
-    cudf::test::strings_column_wrapper{R"({"a":007,"b":NaN,"c":Infinity,"d":1.00000})"};
-  auto const input = cudf::strings_column_view{input_col};
-
-  auto const expected = make_expected_raw_map(
-    {{{"a", "007"}, {"b", "NaN"}, {"c", "Infinity"}, {"d", "1.00000"}}}, all_valid(1));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
-}
-
 // Long ESCAPED value: `RawMapOpt_LongValues` covers the long escape-free (verbatim memcpy) path;
 // this covers the long unescape path, where `make_strings_children` re-parses the whole token once
 // per pass and the rendered length shrinks across hundreds of escapes.
@@ -603,6 +847,41 @@ TEST_F(FromJsonTest, RawMapOpt_Render_LongEscapedValue)
   auto const input     = cudf::strings_column_view{input_col};
 
   auto const expected = make_expected_raw_map({{{"k", unescaped}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// A nested object/array VALUE keeps its VERBATIM raw JSON bytes -- its inner escapes and spacing
+// are NOT re-rendered -- which is the one contract line above that no other test pins. The escaped
+// sibling value forces the values gate TRUE, so the nested bytes are materialized by the render
+// dispatch rather than the raw fast path, and over a range spanning many tokens rather than one.
+TEST_F(FromJsonTest, RawMapOpt_Render_NestedValuesVerbatim)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"o":{"a":"x\"y"},"l":[1,{"b":2},"s"],"e":"p\\q"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"o", R"({"a":"x\"y"})"}, {"l", R"([1,{"b":2},"s"])"}, {"e", R"(p\q)"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Multi-block coverage for the render path: every other gate-flipping test is small enough to fit
+// one thread block, so the render dispatch, the zip compaction, and the device-scope sticky gate
+// flags have never run across blocks. Both gates are TRUE here -- the key carries an escape, and
+// the values span four render categories.
+TEST_F(FromJsonTest, RawMapOpt_Render_MultiBlockTransform)
+{
+  constexpr int num_rows = 50000;
+  std::vector<std::string> rows(static_cast<std::size_t>(num_rows),
+                                R"({"e\tk":"a\"b","f":1.50000,"z":007,"n":NaN})");
+  std::vector<std::vector<kv>> expected_rows(
+    static_cast<std::size_t>(num_rows),
+    {{"e\tk", R"(a"b)"}, {"f", "1.5"}, {"z", "7"}, {"n", R"("NaN")"}});
+
+  auto const input_col = cudf::test::strings_column_wrapper(rows.begin(), rows.end());
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(expected_rows, all_valid(num_rows));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
@@ -770,6 +1049,41 @@ TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryNullMask)
   }
 }
 
+// The VALUES-child null mask around 32-bit bitmask word boundaries. That mask is indexed by PAIR,
+// not by row, so a one-row column still drives it arbitrarily wide; every other null-value test
+// stays under a single word. The first and last pair of each size is a JSON `null`, so the boundary
+// word is written from both ends.
+TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryValueNullMask)
+{
+  for (int const num_pairs : {31, 32, 33, 65}) {
+    SCOPED_TRACE(std::format("num_pairs={}", num_pairs));
+
+    std::string row = "{";
+    std::vector<kv> expected_row;
+    expected_row.reserve(static_cast<std::size_t>(num_pairs));
+    for (int p = 0; p < num_pairs; ++p) {
+      bool const is_null    = p == 0 || p == num_pairs - 1;
+      auto const value_text = is_null ? std::string{"null"} : std::format(R"("v{}")", p);
+      if (p > 0) { row += ","; }
+      row += std::format(R"("k{}":{})", p, value_text);
+      expected_row.emplace_back(
+        std::format("k{}", p),
+        is_null ? std::optional<std::string>{} : std::optional<std::string>{std::format("v{}", p)});
+    }
+    row += "}";
+
+    auto const input_col = cudf::test::strings_column_wrapper{row};
+    auto const result    = raw_map(cudf::strings_column_view{input_col});
+    auto const expected  = make_expected_raw_map({expected_row}, all_valid(1));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+    auto const values =
+      cudf::structs_column_view{cudf::lists_column_view{result->view()}.child()}.child(1);
+    EXPECT_EQ(values.size(), num_pairs);
+    EXPECT_EQ(values.null_count(), 2);
+  }
+}
+
 // ===========================================================================
 // Array path: `from_json_to_raw_map_array_values` -> LIST<STRUCT<STRING, LIST<STRING>>>.
 // Each test asserts exact output via `make_expected_raw_map_array`. Element/value semantics:
@@ -778,9 +1092,13 @@ TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryNullMask)
 //   * value = JSON `null` literal -> row KEPT, NULL inner list (mask #1).
 //   * value = scalar / object (present, non-null, NOT an array) -> HARD TYPE MISMATCH: the WHOLE
 //     row is nullified (Spark row-level bad-record semantics), even if other keys are valid arrays.
-//   * element = string -> de-quoted and JSON-unescaped; every other element kind (number, bool,
-//     nested object/array) keeps its VERBATIM raw JSON bytes.
+//   * element = Spark-rendered like the string-map values: strings de-quoted and JSON-unescaped;
+//     numbers re-rendered (float canonical, leading-zero strip, quoted NaN/Infinity); nested
+//     object/array elements keep their VERBATIM raw JSON bytes; bools byte-identical.
 //   * element = literal `null` -> NULL element (mask #2); a JSON STRING "null" stays valid.
+//   * element = number past the JSON parser's digit cap -> Spark BAD RECORD: the WHOLE row is
+//     nullified, exactly as for a string-map value (a rejected number sitting directly as a value
+//     is already covered by the hard-type-mismatch rule above).
 // ===========================================================================
 
 namespace {
@@ -1009,6 +1327,17 @@ TEST_F(FromJsonTest, RawMapArray_MixedElementKinds)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
+// Already-canonical number / bool elements are byte-identical to their input text.
+TEST_F(FromJsonTest, RawMapArray_NumberBoolElements)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{R"({"k":[1,22,333,true,false]})"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map_array({{{"k", arr({"1", "22", "333", "true", "false"})}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
 // Null input row yields a NULL map row.
 TEST_F(FromJsonTest, RawMapArray_NullInputRow)
 {
@@ -1133,13 +1462,17 @@ TEST_F(FromJsonTest, RawMapArray_SingleQuoteNormalizationWithEscapes)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
 }
 
-// Leading-zeros / non-numeric-number leniency on numeric elements: both spellings keep their
-// verbatim raw JSON bytes at this layer. Number canonicalization arrives in a later layer, which
-// must flip this expectation.
+// Leading-zeros / non-numeric-number leniency on numeric elements: lenient numbers re-render like
+// the string-map values (leading zeros stripped, non-numeric spellings quoted canonical). All six
+// spellings the tokenizer accepts are pinned here, as on the map side. The zero-padded run is far
+// beyond int64 range, so it also pins that the element strip stays textual rather than going
+// through an integer parse.
 TEST_F(FromJsonTest, RawMapArray_NumericLeniency)
 {
-  auto const input_col = cudf::test::strings_column_wrapper{R"({"k":[007,NaN,Infinity]})"};
-  auto const input     = cudf::strings_column_view{input_col};
+  auto const huge_digits = std::string(26, '9');
+  auto const input_col   = cudf::test::strings_column_wrapper{
+    R"({"k":[007,NaN,Infinity,+INF,+Infinity,-INF,-Infinity,-0,00)" + huge_digits + "]}"};
+  auto const input = cudf::strings_column_view{input_col};
 
   auto const result = spark_rapids_jni::from_json_to_raw_map_array_values(
     input,
@@ -1148,9 +1481,34 @@ TEST_F(FromJsonTest, RawMapArray_NumericLeniency)
                                          /*allow_nonnumeric_numbers=*/true,
                                          default_options.allow_unquoted_control});
 
-  auto const expected =
-    make_expected_raw_map_array({{{"k", arr({"007", "NaN", "Infinity"})}}}, all_valid(1));
+  auto const expected = make_expected_raw_map_array({{{"k",
+                                                       arr({"7",
+                                                            R"("NaN")",
+                                                            R"("Infinity")",
+                                                            R"("Infinity")",
+                                                            R"("Infinity")",
+                                                            R"("-Infinity")",
+                                                            R"("-Infinity")",
+                                                            "0",
+                                                            huge_digits})}}},
+                                                    all_valid(1));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+}
+
+// Float elements re-render via Java `Double.toString` semantics; an overflow renders quoted. The
+// last three carry leading zeros (`allow_leading_zeros`), which the strict parser refuses, so they
+// are stripped and re-rendered from the parsed value -- and a NEGATIVE one has its sign re-applied
+// to that render, landing INSIDE the quote of a quoted special.
+TEST_F(FromJsonTest, RawMapArray_Render_FloatElements)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":[1.00000,1e2,-1e309,007.5,-007.5,-007e309]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({"1.0", "100.0", R"("-Infinity")", "7.5", "-7.5", R"("-Infinity")"})}}},
+    all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
 // All-canonical, escape-free column (clean strings/ints/bools, an empty array): every key/element
@@ -1193,6 +1551,63 @@ TEST_F(FromJsonTest, RawMapArray_Render_MultiBlockEscaped)
 
   auto const expected = make_expected_raw_map_array(expected_rows, all_valid(num_rows));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Digit-cap boundary for ARRAY ELEMENTS, mirroring the string-map boundary tests: exactly
+// `max_num_digits` renders, one more nullifies the whole row. Covers integers on both
+// classification arms (canonical/verbatim and leading-zero-stripped) and floats on both rendering
+// arms (plain and negative-with-stripped-zeros).
+TEST_F(FromJsonTest, RawMapArray_Reject_ElementDigitCapBoundary)
+{
+  auto const at_cap_int   = digits(max_num_digits);
+  auto const over_int     = digits(max_num_digits + 1);
+  auto const at_cap_float = huge_float(max_num_digits);
+  auto const over_float   = huge_float(max_num_digits + 1);
+  auto const input_col =
+    cudf::test::strings_column_wrapper{// Row 0: every arm exactly AT the cap -> all render.
+                                       R"({"k":[)" + at_cap_int + ",00" + at_cap_int + "," +
+                                         at_cap_float + ",-00" + at_cap_float + "]}",
+                                       // Rows 1-4: one digit OVER, one arm each -> whole row null.
+                                       R"({"k":[)" + over_int + "]}",
+                                       R"({"k":[00)" + over_int + "]}",
+                                       R"({"k":[)" + over_float + "]}",
+                                       R"({"k":[-00)" + over_float + "]}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({at_cap_int, at_cap_int, R"("Infinity")", R"("-Infinity")"})}}, {}, {}, {}, {}},
+    {true, false, false, false, false});
+  auto const result = raw_map_array(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  for (cudf::size_type row = 1; row < 5; ++row) {
+    SCOPED_TRACE(std::format("row={}", row));
+    EXPECT_TRUE(row_is_null(result->view(), row));
+  }
+}
+
+// A refused ELEMENT nullifies the whole row even when it sits among valid elements and valid keys,
+// and leaves neighbouring rows untouched. The nulled row has materialized pairs, so the outer list
+// would carry a non-empty null without the sanitation step -- `CUDF_TEST_EXPECT_COLUMNS_EQUAL`
+// compares offsets and would fail. A refused number sitting DIRECTLY as a value needs no case of
+// its own: it is already a hard type mismatch (see `RawMapArray_NonArrayValuesNullInnerList`).
+TEST_F(FromJsonTest, RawMapArray_Reject_ElementNullsWholeRow)
+{
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"ok":["a","b"]})", R"({"good":["x"],"bad":["1",)" + over + R"(,"3"]})", R"({"ok2":["c"]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"ok", arr({"a", "b"})}}, {}, {{"ok2", arr({"c"})}}}, {true, false, true});
+  auto const result = raw_map_array(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 1);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_FALSE(row_is_null(result->view(), 2));
 }
 
 // Whitespace around values: insignificant whitespace is not part of the element bytes. The

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -47,19 +47,21 @@ struct FromJsonTest : public cudf::test::BaseFixture {};
 namespace {
 
 // One (key, value) entry of a raw-map row, in the exact textual content the raw-map engine emits.
-// A string value (or key) is stored WITHOUT surrounding quotes and JSON-unescaped; every other
-// value kind carries its verbatim raw JSON bytes (see the RawMapOpt_* contract block below).
-using kv = std::pair<std::string, std::string>;
+// A string value (or key) is stored WITHOUT surrounding quotes and JSON-unescaped; a non-string
+// scalar carries its Spark-rendered text, while a nested object or array is still stored verbatim
+// (see the RawMapOpt_* contract block below). A `std::nullopt` value models a SQL NULL value slot:
+// a JSON `null` value keeps the pair but nulls the corresponding entry of the values child.
+using kv = std::pair<std::string, std::optional<std::string>>;
 
 // Build the expected `LIST<STRUCT<STRING,STRING>>` raw-map column directly from host data.
 //
 // `rows[r]` is the ordered list of (key, value) pairs that row `r` must contain (already in the
-// exact byte content the engine emits: keys and string values de-quoted and unescaped, every other
-// value kind its verbatim raw bytes). `row_valid[r] == false` makes row `r` a NULL list row
-// (its pairs, if any, are ignored and contribute nothing to the children). The keys child and
-// values child are flat STRING columns concatenated in row-major order; the structs child wraps
-// them; the list offsets are the running per-row pair counts of the valid rows; the row null mask
-// comes from `row_valid`.
+// exact byte content the engine emits). `row_valid[r] == false` makes row `r` a NULL list row (its
+// pairs, if any, are ignored and contribute nothing to the children). The keys child and values
+// child are flat STRING columns concatenated in row-major order; a `std::nullopt` value makes its
+// values-child entry null (the pair itself is kept). The structs child wraps them; the list
+// offsets are the running per-row pair counts of the valid rows; the row null mask comes from
+// `row_valid`.
 std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>> const& rows,
                                                     std::vector<bool> const& row_valid)
 {
@@ -69,7 +71,8 @@ std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>>
   auto const num_rows = rows.size();
 
   std::vector<std::string> flat_keys;
-  std::vector<std::string> flat_values;
+  std::vector<std::string> flat_values;  // Content (empty placeholder for a NULL value).
+  std::vector<bool> flat_value_valid;    // SQL-NULL value slots (a JSON `null` value) are false.
   std::vector<cudf::size_type> offsets{0};
   offsets.reserve(num_rows + 1);
 
@@ -79,15 +82,23 @@ std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>>
     if (row_valid[r]) {
       for (auto const& [k, v] : rows[r]) {
         flat_keys.push_back(k);
-        flat_values.push_back(v);
+        flat_values.push_back(v.value_or(""));
+        flat_value_valid.push_back(v.has_value());
         ++running;
       }
     }
     offsets.push_back(running);
   }
 
-  auto keys_child    = cudf::test::strings_column_wrapper(flat_keys.begin(), flat_keys.end());
-  auto values_child  = cudf::test::strings_column_wrapper(flat_values.begin(), flat_values.end());
+  auto keys_child = cudf::test::strings_column_wrapper(flat_keys.begin(), flat_keys.end());
+
+  bool const any_value_null = std::any_of(
+    flat_value_valid.begin(), flat_value_valid.end(), [](bool value) { return !value; });
+  auto values_child =
+    any_value_null ? cudf::test::strings_column_wrapper(
+                       flat_values.begin(), flat_values.end(), flat_value_valid.begin())
+                   : cudf::test::strings_column_wrapper(flat_values.begin(), flat_values.end());
+
   auto structs_child = cudf::test::structs_column_wrapper{{keys_child, values_child}}.release();
 
   auto offsets_col =
@@ -237,16 +248,21 @@ TEST_F(FromJsonTest, RawMapOpt_UnquotedControlCharactersStrict)
 
 // ===========================================================================
 // RawMapOpt_* : pin the exact LIST<STRUCT<STRING,STRING>> output of `from_json_to_raw_map`.
-// Value semantics (this layer renders string keys/values only; every other value kind is verbatim):
+// Value semantics match Spark's `from_json` StringType conversion (Jackson):
 //   * String VALUES/KEYS are emitted WITHOUT surrounding quotes and JSON-UNESCAPED (`\"` -> `"`,
 //     `\uXXXX` -> UTF-8, ...); escape-free strings are byte-identical to the raw extraction.
-//   * Every non-string value kind keeps its VERBATIM raw JSON bytes: a number (e.g. `1.00000`,
-//     `007`), a `NaN`/`Infinity` spelling, a nested object/array value, and the JSON `null` literal
-//     are all copied unchanged; `true`/`false` and already-canonical scalars are byte-identical.
+//   * Numbers are re-rendered: floats via Java `Double.toString`; integer leading zeros and `-0`
+//     are stripped; `NaN`/`Infinity` spellings become their QUOTED canonical forms.
+//   * A nested object/array value keeps its VERBATIM raw JSON bytes (copied unchanged).
+//   * A JSON `null` VALUE keeps the pair but nulls the values-child entry (SQL NULL).
+//   * `true`/`false` and already-canonical scalars are byte-identical to the input.
 //   * A populated object yields a non-null list of its (key, value) pairs in INPUT TEXTUAL order;
 //     a duplicate key is emitted once PER OCCURRENCE (no collapsing).
 //   * An empty object `{}` yields an EMPTY, NON-NULL list row.
 //   * A true-null / empty / whitespace-only / invalid row yields a NULL list row.
+//   * A value that is a number past the JSON parser's digit cap (`json_parser.cuh`'s
+//     `max_num_len`, counting digits only, after leading zeros) is a Spark BAD RECORD: the WHOLE
+//     row is nullified, integers and floats alike, even when its other pairs are fine.
 // ===========================================================================
 
 // Single key, single row.
@@ -406,17 +422,18 @@ void expect_raw_map_shape(cudf::column_view const& col, cudf::size_type num_rows
 
 }  // namespace
 
-// JSON `null` literal value `{"k":null}` -- this layer keeps the literal text "null" as the value
-// (the value node range is copied verbatim; SQL-NULL handling is a later layer). The whole row
-// stays valid.
+// JSON `null` literal value `{"k":null}` -- the pair is KEPT and its values-child entry is SQL
+// NULL, matching Spark (JacksonParser's map conversion nulls the value slot). The whole row stays
+// valid, and sibling pairs of the same row are unaffected.
 TEST_F(FromJsonTest, RawMapOpt_Char_NullLiteralValue)
 {
-  auto const input_col =
-    cudf::test::strings_column_wrapper{R"({"a":"x"})", R"({"k":null})", R"({"b":"y"})"};
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":"x"})", R"({"k":null})", R"({"b":"y"})", R"({"c":null,"d":"z"})"};
   auto const input = cudf::strings_column_view{input_col};
 
-  auto const expected =
-    make_expected_raw_map({{{"a", "x"}}, {{"k", "null"}}, {{"b", "y"}}}, all_valid(3));
+  auto const expected = make_expected_raw_map(
+    {{{"a", "x"}}, {{"k", std::nullopt}}, {{"b", "y"}}, {{"c", std::nullopt}, {"d", "z"}}},
+    all_valid(4));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
@@ -474,6 +491,247 @@ TEST_F(FromJsonTest, RawMapOpt_Render_KeyEscapes)
 
   auto const expected =
     make_expected_raw_map({{{"kéy", "v\tz"}, {"a\tb", "w"}, {"q\"r", "x"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Float values re-render via Java `Double.toString` semantics (exactly-parseable literals only:
+// the device float parse is not correctly-rounded for adversarial long mantissas).
+TEST_F(FromJsonTest, RawMapOpt_Render_FloatCanonical)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":1.00000,"b":1e2,"c":351.980,"d":1E308,"e":0.0003,"f":0.003})",
+    R"({"g":12345678900000000000.0,"h":-2.5,"i":-0.5,"j":-0.0})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"a", "1.0"},
+                            {"b", "100.0"},
+                            {"c", "351.98"},
+                            {"d", "1.0E308"},
+                            {"e", "3.0E-4"},
+                            {"f", "0.003"}},
+                           {{"g", "1.23456789E19"}, {"h", "-2.5"}, {"i", "-0.5"}, {"j", "-0.0"}}},
+                          all_valid(2));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Float overflow/underflow: out-of-range magnitudes parse to +/-Infinity (rendered QUOTED) or
+// +/-0.0, matching Java `Double.parseDouble` + `Double.toString`.
+TEST_F(FromJsonTest, RawMapOpt_Render_FloatOverflow)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":1e309,"b":-1e309,"c":1e-999,"d":-1e-999})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"a", R"("Infinity")"}, {"b", R"("-Infinity")"}, {"c", "0.0"}, {"d", "-0.0"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Integer leading zeros (`allow_leading_zeros`) and `-0` are stripped textually, so digit runs far
+// beyond int64 range keep every significant digit (matching Jackson's BigInteger re-render).
+TEST_F(FromJsonTest, RawMapOpt_Render_IntLeadingZeros)
+{
+  auto const huge_digits = std::string(26, '9');
+  auto const input_col   = cudf::test::strings_column_wrapper{
+    R"({"a":007,"b":-007,"c":-0,"d":0,"e":42})",
+    "{\"f\":00" + huge_digits + ",\"g\":0000000000000000000000000000007}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"a", "7"}, {"b", "-7"}, {"c", "0"}, {"d", "0"}, {"e", "42"}},
+                           {{"f", huge_digits}, {"g", "7"}}},
+                          all_valid(2));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Floats carrying leading zeros (`allow_leading_zeros`) re-render from the parsed value, including
+// a negative overflow whose sign must land INSIDE the quoted special form.
+TEST_F(FromJsonTest, RawMapOpt_Render_FloatLeadingZeros)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":007.5,"b":-007.5,"c":00.5,"d":-000e1,"e":-007e309})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"a", "7.5"}, {"b", "-7.5"}, {"c", "0.5"}, {"d", "-0.0"}, {"e", R"("-Infinity")"}}},
+    all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+namespace {
+
+// The JSON parser's number digit cap (`max_num_len` in `json_parser.cuh`, which also matches
+// Jackson's `StreamReadConstraints.DEFAULT_MAX_NUM_LEN`). A number is refused once its digit count
+// EXCEEDS this, so exactly this many digits is still accepted. Spelled out here rather than
+// included: `json_parser.cuh` is device-only, and an independent literal is what makes these tests
+// catch the classifier drifting away from the parser.
+constexpr int max_num_digits = 1000;
+
+// `n` copies of one digit -- the building block for a number with an exact digit count.
+std::string digits(int n, char d = '7') { return std::string(static_cast<std::size_t>(n), d); }
+
+// A float carrying exactly `n` counted digits: `n - 1` nines and a one-digit exponent. Its
+// magnitude overflows double by such a margin that it renders as the quoted `Infinity` special
+// whatever the mantissa rounds to, so the expectation does not depend on float parsing detail.
+std::string huge_float(int n) { return digits(n - 1, '9') + "e9"; }
+
+// True iff OUTPUT ROW `row` is a null list row. Asserts the OUTER row's validity specifically --
+// an empty or degenerate row is not a null row, and only slicing distinguishes them.
+bool row_is_null(cudf::column_view const& result, cudf::size_type row)
+{
+  return cudf::slice(result, {row, row + 1})[0].null_count() == 1;
+}
+
+}  // namespace
+
+// Digit-cap boundary for INTEGERS, on both classification arms: a canonical integer (verbatim, the
+// raw fast path) and one carrying leading zeros or a sign (textually stripped). Exactly
+// `max_num_digits` digits renders; one more makes the record a Spark bad record and nulls the whole
+// row. This boundary is what pins the classifier's digit count to the parser's own, so it must
+// break loudly if either side moves.
+TEST_F(FromJsonTest, RawMapOpt_Reject_IntDigitCapBoundary)
+{
+  auto const at_cap    = digits(max_num_digits);
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    // Row 0: every arm exactly AT the cap -> all render.
+    R"({"plain":)" + at_cap + R"(,"zeros":00)" + at_cap + R"(,"neg":-00)" + at_cap + "}",
+    // Rows 1-3: one digit OVER, one arm each -> whole row null.
+    R"({"plain":)" + over + "}",
+    R"({"zeros":00)" + over + "}",
+    R"({"neg":-00)" + over + "}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"plain", at_cap}, {"zeros", at_cap}, {"neg", "-" + at_cap}}, {}, {}, {}},
+    {true, false, false, false});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_TRUE(row_is_null(result->view(), 2));
+  EXPECT_TRUE(row_is_null(result->view(), 3));
+}
+
+// Digit-cap boundary for FLOATS, on both rendering arms of `render_normalized_float`: the plain arm
+// (no leading zeros, parsed whole) and the negative-with-stripped-zeros arm that renders the
+// positive value one byte in and re-applies the sign INSIDE the quoted special. The over-cap
+// negative case is the crash repro: the parser refuses it and writes nothing, which used to be read
+// back as a rendered byte and turned into a `memcpy` of length `0 - 1`.
+TEST_F(FromJsonTest, RawMapOpt_Reject_FloatDigitCapBoundary)
+{
+  auto const at_cap    = huge_float(max_num_digits);
+  auto const over      = huge_float(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    // Row 0: both arms exactly AT the cap -> both render as the quoted special.
+    R"({"plain":)" + at_cap + R"(,"negzeros":-00)" + at_cap + "}",
+    // Rows 1-2: one digit OVER, one arm each -> whole row null.
+    R"({"plain":)" + over + "}",
+    R"({"negzeros":-00)" + over + "}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"plain", R"("Infinity")"}, {"negzeros", R"("-Infinity")"}}, {}, {}}, {true, false, false});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_TRUE(row_is_null(result->view(), 2));
+}
+
+// Leading zeros are NOT counted toward the cap -- both the parser and Jackson skip them before
+// counting. These tokens are far longer than the cap in raw bytes yet carry only two counted
+// digits, so they must render normally. A digit count taken over the raw range would reject every
+// one of them.
+TEST_F(FromJsonTest, RawMapOpt_Reject_LeadingZerosNotCounted)
+{
+  auto const zeros = digits(max_num_digits + 5, '0');
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":)" + zeros + R"(.5,"b":-)" + zeros + R"(.5,"c":)" +
+                                       zeros + R"(7,"d":-)" + zeros + "7}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  // `a`/`b` keep one zero before the point (a zero is dropped only while another DIGIT follows);
+  // `c`/`d` strip the whole run down to the single significant digit.
+  auto const expected =
+    make_expected_raw_map({{{"a", "0.5"}, {"b", "-0.5"}, {"c", "7"}, {"d", "-7"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// A refused number nullifies its ENTIRE row, not merely its own value slot, and touches no other
+// row: the neighbours keep every pair. Also pins that a rejected value nulls the row even when the
+// object is otherwise well formed and its other pairs already rendered.
+TEST_F(FromJsonTest, RawMapOpt_Reject_NullsWholeRowNotJustValue)
+{
+  auto const over = digits(max_num_digits + 1);
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"a":"keep","b":1})",
+                                       R"({"a":"drop","b":)" + over + R"(,"c":"drop too"})",
+                                       R"({"a":"keep2"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"a", "keep"}, {"b", "1"}}, {}, {{"a", "keep2"}}}, {true, false, true});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 1);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_FALSE(row_is_null(result->view(), 2));
+}
+
+// Every value in the column renders zero bytes -- one refused number and one SQL NULL -- so the
+// VALUES extraction's total size is zero and `make_strings_children` skips its write pass entirely.
+// The reject must therefore already be settled at classification time: a signal raised only while
+// writing chars would never run here. The surviving `null` row keeps the case non-degenerate.
+TEST_F(FromJsonTest, RawMapOpt_Reject_ZeroTotalValueBytesSkipsWritePass)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"k":)" + digits(max_num_digits + 1) + "}", R"({"n":null})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{}, {{"n", std::nullopt}}}, {false, true});
+  auto const result   = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+  EXPECT_TRUE(row_is_null(result->view(), 0));
+  EXPECT_FALSE(row_is_null(result->view(), 1));
+}
+
+// A row nulled for a refused number is a well-formed object whose earlier pairs were already
+// materialized, so its outer list slot would be a NON-EMPTY null. The hand-assembled list must be
+// sanitized: `CUDF_TEST_EXPECT_COLUMNS_EQUAL` compares offsets, so an unpurged row fails here.
+TEST_F(FromJsonTest, RawMapOpt_Reject_AfterValidPairsPurgesNonEmptyNull)
+{
+  auto const over      = huge_float(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"p":"one","q":"two","r":"three","s":)" + over + "}", R"({"p":"kept"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{}, {{"p", "kept"}}}, {false, true});
+  auto const result   = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+  EXPECT_TRUE(row_is_null(result->view(), 0));
+}
+
+// All six tokenizer-accepted non-numeric spellings (`allow_nonnumeric_numbers`) render as their
+// QUOTED canonical forms, exactly as Jackson writes them with QUOTE_NON_NUMERIC_NUMBERS.
+TEST_F(FromJsonTest, RawMapOpt_Render_NonNumeric)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"a":NaN,"b":Infinity,"c":+INF,"d":+Infinity,"e":-INF,"f":-Infinity})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"a", R"("NaN")"},
+                                                {"b", R"("Infinity")"},
+                                                {"c", R"("Infinity")"},
+                                                {"d", R"("Infinity")"},
+                                                {"e", R"("-Infinity")"},
+                                                {"f", R"("-Infinity")"}}},
+                                              all_valid(1));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
@@ -573,20 +831,6 @@ TEST_F(FromJsonTest, RawMapOpt_Render_VerbatimScalarValues)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
-// Lenient number spellings keep their verbatim raw JSON bytes at this layer: `allow_leading_zeros`
-// keeps `007`, `allow_nonnumeric_numbers` keeps `NaN`/`Infinity`, and a non-canonical float is not
-// normalized. Number canonicalization arrives in a later layer, which must flip this expectation.
-TEST_F(FromJsonTest, RawMapOpt_Render_VerbatimLenientNumbers)
-{
-  auto const input_col =
-    cudf::test::strings_column_wrapper{R"({"a":007,"b":NaN,"c":Infinity,"d":1.00000})"};
-  auto const input = cudf::strings_column_view{input_col};
-
-  auto const expected = make_expected_raw_map(
-    {{{"a", "007"}, {"b", "NaN"}, {"c", "Infinity"}, {"d", "1.00000"}}}, all_valid(1));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
-}
-
 // Long ESCAPED value: `RawMapOpt_LongValues` covers the long escape-free (verbatim memcpy) path;
 // this covers the long unescape path, where `make_strings_children` re-parses the whole token once
 // per pass and the rendered length shrinks across hundreds of escapes.
@@ -603,6 +847,41 @@ TEST_F(FromJsonTest, RawMapOpt_Render_LongEscapedValue)
   auto const input     = cudf::strings_column_view{input_col};
 
   auto const expected = make_expected_raw_map({{{"k", unescaped}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// A nested object/array VALUE keeps its VERBATIM raw JSON bytes -- its inner escapes and spacing
+// are NOT re-rendered -- which is the one contract line above that no other test pins. The escaped
+// sibling value forces the values gate TRUE, so the nested bytes are materialized by the render
+// dispatch rather than the raw fast path, and over a range spanning many tokens rather than one.
+TEST_F(FromJsonTest, RawMapOpt_Render_NestedValuesVerbatim)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"o":{"a":"x\"y"},"l":[1,{"b":2},"s"],"e":"p\\q"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"o", R"({"a":"x\"y"})"}, {"l", R"([1,{"b":2},"s"])"}, {"e", R"(p\q)"}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Multi-block coverage for the render path: every other gate-flipping test is small enough to fit
+// one thread block, so the render dispatch, the zip compaction, and the device-scope sticky gate
+// flags have never run across blocks. Both gates are TRUE here -- the key carries an escape, and
+// the values span four render categories.
+TEST_F(FromJsonTest, RawMapOpt_Render_MultiBlockTransform)
+{
+  constexpr int num_rows = 50000;
+  std::vector<std::string> rows(static_cast<std::size_t>(num_rows),
+                                R"({"e\tk":"a\"b","f":1.50000,"z":007,"n":NaN})");
+  std::vector<std::vector<kv>> expected_rows(
+    static_cast<std::size_t>(num_rows),
+    {{"e\tk", R"(a"b)"}, {"f", "1.5"}, {"z", "7"}, {"n", R"("NaN")"}});
+
+  auto const input_col = cudf::test::strings_column_wrapper(rows.begin(), rows.end());
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(expected_rows, all_valid(num_rows));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
@@ -770,6 +1049,41 @@ TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryNullMask)
   }
 }
 
+// The VALUES-child null mask around 32-bit bitmask word boundaries. That mask is indexed by PAIR,
+// not by row, so a one-row column still drives it arbitrarily wide; every other null-value test
+// stays under a single word. The first and last pair of each size is a JSON `null`, so the boundary
+// word is written from both ends.
+TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryValueNullMask)
+{
+  for (int const num_pairs : {31, 32, 33, 65}) {
+    SCOPED_TRACE(std::format("num_pairs={}", num_pairs));
+
+    std::string row = "{";
+    std::vector<kv> expected_row;
+    expected_row.reserve(static_cast<std::size_t>(num_pairs));
+    for (int p = 0; p < num_pairs; ++p) {
+      bool const is_null    = p == 0 || p == num_pairs - 1;
+      auto const value_text = is_null ? std::string{"null"} : std::format(R"("v{}")", p);
+      if (p > 0) { row += ","; }
+      row += std::format(R"("k{}":{})", p, value_text);
+      expected_row.emplace_back(
+        std::format("k{}", p),
+        is_null ? std::optional<std::string>{} : std::optional<std::string>{std::format("v{}", p)});
+    }
+    row += "}";
+
+    auto const input_col = cudf::test::strings_column_wrapper{row};
+    auto const result    = raw_map(cudf::strings_column_view{input_col});
+    auto const expected  = make_expected_raw_map({expected_row}, all_valid(1));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+    auto const values =
+      cudf::structs_column_view{cudf::lists_column_view{result->view()}.child()}.child(1);
+    EXPECT_EQ(values.size(), num_pairs);
+    EXPECT_EQ(values.null_count(), 2);
+  }
+}
+
 // ===========================================================================
 // Array path: `from_json_to_raw_map_array_values` -> LIST<STRUCT<STRING, LIST<STRING>>>.
 // Each test asserts exact output via `make_expected_raw_map_array`. Element/value semantics:
@@ -778,9 +1092,13 @@ TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryNullMask)
 //   * value = JSON `null` literal -> row KEPT, NULL inner list (mask #1).
 //   * value = scalar / object (present, non-null, NOT an array) -> HARD TYPE MISMATCH: the WHOLE
 //     row is nullified (Spark row-level bad-record semantics), even if other keys are valid arrays.
-//   * element = string -> de-quoted and JSON-unescaped; every other element kind (number, bool,
-//     nested object/array) keeps its VERBATIM raw JSON bytes.
+//   * element = Spark-rendered like the string-map values: strings de-quoted and JSON-unescaped;
+//     numbers re-rendered (float canonical, leading-zero strip, quoted NaN/Infinity); nested
+//     object/array elements keep their VERBATIM raw JSON bytes; bools byte-identical.
 //   * element = literal `null` -> NULL element (mask #2); a JSON STRING "null" stays valid.
+//   * element = number past the JSON parser's digit cap -> Spark BAD RECORD: the WHOLE row is
+//     nullified, exactly as for a string-map value (a rejected number sitting directly as a value
+//     is already covered by the hard-type-mismatch rule above).
 // ===========================================================================
 
 namespace {
@@ -1009,6 +1327,17 @@ TEST_F(FromJsonTest, RawMapArray_MixedElementKinds)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
+// Already-canonical number / bool elements are byte-identical to their input text.
+TEST_F(FromJsonTest, RawMapArray_NumberBoolElements)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{R"({"k":[1,22,333,true,false]})"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map_array({{{"k", arr({"1", "22", "333", "true", "false"})}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
 // Null input row yields a NULL map row.
 TEST_F(FromJsonTest, RawMapArray_NullInputRow)
 {
@@ -1133,13 +1462,17 @@ TEST_F(FromJsonTest, RawMapArray_SingleQuoteNormalizationWithEscapes)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
 }
 
-// Leading-zeros / non-numeric-number leniency on numeric elements: both spellings keep their
-// verbatim raw JSON bytes at this layer. Number canonicalization arrives in a later layer, which
-// must flip this expectation.
+// Leading-zeros / non-numeric-number leniency on numeric elements: lenient numbers re-render like
+// the string-map values (leading zeros stripped, non-numeric spellings quoted canonical). All six
+// spellings the tokenizer accepts are pinned here, as on the map side. The zero-padded run is far
+// beyond int64 range, so it also pins that the element strip stays textual rather than going
+// through an integer parse.
 TEST_F(FromJsonTest, RawMapArray_NumericLeniency)
 {
-  auto const input_col = cudf::test::strings_column_wrapper{R"({"k":[007,NaN,Infinity]})"};
-  auto const input     = cudf::strings_column_view{input_col};
+  auto const huge_digits = std::string(26, '9');
+  auto const input_col   = cudf::test::strings_column_wrapper{
+    R"({"k":[007,NaN,Infinity,+INF,+Infinity,-INF,-Infinity,-0,00)" + huge_digits + "]}"};
+  auto const input = cudf::strings_column_view{input_col};
 
   auto const result = spark_rapids_jni::from_json_to_raw_map_array_values(
     input,
@@ -1148,9 +1481,34 @@ TEST_F(FromJsonTest, RawMapArray_NumericLeniency)
                                          /*allow_nonnumeric_numbers=*/true,
                                          default_options.allow_unquoted_control});
 
-  auto const expected =
-    make_expected_raw_map_array({{{"k", arr({"007", "NaN", "Infinity"})}}}, all_valid(1));
+  auto const expected = make_expected_raw_map_array({{{"k",
+                                                       arr({"7",
+                                                            R"("NaN")",
+                                                            R"("Infinity")",
+                                                            R"("Infinity")",
+                                                            R"("Infinity")",
+                                                            R"("-Infinity")",
+                                                            R"("-Infinity")",
+                                                            "0",
+                                                            huge_digits})}}},
+                                                    all_valid(1));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+}
+
+// Float elements re-render via Java `Double.toString` semantics; an overflow renders quoted. The
+// last three carry leading zeros (`allow_leading_zeros`), which the strict parser refuses, so they
+// are stripped and re-rendered from the parsed value -- and a NEGATIVE one has its sign re-applied
+// to that render, landing INSIDE the quote of a quoted special.
+TEST_F(FromJsonTest, RawMapArray_Render_FloatElements)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":[1.00000,1e2,-1e309,007.5,-007.5,-007e309]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({"1.0", "100.0", R"("-Infinity")", "7.5", "-7.5", R"("-Infinity")"})}}},
+    all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
 // All-canonical, escape-free column (clean strings/ints/bools, an empty array): every key/element
@@ -1193,6 +1551,63 @@ TEST_F(FromJsonTest, RawMapArray_Render_MultiBlockEscaped)
 
   auto const expected = make_expected_raw_map_array(expected_rows, all_valid(num_rows));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Digit-cap boundary for ARRAY ELEMENTS, mirroring the string-map boundary tests: exactly
+// `max_num_digits` renders, one more nullifies the whole row. Covers integers on both
+// classification arms (canonical/verbatim and leading-zero-stripped) and floats on both rendering
+// arms (plain and negative-with-stripped-zeros).
+TEST_F(FromJsonTest, RawMapArray_Reject_ElementDigitCapBoundary)
+{
+  auto const at_cap_int   = digits(max_num_digits);
+  auto const over_int     = digits(max_num_digits + 1);
+  auto const at_cap_float = huge_float(max_num_digits);
+  auto const over_float   = huge_float(max_num_digits + 1);
+  auto const input_col =
+    cudf::test::strings_column_wrapper{// Row 0: every arm exactly AT the cap -> all render.
+                                       R"({"k":[)" + at_cap_int + ",00" + at_cap_int + "," +
+                                         at_cap_float + ",-00" + at_cap_float + "]}",
+                                       // Rows 1-4: one digit OVER, one arm each -> whole row null.
+                                       R"({"k":[)" + over_int + "]}",
+                                       R"({"k":[00)" + over_int + "]}",
+                                       R"({"k":[)" + over_float + "]}",
+                                       R"({"k":[-00)" + over_float + "]}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({at_cap_int, at_cap_int, R"("Infinity")", R"("-Infinity")"})}}, {}, {}, {}, {}},
+    {true, false, false, false, false});
+  auto const result = raw_map_array(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  for (cudf::size_type row = 1; row < 5; ++row) {
+    SCOPED_TRACE(std::format("row={}", row));
+    EXPECT_TRUE(row_is_null(result->view(), row));
+  }
+}
+
+// A refused ELEMENT nullifies the whole row even when it sits among valid elements and valid keys,
+// and leaves neighbouring rows untouched. The nulled row has materialized pairs, so the outer list
+// would carry a non-empty null without the sanitation step -- `CUDF_TEST_EXPECT_COLUMNS_EQUAL`
+// compares offsets and would fail. A refused number sitting DIRECTLY as a value needs no case of
+// its own: it is already a hard type mismatch (see `RawMapArray_NonArrayValuesNullInnerList`).
+TEST_F(FromJsonTest, RawMapArray_Reject_ElementNullsWholeRow)
+{
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"ok":["a","b"]})", R"({"good":["x"],"bad":["1",)" + over + R"(,"3"]})", R"({"ok2":["c"]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"ok", arr({"a", "b"})}}, {}, {{"ok2", arr({"c"})}}}, {true, false, true});
+  auto const result = raw_map_array(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 1);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_FALSE(row_is_null(result->view(), 2));
 }
 
 // Whitespace around values: insignificant whitespace is not part of the element bytes. The

--- a/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
@@ -153,17 +153,19 @@ public class JSONUtils {
   }
 
   /**
-   * Extract key-value pairs for each output map from the given json strings, targeting the Spark
-   * schema {@code MapType[StringType, StringType]}. String keys and values are de-quoted and
-   * JSON-unescaped ({@code \"} -> {@code "}, <code>&#92;uXXXX</code> -> UTF-8, ...) to match
-   * Spark's `getText`; every other value kind (number, boolean, `NaN`/`Infinity` spelling, nested
-   * object/array, and the JSON `null` literal) keeps its verbatim raw JSON bytes.
+   * Extract key-value pairs for each output map from the given json strings. Keys and values are
+   * rendered to match Spark's `from_json` for the schema {@code MapType[StringType, StringType]}
+   * (Jackson semantics): string keys/values are de-quoted and JSON-unescaped; floats re-render via
+   * Java `Double.toString`; integer leading zeros and `-0` are stripped; the `NaN`/`Infinity`
+   * spellings become their quoted canonical forms; a nested object/array value keeps its verbatim
+   * raw JSON bytes. A JSON `null` value keeps its pair but nulls the corresponding entry of the
+   * values child.
    * <p/>
-   * This is the raw-map layer only, so the output is not yet byte-identical to Spark's `from_json`:
-   * Spark re-serializes a non-string value through a JSON generator while this function copies the
-   * input bytes unchanged (a number keeps its input spelling, e.g. {@code 1.00000}), and Spark maps
-   * a JSON {@code null} value to SQL NULL while this function emits the text {@code null}. Callers
-   * needing Spark-identical output must apply that normalization downstream.
+   * A row is nullified when the input row is null, empty, whitespace only, or not a valid JSON
+   * object, or when any of its values is a number the JSON parser refuses. The parser caps a
+   * number's digit count (signs, `.`, `e`/`E`, and leading zeros excluded) and applies that cap to
+   * integers and floats alike; a number past it makes the record a Spark bad record, so the whole
+   * row becomes null instead of that value rendering.
    *
    * @param input The input strings column in which each row specifies a json object
    * @param opts The options for parsing JSON strings
@@ -180,25 +182,24 @@ public class JSONUtils {
   }
 
   /**
-   * Extract key-value pairs for each output map from the given json strings. String keys, values,
-   * and elements are de-quoted and JSON-unescaped ({@code \"} -> {@code "}, <code>&#92;uXXXX</code>
-   * -> UTF-8, ...) to match Spark's `getText`; every other value or element kind (number, boolean,
-   * `NaN`/`Infinity` spelling, nested object/array) keeps its verbatim raw JSON bytes. The JSON
-   * {@code null} literal is verbatim only for {@link MapValueType#STRING}; under
-   * {@link MapValueType#ARRAY_OF_STRING} it becomes a null inner list (as a value) or a null
-   * element, as described below.
+   * Extract key-value pairs for each output map from the given json strings. Keys and values are
+   * rendered to match Spark's `from_json` StringType conversion (Jackson semantics): string
+   * keys/values/elements are de-quoted and JSON-unescaped; floats re-render via Java
+   * `Double.toString`; integer leading zeros and `-0` are stripped; the `NaN`/`Infinity` spellings
+   * become their quoted canonical forms; nested objects/arrays keep their verbatim raw JSON bytes.
    * <p/>
-   * This is the raw-map layer only, so the output is not yet byte-identical to Spark's `from_json`:
-   * Spark re-serializes a non-string value through a JSON generator while this function copies the
-   * input bytes unchanged (a number keeps its input spelling, e.g. {@code 1.00000}), and for
-   * {@link MapValueType#STRING} Spark maps a JSON {@code null} value to SQL NULL while this
-   * function emits the text {@code null}. Callers needing Spark-identical output must apply that
-   * normalization downstream.
+   * For BOTH value types, a row is nullified when the input row is null, empty, whitespace only, or
+   * not a valid JSON object, or when any number in it is one the JSON parser refuses. The parser
+   * caps a number's digit count (signs, `.`, `e`/`E`, and leading zeros excluded) and applies that
+   * cap to integers and floats alike; a number past it makes the record a Spark bad record, so the
+   * whole row becomes null instead of that number rendering -- as an array element just as much as
+   * a direct value. This is independent of the array-schema type-mismatch rule described below.
    * <p/>
    * The {@code valueType} parameter selects how each JSON value is interpreted and therefore the
    * shape of the output map column:<br>
    * - {@link MapValueType#STRING}: values are scalar strings, producing a column of type
-   *   {@code List<Struct<String,String>>}.<br>
+   *   {@code List<Struct<String,String>>}. A JSON {@code null} value keeps its pair but nulls the
+   *   corresponding entry of the values child.<br>
    * - {@link MapValueType#ARRAY_OF_STRING}: values are JSON arrays of strings, producing a column of
    *   type {@code List<Struct<String,List<String>>>} (targets Spark's `from_json` for the schema
    *   {@code MapType[StringType, ArrayType[StringType]]}).

--- a/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
@@ -175,11 +175,33 @@ public class FromJsonToRawMapTest {
     }
   }
 
+  // A JSON `null` VALUE keeps its pair and nulls the corresponding entry of the values child (SQL
+  // NULL), which is what the extractRawMapFromJsonString contract promises. Sibling pairs of the
+  // same row, and neighbouring rows, are unaffected.
+  @Test
+  void testFromJsonNullLiteralValue() {
+    try (ColumnVector input =
+             ColumnVector.fromStrings("{\"a\":null,\"b\":\"x\"}", null, "{\"c\":null}");
+         ColumnVector outputMap = JSONUtils.extractRawMapFromJsonString(input, getOptions());
+
+         ColumnVector expectedKeys = ColumnVector.fromStrings("a", "b", "c");
+         ColumnVector expectedValues = ColumnVector.fromStrings(null, "x", null);
+         ColumnVector expectedStructs = ColumnVector.makeStruct(expectedKeys, expectedValues);
+         ColumnVector expectedOffsets = ColumnVector.fromInts(0, 2, 2, 3);
+         ColumnVector tmpMap = expectedStructs.makeListFromOffsets(3, expectedOffsets);
+         ColumnVector templateBitmask = ColumnVector.fromBoxedInts(1, null, 1);
+         ColumnVector expectedMap = tmpMap.mergeAndSetValidity(BinaryOp.BITWISE_AND,
+             templateBitmask);
+    ) {
+      assertColumnsAreEqual(expectedMap, outputMap);
+    }
+  }
+
   // ===== MAP<STRING,ARRAY<STRING>> (array-valued map) =====
 
-  // ARRAY_OF_STRING: a single object whose one key maps to a two-element string array. The engine
-  // copies the elements verbatim with their surrounding quotes stripped, so {"k":["a","b"]} yields
-  // one non-null row holding the pair (k -> ["a", "b"]).
+  // ARRAY_OF_STRING: a single object whose one key maps to a two-element string array. Elements are
+  // de-quoted and JSON-unescaped; both elements here are escape-free, so {"k":["a","b"]} yields one
+  // non-null row holding the pair (k -> ["a", "b"]).
   @Test
   void testExtractRawMapArrayFromJsonString() {
     List<HostColumnVector.StructData> row0 =


### PR DESCRIPTION
Fix the `from_json` API for rendering numeric raw-map values the way Spark does — integers with leading zeros and `-0` normalized, floats in Java `Double.toString` form, and the non-numeric `NaN` and `Infinity` spellings quoted. This also turns a top-level JSON `null` map value into a SQL NULL value, keeping its pair, instead of the literal string `null`.

A number whose digit count exceeds the parser's cap now nullifies its whole row, matching Spark: it does length-checks both integer and floating-point tokens and throws while tokenizing in PERMISSIVE mode (which is the only mode our plugin supports).

Example for output of type `MAP<STRING,STRING>`:

| Input | GPU before (wrong) | GPU after (matches Spark) |
|---|---|---|
| `{"a":1.00000}` | `1.00000` | `1.0` |
| `{"b":1e2}` | `1e2` | `100.0` |
| `{"c":351.980}` | `351.980` | `351.98` |
| `{"e":0.0003}` | `0.0003` | `3.0E-4` |
| `{"g":12345678900000000000.0}` | `12345678900000000000.0` | `1.23456789E19` |
| `{"h":007}` | `007` | `7` |
| `{"i":-0}` | `-0` | `0` |
| `{"j":NaN}` | `NaN` | `"NaN"` — with the quotes |
| `{"m":+INF}` | `+INF` | `"Infinity"` |
| `{"k":null}` | the string `null`, a valid pair | a SQL NULL value, the pair kept |
| `{"k":<1001 digits>}` | the raw digits | the whole row is NULL |

Nested values are deliberately untouched here but will be fixed in the follow up PR.

Depends on `Unescape from_json raw-map string values and keys` and `Keep escape-free from_json raw-map columns on the raw copy path` — it extends the rendering category and dispatch the first introduces, and rewrites comment blocks that only exist once the second lands.

Partially contribute to https://github.com/NVIDIA/cudf-spark/issues/15240.

Depends on:
 * https://github.com/NVIDIA/cudf-spark-jni/pull/4948

### Performance

Ratio is this PR stacked on its parents, divided by the GPU time of unmodified `main` - above 1.00 is slower.

| Benchmark | Cells | Median | Best | Worst |
|---|---|---|---|---|
| `..._null_density` | 4 | 1.051x | 1.034x | 1.054x |
| `..._micro_size` | 4 | 1.046x | 1.001x | 1.077x |
| `..._key_name_len` | 3 | 1.044x | 1.033x | 1.062x |
| `..._value_width` | 4 | 1.039x | 0.921x | 1.427x |
| `..._row_shape` | 3 | 1.033x | 0.824x | 1.362x |
| `..._array_values_keys_per_row` | 3 | 1.032x | 1.028x | 1.034x |
| `from_json_to_raw_map` | 24 | 1.029x | 0.991x | 1.092x |
| `..._array_values` | 18 | 1.029x | 0.978x | 1.062x |
| `..._array_values_null_density` | 9 | 1.023x | 1.007x | 1.034x |
| `..._array_values_type_mismatch` | 3 | 1.023x | 1.022x | 1.031x |
| `..._array_values_key_name_len` | 3 | 1.015x | 1.008x | 1.018x |

**Overall: 78 cells, median 1.029x, best 0.824x, worst 1.427x slower.** 

Comparing with its parent PR, this PR is neutral: `1.000x` overall median, with no benchmark outside measurement noise.
