### PR TITLE
Re-serialize `from_json` raw-map nested values

### DIFF
--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -421,6 +421,7 @@ enum class token_category : int8_t {
   float_norm,       // float: parse and re-render via Java `Double.toString` semantics
   nonnumeric,       // NaN/Infinity spelling: fixed quoted canonical form
   rejected,         // number past the parser's digit cap: renders 0 bytes and nullifies its row
+  nested,           // object/array value or element: compact re-render from tokens
   null_value        // JSON `null` value in the string map: SQL NULL (empty span)
 };
 
@@ -731,10 +732,8 @@ __device__ token_category classify_value_bytes(char const* json,
 }
 
 // Rendering category of a selected node/element from its begin token and de-quoted byte range.
-// A string or key carrying a backslash escape needs JSON-unescaping, and a value's bytes decide
-// whether it needs number canonicalization or SQL NULL (`classify_value_bytes`); everything else --
-// an escape-free string/key, a bool, or a nested object/array -- is `verbatim` and copies its raw
-// byte range unchanged.
+// Escapes, nested values, and a value's own bytes each pick a renderer; an escape-free string or
+// key and a bool stay `verbatim`.
 __device__ inline token_category classify_token(char const* json,
                                                 PdaTokenT const token,
                                                 SymbolOffsetT const range_begin,
@@ -745,9 +744,35 @@ __device__ inline token_category classify_token(char const* json,
     case token_t::FieldNameBegin:
       return contains_backslash(json, range_begin, range_end) ? token_category::string_unescape
                                                               : token_category::verbatim;
+    case token_t::StructBegin:
+    case token_t::ListBegin: return token_category::nested;
     case token_t::ValueBegin: return classify_value_bytes(json, range_begin, range_end);
     default: return token_category::verbatim;
   }
+}
+
+// Does this nested value hold a number the parser refuses? Jackson throws while tokenizing such a
+// number at any depth, so one buried in a nested value makes the record a Spark bad record exactly
+// as a top-level value does. Walks the same token subrange `render_nested` renders, keeping the
+// nesting balance the same way, and stops at the first offender.
+__device__ inline bool nested_has_rejected_scalar(
+  cudf::device_span<PdaTokenT const> tokens,
+  cudf::device_span<SymbolOffsetT const> token_positions,
+  char const* json,
+  NodeIndexT const begin_token_idx)
+{
+  int32_t depth = 0;
+  for (auto i = begin_token_idx; i < static_cast<NodeIndexT>(tokens.size()); ++i) {
+    depth += nested_node_to_value(tokens[i]);
+    // The partner `ValueEnd` position is one past the scalar's last byte, as in `render_nested`.
+    if (tokens[i] == token_t::ValueBegin &&
+        classify_value_bytes(json, token_positions[i], token_positions[i + 1]) ==
+          token_category::rejected) {
+      return true;
+    }
+    if (depth == 0) { break; }  // the matching close was just consumed
+  }
+  return false;
 }
 
 // The two-pass write convention shared by all renderers below (and `make_strings_children`):
@@ -844,6 +869,104 @@ __device__ cudf::size_type render_nonnumeric(char const* json, SymbolOffsetT con
   return ftos_converter::double_normalization(value, out);
 }
 
+// Render one scalar (`ValueBegin` text) inside a nested value: lenient ints/floats/non-numerics
+// re-render; `true`/`false` and a nested `null` stay their literal bytes (Jackson keeps a nested
+// `null` literal -- only a top-level map value `null` becomes a SQL NULL).
+__device__ cudf::size_type render_scalar(char const* json,
+                                         SymbolOffsetT const begin,
+                                         SymbolOffsetT const end,
+                                         char* out)
+{
+  switch (classify_value_bytes(json, begin, end)) {
+    case token_category::int_strip: return render_stripped_int(json, begin, end, out);
+    case token_category::float_norm: return render_normalized_float(json, begin, end, out);
+    case token_category::nonnumeric: return render_nonnumeric(json, begin, out);
+    default: {
+      auto const size = static_cast<cudf::size_type>(end - begin);
+      if (out != nullptr) { memcpy(out, json + begin, size); }
+      return size;
+    }
+  }
+}
+
+// Compact re-render of a nested (object/array) node from its token subrange, matching Jackson's
+// `copyCurrentStructure`: structural bytes come from the tokens (whitespace vanishes by
+// construction), keys and inner strings are re-escaped, scalars re-rendered via `render_scalar`.
+// Walking the lenient libcudf token stream makes lenient scalars correct by construction and
+// imposes no nesting-depth limit (the per-string re-parses are flat root scalars). Begin/end
+// token pairs of terminal tokens are adjacent in the stream, so `i + 1` addresses each partner.
+__device__ cudf::size_type render_nested(cudf::device_span<PdaTokenT const> tokens,
+                                         cudf::device_span<SymbolOffsetT const> token_positions,
+                                         char const* json,
+                                         NodeIndexT const begin_token_idx,
+                                         char* out)
+{
+  cudf::size_type size = 0;
+  auto const emit      = [&](char const c) {
+    if (out != nullptr) { out[size] = c; }
+    ++size;
+  };
+  // Write a quoted key or string value re-escaped, via a root-scalar parse of its quoted bytes.
+  auto const emit_escaped_string = [&](SymbolOffsetT const quoted_begin,
+                                       SymbolOffsetT const quoted_end) {
+    json_parser parser(
+      char_range(json + quoted_begin, static_cast<cudf::size_type>(quoted_end - quoted_begin)));
+    parser.next_token();
+    size += parser.write_escaped_text(out != nullptr ? out + size : nullptr);
+  };
+
+  // A just-closed value makes a following sibling need a ',' separator.
+  bool prev_closed_value = false;
+  // The render loop keeps the nesting balance itself rather than paying a separate matching-close
+  // pre-scan, which would double the token walk in each of the two passes. The first token is
+  // always an open (only `StructBegin`/`ListBegin` classify `nested`) and every partner token the
+  // loop skips has weight 0, so the balance reaches 0 exactly at the matching close. An unbalanced
+  // stream cannot occur in a validated one; if it did, both passes would render the same partial
+  // text, so their sizes still agree.
+  int32_t depth = 0;
+  for (auto i = begin_token_idx; i < static_cast<NodeIndexT>(tokens.size()); ++i) {
+    depth += nested_node_to_value(tokens[i]);
+    switch (tokens[i]) {
+      case token_t::StructBegin:
+      case token_t::ListBegin:
+        if (prev_closed_value) { emit(','); }
+        emit(tokens[i] == token_t::StructBegin ? '{' : '[');
+        prev_closed_value = false;
+        break;
+      case token_t::StructEnd:
+      case token_t::ListEnd:
+        emit(tokens[i] == token_t::StructEnd ? '}' : ']');
+        prev_closed_value = true;
+        break;
+      case token_t::FieldNameBegin:
+        if (prev_closed_value) { emit(','); }
+        // Quoted key = [pos, partner pos + 1); the partner `FieldNameEnd` sits on the close quote.
+        emit_escaped_string(token_positions[i], token_positions[i + 1] + 1);
+        emit(':');
+        prev_closed_value = false;
+        ++i;  // skip the FieldNameEnd partner
+        break;
+      case token_t::StringBegin:
+        if (prev_closed_value) { emit(','); }
+        emit_escaped_string(token_positions[i], token_positions[i + 1] + 1);
+        prev_closed_value = true;
+        ++i;  // skip the StringEnd partner
+        break;
+      case token_t::ValueBegin:
+        if (prev_closed_value) { emit(','); }
+        // The partner `ValueEnd` position is one past the scalar's last byte.
+        size += render_scalar(
+          json, token_positions[i], token_positions[i + 1], out != nullptr ? out + size : nullptr);
+        prev_closed_value = true;
+        ++i;  // skip the ValueEnd partner
+        break;
+      default: break;  // StructMemberBegin/StructMemberEnd contribute no bytes
+    }
+    if (depth == 0) { break; }  // the matching close was just emitted
+  }
+  return size;
+}
+
 // Convert token positions to node ranges and rendering categories for each valid node, fused in
 // one pass (the category classification reads the same token and, for strings/scalars, scans the
 // just-computed byte range). Unselected nodes stay `{0, 0}`/`verbatim` and are never scanned.
@@ -853,6 +976,10 @@ struct node_classify_fn {
   cudf::device_span<SymbolOffsetT const> token_positions;
   cudf::device_span<NodeIndexT const> node_token_ids;
   cudf::device_span<node_kind const> key_or_value;
+  // Only the map path folds a value node's category into the row-null decision. The array path
+  // reads these categories for keys alone and catches a refused number through its own element
+  // classifier, so walking every array value's subtree there would be pure waste.
+  bool classify_nested_reject;
 
   cuda::std::pair<SymbolOffsetT, SymbolOffsetT>* node_ranges;
   token_category* node_categories;
@@ -883,6 +1010,13 @@ struct node_classify_fn {
 
       range    = compute_token_range(tokens, token_positions, token_idx, include_quote_char);
       category = classify_token(input_json.data(), tokens[token_idx], range.first, range.second);
+      // A refused number anywhere inside a nested value nullifies the row just as a top-level one
+      // does, so on the map path the nested node inherits `rejected` and the shared sink does the
+      // rest.
+      if (classify_nested_reject && category == token_category::nested &&
+          nested_has_rejected_scalar(tokens, token_positions, input_json.data(), token_idx)) {
+        category = token_category::rejected;
+      }
     }
     node_ranges[node_id]     = range;
     node_categories[node_id] = category;
@@ -901,6 +1035,7 @@ classified_nodes compute_node_ranges_and_categories(
   cudf::device_span<SymbolOffsetT const> token_positions,
   cudf::device_span<NodeIndexT const> node_token_ids,
   cudf::device_span<node_kind const> key_or_value,
+  bool classify_nested_reject,
   rmm::cuda_stream_view stream)
 {
   auto const num_nodes = node_token_ids.size();
@@ -916,6 +1051,7 @@ classified_nodes compute_node_ranges_and_categories(
                                     token_positions,
                                     node_token_ids,
                                     key_or_value,
+                                    classify_nested_reject,
                                     node_ranges.begin(),
                                     node_categories.begin()});
 
@@ -956,8 +1092,11 @@ struct substring_fn {
 // the caller from the same categories).
 struct transform_fn {
   cudf::device_span<char const> d_string;
+  cudf::device_span<PdaTokenT const> tokens;
+  cudf::device_span<SymbolOffsetT const> token_positions;
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
   cudf::device_span<token_category const> d_categories;
+  cudf::device_span<NodeIndexT const> d_token_ids;
 
   cudf::size_type* d_sizes;
   char* d_chars;
@@ -988,6 +1127,9 @@ struct transform_fn {
       // The parser refuses this number, so the whole row is nullified: write nothing, in BOTH
       // passes, and never invoke the parser on bytes it already rejected.
       case token_category::rejected: break;
+      case token_category::nested:
+        size = render_nested(tokens, token_positions, json, d_token_ids[idx], out);
+        break;
       case token_category::null_value: break;  // SQL NULL: empty span, write nothing
     }
     if (out == nullptr) { d_sizes[idx] = size; }
@@ -1080,14 +1222,17 @@ conversion_gates compute_transform_gates(extraction_spec first,
 // selected node classified `verbatim` (`needs_transform == false`, precomputed by
 // `compute_transform_gates` and carried on the extraction itself), the extraction is exactly the
 // raw byte-range gather; otherwise the compaction additionally carries each node's category and
-// materializes through `transform_fn`. `attach_null_value_mask` turns each `null_value` slot into a
-// null entry of the returned strings column (the compacted categories provide the validity); the
-// caller passes it for the string-map VALUES extraction, and only when the gate pass actually found
-// such a value -- an all-valid mask would cost an allocation, a pass, and a `bools_to_mask` only to
-// be discarded.
+// token id and materializes through `transform_fn`. `attach_null_value_mask` turns each
+// `null_value` slot into a null entry of the returned strings column (the compacted categories
+// provide the validity); the caller passes it for the string-map VALUES extraction, and only when
+// the gate pass actually found such a value -- an all-valid mask would cost an allocation, a pass,
+// and a `bools_to_mask` only to be discarded.
 std::unique_ptr<cudf::column> extract_keys_or_values(
   gated_extraction const& extraction,
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> node_ranges,
+  cudf::device_span<NodeIndexT const> node_token_ids,
+  cudf::device_span<PdaTokenT const> tokens,
+  cudf::device_span<SymbolOffsetT const> token_positions,
   cudf::device_span<char const> input_json,
   bool attach_null_value_mask,
   rmm::cuda_stream_view stream,
@@ -1125,15 +1270,17 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
       num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
   }
 
-  // Transform path: compact (range, category) with the same stencil in one pass, then
+  // Transform path: compact (range, category, token id) with the same stencil in one pass, then
   // materialize through the category dispatch.
   auto const num_nodes = node_ranges.size();
   auto extracted_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
   auto extracted_categories = rmm::device_uvector<token_category>(num_nodes, stream);
-  auto const zip_in = thrust::make_zip_iterator(node_ranges.begin(), spec.categories.begin());
-  auto const zip_out =
-    thrust::make_zip_iterator(extracted_ranges.begin(), extracted_categories.begin());
+  auto extracted_token_ids  = rmm::device_uvector<NodeIndexT>(num_nodes, stream);
+  auto const zip_in =
+    thrust::make_zip_iterator(node_ranges.begin(), spec.categories.begin(), node_token_ids.begin());
+  auto const zip_out = thrust::make_zip_iterator(
+    extracted_ranges.begin(), extracted_categories.begin(), extracted_token_ids.begin());
   auto const zip_end     = copy_if(zip_in,
                                zip_in + num_nodes,
                                thrust::make_counting_iterator(0),
@@ -1143,8 +1290,16 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
   auto const num_extract = static_cast<cudf::size_type>(zip_end - zip_out);
   if (num_extract == 0) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}); }
 
-  auto [offsets, chars] = cudf::strings::detail::make_strings_children(
-    transform_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
+  auto [offsets, chars] =
+    cudf::strings::detail::make_strings_children(transform_fn{input_json,
+                                                              tokens,
+                                                              token_positions,
+                                                              extracted_ranges,
+                                                              extracted_categories,
+                                                              extracted_token_ids},
+                                                 num_extract,
+                                                 stream,
+                                                 mr);
   auto output = cudf::make_strings_column(
     num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
 
@@ -1423,6 +1578,11 @@ struct element_classify_fn {
         range = {range_begin, range_begin};
       } else {
         category = classify_token(input_json.data(), token, range_begin, range_end);
+        // Same sink as the value path: a refused number inside a nested ELEMENT nullifies its row.
+        if (category == token_category::nested &&
+            nested_has_rejected_scalar(tokens, token_positions, input_json.data(), token_idx)) {
+          category = token_category::rejected;
+        }
       }
     }
 
@@ -1458,8 +1618,13 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
 
   // Compute the byte range and rendering category for each node. The ranges identify positions to
   // extract nodes from the unified json string; the categories drive the Spark-render dispatch.
-  auto const classified = compute_node_ranges_and_categories(
-    preprocessed_input, tokens, token_positions, node_token_ids, is_key_or_value_node, stream);
+  auto const classified       = compute_node_ranges_and_categories(preprocessed_input,
+                                                             tokens,
+                                                             token_positions,
+                                                             node_token_ids,
+                                                             is_key_or_value_node,
+                                                             /*classify_nested_reject=*/true,
+                                                             stream);
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
@@ -1470,13 +1635,27 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
                             {node_kind::value, is_key_or_value_node, node_categories},
                             stream);
 
-  auto extracted_keys = extract_keys_or_values(
-    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  auto extracted_keys = extract_keys_or_values(keys,
+                                               node_ranges,
+                                               node_token_ids,
+                                               tokens,
+                                               token_positions,
+                                               preprocessed_input,
+                                               /*attach_null_value_mask=*/false,
+                                               stream,
+                                               mr);
   // A JSON `null` VALUE keeps its pair but nulls the values-child entry (SQL NULL), so the values
   // extraction attaches the null mask derived from its `null_value` categories -- only when the
   // gate pass saw such a value, since otherwise the mask would be all-valid and thrown away.
-  auto extracted_values = extract_keys_or_values(
-    values, node_ranges, preprocessed_input, values_have_null_value, stream, mr);
+  auto extracted_values = extract_keys_or_values(values,
+                                                 node_ranges,
+                                                 node_token_ids,
+                                                 tokens,
+                                                 token_positions,
+                                                 preprocessed_input,
+                                                 values_have_null_value,
+                                                 stream,
+                                                 mr);
   CUDF_EXPECTS(extracted_keys->size() == extracted_values->size(),
                "Invalid key-value pair extraction.");
 
@@ -1598,9 +1777,16 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   auto const& is_key_or_value_node = tok.is_key_or_value_node;
 
   // Keys use the shared node-range/category computation; element ranges and categories come from
-  // the fused classifier below.
-  auto const classified = compute_node_ranges_and_categories(
-    preprocessed_input, tokens, token_positions, node_token_ids, is_key_or_value_node, stream);
+  // the fused classifier below. Value nodes need no nested-reject walk here: a refused number
+  // inside an array element is caught by `element_classify_fn`, and one that IS the value makes it
+  // a non-array, which the type-mismatch rule below already nullifies.
+  auto const classified       = compute_node_ranges_and_categories(preprocessed_input,
+                                                             tokens,
+                                                             token_positions,
+                                                             node_token_ids,
+                                                             is_key_or_value_node,
+                                                             /*classify_nested_reject=*/false,
+                                                             stream);
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
@@ -1640,12 +1826,26 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   // element validity source.
   CUDF_EXPECTS(!elements_have_null_value, "Unexpected null-value category on the element path.");
 
-  auto extracted_keys = extract_keys_or_values(
-    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  auto extracted_keys = extract_keys_or_values(keys,
+                                               node_ranges,
+                                               node_token_ids,
+                                               tokens,
+                                               token_positions,
+                                               preprocessed_input,
+                                               /*attach_null_value_mask=*/false,
+                                               stream,
+                                               mr);
 
   // Extract element strings with the shared extractor (a 0-null STRING column); attach mask #2.
-  auto extracted_elements = extract_keys_or_values(
-    elements, element_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  auto extracted_elements = extract_keys_or_values(elements,
+                                                   element_ranges,
+                                                   node_token_ids,
+                                                   tokens,
+                                                   token_positions,
+                                                   preprocessed_input,
+                                                   /*attach_null_value_mask=*/false,
+                                                   stream,
+                                                   mr);
   {
     // Mask #2 over only the selected (element-flagged) nodes, in element document order, matching
     // the order `extract_keys_or_values` emits.

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -424,6 +424,7 @@ enum class token_category : int8_t {
   float_norm,       // float: parse and re-render via Java `Double.toString` semantics
   nonnumeric,       // NaN/Infinity spelling: fixed quoted canonical form
   rejected,         // number past the parser's digit cap: renders 0 bytes and nullifies its row
+  nested,           // object/array value or element: compact re-render from tokens
   null_value        // JSON `null` value in the string map: SQL NULL (empty span)
 };
 
@@ -740,10 +741,10 @@ __device__ token_category classify_value_bytes(char const* json,
 }
 
 // Rendering category of a selected node/element from its begin token and de-quoted byte range.
-// A string or key carrying a backslash escape needs JSON-unescaping, and a value's bytes decide
-// whether it needs number canonicalization or SQL NULL (`classify_value_bytes`); everything else --
-// an escape-free string/key, a bool, or a nested object/array -- is `verbatim` and copies its raw
-// byte range unchanged.
+// A string or key carrying a backslash escape needs JSON-unescaping, a nested object/array needs a
+// compact re-render, and a value's bytes decide whether it needs number canonicalization or SQL
+// NULL (`classify_value_bytes`); an escape-free string/key and a bool are `verbatim` and copy their
+// raw byte range unchanged.
 __device__ inline token_category classify_token(char const* json,
                                                 PdaTokenT const token,
                                                 SymbolOffsetT const range_begin,
@@ -754,9 +755,35 @@ __device__ inline token_category classify_token(char const* json,
     case token_t::FieldNameBegin:
       return contains_backslash(json, range_begin, range_end) ? token_category::string_unescape
                                                               : token_category::verbatim;
+    case token_t::StructBegin:
+    case token_t::ListBegin: return token_category::nested;
     case token_t::ValueBegin: return classify_value_bytes(json, range_begin, range_end);
     default: return token_category::verbatim;
   }
+}
+
+// Does this nested value hold a number the parser refuses? Jackson throws while tokenizing such a
+// number at any depth, so one buried in a nested value makes the record a Spark bad record exactly
+// as a top-level value does. Walks the same token subrange `render_nested` renders, keeping the
+// nesting balance the same way, and stops at the first offender.
+__device__ inline bool nested_has_rejected_scalar(
+  cudf::device_span<PdaTokenT const> tokens,
+  cudf::device_span<SymbolOffsetT const> token_positions,
+  char const* json,
+  NodeIndexT const begin_token_idx)
+{
+  int32_t depth = 0;
+  for (auto i = begin_token_idx; i < static_cast<NodeIndexT>(tokens.size()); ++i) {
+    depth += nested_node_to_value(tokens[i]);
+    // The partner `ValueEnd` position is one past the scalar's last byte, as in `render_nested`.
+    if (tokens[i] == token_t::ValueBegin &&
+        classify_value_bytes(json, token_positions[i], token_positions[i + 1]) ==
+          token_category::rejected) {
+      return true;
+    }
+    if (depth == 0) { break; }  // the matching close was just consumed
+  }
+  return false;
 }
 
 // The two-pass write convention shared by all renderers below (and `make_strings_children`):
@@ -854,6 +881,104 @@ __device__ cudf::size_type render_nonnumeric(char const* json, SymbolOffsetT con
   return ftos_converter::double_normalization(value, out);
 }
 
+// Render one scalar (`ValueBegin` text) inside a nested value: lenient ints/floats/non-numerics
+// re-render; `true`/`false` and a nested `null` stay their literal bytes (Jackson keeps a nested
+// `null` literal -- only a top-level map value `null` becomes a SQL NULL).
+__device__ cudf::size_type render_scalar(char const* json,
+                                         SymbolOffsetT const begin,
+                                         SymbolOffsetT const end,
+                                         char* out)
+{
+  switch (classify_value_bytes(json, begin, end)) {
+    case token_category::int_strip: return render_stripped_int(json, begin, end, out);
+    case token_category::float_norm: return render_normalized_float(json, begin, end, out);
+    case token_category::nonnumeric: return render_nonnumeric(json, begin, out);
+    default: {
+      auto const size = static_cast<cudf::size_type>(end - begin);
+      if (out != nullptr) { memcpy(out, json + begin, size); }
+      return size;
+    }
+  }
+}
+
+// Compact re-render of a nested (object/array) node from its token subrange, matching Jackson's
+// `copyCurrentStructure`: structural bytes come from the tokens (whitespace vanishes by
+// construction), keys and inner strings are re-escaped, scalars re-rendered via `render_scalar`.
+// Walking the lenient libcudf token stream makes lenient scalars correct by construction and
+// imposes no nesting-depth limit (the per-string re-parses are flat root scalars). Begin/end
+// token pairs of terminal tokens are adjacent in the stream, so `i + 1` addresses each partner.
+__device__ cudf::size_type render_nested(cudf::device_span<PdaTokenT const> tokens,
+                                         cudf::device_span<SymbolOffsetT const> token_positions,
+                                         char const* json,
+                                         NodeIndexT const begin_token_idx,
+                                         char* out)
+{
+  cudf::size_type size = 0;
+  auto const emit      = [&](char const c) {
+    if (out != nullptr) { out[size] = c; }
+    ++size;
+  };
+  // Write a quoted key or string value re-escaped, via a root-scalar parse of its quoted bytes.
+  auto const emit_escaped_string = [&](SymbolOffsetT const quoted_begin,
+                                       SymbolOffsetT const quoted_end) {
+    json_parser parser(
+      char_range(json + quoted_begin, static_cast<cudf::size_type>(quoted_end - quoted_begin)));
+    parser.next_token();
+    size += parser.write_escaped_text(out != nullptr ? out + size : nullptr);
+  };
+
+  // A just-closed value makes a following sibling need a ',' separator.
+  bool prev_closed_value = false;
+  // The render loop keeps the nesting balance itself rather than paying a separate matching-close
+  // pre-scan, which would double the token walk in each of the two passes. The first token is
+  // always an open (only `StructBegin`/`ListBegin` classify `nested`) and every partner token the
+  // loop skips has weight 0, so the balance reaches 0 exactly at the matching close. An unbalanced
+  // stream cannot occur in a validated one; if it did, both passes would render the same partial
+  // text, so their sizes still agree.
+  int32_t depth = 0;
+  for (auto i = begin_token_idx; i < static_cast<NodeIndexT>(tokens.size()); ++i) {
+    depth += nested_node_to_value(tokens[i]);
+    switch (tokens[i]) {
+      case token_t::StructBegin:
+      case token_t::ListBegin:
+        if (prev_closed_value) { emit(','); }
+        emit(tokens[i] == token_t::StructBegin ? '{' : '[');
+        prev_closed_value = false;
+        break;
+      case token_t::StructEnd:
+      case token_t::ListEnd:
+        emit(tokens[i] == token_t::StructEnd ? '}' : ']');
+        prev_closed_value = true;
+        break;
+      case token_t::FieldNameBegin:
+        if (prev_closed_value) { emit(','); }
+        // Quoted key = [pos, partner pos + 1); the partner `FieldNameEnd` sits on the close quote.
+        emit_escaped_string(token_positions[i], token_positions[i + 1] + 1);
+        emit(':');
+        prev_closed_value = false;
+        ++i;  // skip the FieldNameEnd partner
+        break;
+      case token_t::StringBegin:
+        if (prev_closed_value) { emit(','); }
+        emit_escaped_string(token_positions[i], token_positions[i + 1] + 1);
+        prev_closed_value = true;
+        ++i;  // skip the StringEnd partner
+        break;
+      case token_t::ValueBegin:
+        if (prev_closed_value) { emit(','); }
+        // The partner `ValueEnd` position is one past the scalar's last byte.
+        size += render_scalar(
+          json, token_positions[i], token_positions[i + 1], out != nullptr ? out + size : nullptr);
+        prev_closed_value = true;
+        ++i;  // skip the ValueEnd partner
+        break;
+      default: break;  // StructMemberBegin/StructMemberEnd contribute no bytes
+    }
+    if (depth == 0) { break; }  // the matching close was just emitted
+  }
+  return size;
+}
+
 // Convert token positions to node ranges and rendering categories for each valid node, fused in
 // one pass (the category classification reads the same token and, for strings/scalars, scans the
 // just-computed byte range). Unselected nodes stay `{0, 0}`/`verbatim` and are never scanned.
@@ -863,6 +988,10 @@ struct node_classify_fn {
   cudf::device_span<SymbolOffsetT const> token_positions;
   cudf::device_span<NodeIndexT const> node_token_ids;
   cudf::device_span<node_kind const> key_or_value;
+  // Only the map path folds a value node's category into the row-null decision. The array path
+  // reads these categories for keys alone and catches a refused number through its own element
+  // classifier, so walking every array value's subtree there would be pure waste.
+  bool classify_nested_reject;
 
   // Outputs.
   cuda::std::pair<SymbolOffsetT, SymbolOffsetT>* node_ranges;
@@ -895,6 +1024,13 @@ struct node_classify_fn {
 
       range    = compute_token_range(tokens, token_positions, token_idx, include_quote_char);
       category = classify_token(input_json.data(), tokens[token_idx], range.first, range.second);
+      // A refused number anywhere inside a nested value nullifies the row just as a top-level one
+      // does, so on the map path the nested node inherits `rejected` and the shared sink does the
+      // rest.
+      if (classify_nested_reject && category == token_category::nested &&
+          nested_has_rejected_scalar(tokens, token_positions, input_json.data(), token_idx)) {
+        category = token_category::rejected;
+      }
     }
     node_ranges[node_id]     = range;
     node_categories[node_id] = category;
@@ -916,6 +1052,7 @@ classified_nodes compute_node_ranges_and_categories(
   cudf::device_span<SymbolOffsetT const> token_positions,
   cudf::device_span<NodeIndexT const> node_token_ids,
   cudf::device_span<node_kind const> key_or_value,
+  bool classify_nested_reject,
   rmm::cuda_stream_view stream)
 {
   auto const num_nodes = node_token_ids.size();
@@ -931,6 +1068,7 @@ classified_nodes compute_node_ranges_and_categories(
                                     token_positions,
                                     node_token_ids,
                                     key_or_value,
+                                    classify_nested_reject,
                                     node_ranges.begin(),
                                     node_categories.begin()});
 
@@ -971,8 +1109,11 @@ struct substring_fn {
 // the caller from the same categories).
 struct transform_fn {
   cudf::device_span<char const> d_string;
+  cudf::device_span<PdaTokenT const> tokens;
+  cudf::device_span<SymbolOffsetT const> token_positions;
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> d_ranges;
   cudf::device_span<token_category const> d_categories;
+  cudf::device_span<NodeIndexT const> d_token_ids;
 
   cudf::size_type* d_sizes;
   char* d_chars;
@@ -1003,6 +1144,9 @@ struct transform_fn {
       // The parser refuses this number, so the whole row is nullified: write nothing, in BOTH
       // passes, and never invoke the parser on bytes it already rejected.
       case token_category::rejected: break;
+      case token_category::nested:
+        size = render_nested(tokens, token_positions, json, d_token_ids[idx], out);
+        break;
       case token_category::null_value: break;  // SQL NULL: empty span, write nothing
     }
     if (out == nullptr) { d_sizes[idx] = size; }
@@ -1097,14 +1241,17 @@ conversion_gates compute_transform_gates(extraction_spec first,
 // selected node classified `verbatim` (`needs_transform == false`, precomputed by
 // `compute_transform_gates` and carried on the extraction itself), the extraction is exactly the
 // raw byte-range gather; otherwise the compaction additionally carries each node's category and
-// materializes through `transform_fn`. `attach_null_value_mask` turns each `null_value` slot into a
-// null entry of the returned strings column (the compacted categories provide the validity); the
-// caller passes it for the string-map VALUES extraction, and only when the gate pass actually found
-// such a value -- an all-valid mask would cost an allocation, a pass, and a `bools_to_mask` only to
-// be discarded.
+// token id and materializes through `transform_fn`. `attach_null_value_mask` turns each
+// `null_value` slot into a null entry of the returned strings column (the compacted categories
+// provide the validity); the caller passes it for the string-map VALUES extraction, and only when
+// the gate pass actually found such a value -- an all-valid mask would cost an allocation, a pass,
+// and a `bools_to_mask` only to be discarded.
 std::unique_ptr<cudf::column> extract_keys_or_values(
   gated_extraction const& extraction,
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> node_ranges,
+  cudf::device_span<NodeIndexT const> node_token_ids,
+  cudf::device_span<PdaTokenT const> tokens,
+  cudf::device_span<SymbolOffsetT const> token_positions,
   cudf::device_span<char const> input_json,
   bool attach_null_value_mask,
   rmm::cuda_stream_view stream,
@@ -1142,15 +1289,17 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
       num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
   }
 
-  // Transform path: compact (range, category) with the same stencil in one pass, then
+  // Transform path: compact (range, category, token id) with the same stencil in one pass, then
   // materialize through the category dispatch.
   auto const num_nodes = node_ranges.size();
   auto extracted_ranges =
     rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>>(num_nodes, stream);
   auto extracted_categories = rmm::device_uvector<token_category>(num_nodes, stream);
-  auto const zip_in = thrust::make_zip_iterator(node_ranges.begin(), spec.categories.begin());
-  auto const zip_out =
-    thrust::make_zip_iterator(extracted_ranges.begin(), extracted_categories.begin());
+  auto extracted_token_ids  = rmm::device_uvector<NodeIndexT>(num_nodes, stream);
+  auto const zip_in =
+    thrust::make_zip_iterator(node_ranges.begin(), spec.categories.begin(), node_token_ids.begin());
+  auto const zip_out = thrust::make_zip_iterator(
+    extracted_ranges.begin(), extracted_categories.begin(), extracted_token_ids.begin());
   auto const zip_end     = copy_if(zip_in,
                                zip_in + num_nodes,
                                thrust::make_counting_iterator(0),
@@ -1160,8 +1309,16 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
   auto const num_extract = static_cast<cudf::size_type>(zip_end - zip_out);
   if (num_extract == 0) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}); }
 
-  auto [offsets, chars] = cudf::strings::detail::make_strings_children(
-    transform_fn{input_json, extracted_ranges, extracted_categories}, num_extract, stream, mr);
+  auto [offsets, chars] =
+    cudf::strings::detail::make_strings_children(transform_fn{input_json,
+                                                              tokens,
+                                                              token_positions,
+                                                              extracted_ranges,
+                                                              extracted_categories,
+                                                              extracted_token_ids},
+                                                 num_extract,
+                                                 stream,
+                                                 mr);
   auto output = cudf::make_strings_column(
     num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
 
@@ -1446,6 +1603,11 @@ struct element_classify_fn {
         range = {range_begin, range_begin};
       } else {
         category = classify_token(input_json.data(), token, range_begin, range_end);
+        // Same sink as the value path: a refused number inside a nested ELEMENT nullifies its row.
+        if (category == token_category::nested &&
+            nested_has_rejected_scalar(tokens, token_positions, input_json.data(), token_idx)) {
+          category = token_category::rejected;
+        }
       }
     }
 
@@ -1481,8 +1643,13 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
 
   // Compute the byte range and rendering category for each node. The ranges identify positions to
   // extract nodes from the unified json string; the categories drive the Spark-render dispatch.
-  auto const classified = compute_node_ranges_and_categories(
-    preprocessed_input, tokens, token_positions, node_token_ids, is_key_or_value_node, stream);
+  auto const classified       = compute_node_ranges_and_categories(preprocessed_input,
+                                                             tokens,
+                                                             token_positions,
+                                                             node_token_ids,
+                                                             is_key_or_value_node,
+                                                             /*classify_nested_reject=*/true,
+                                                             stream);
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
@@ -1493,13 +1660,27 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
                             {node_kind::value, is_key_or_value_node, node_categories},
                             stream);
 
-  auto extracted_keys = extract_keys_or_values(
-    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  auto extracted_keys = extract_keys_or_values(keys,
+                                               node_ranges,
+                                               node_token_ids,
+                                               tokens,
+                                               token_positions,
+                                               preprocessed_input,
+                                               /*attach_null_value_mask=*/false,
+                                               stream,
+                                               mr);
   // A JSON `null` VALUE keeps its pair but nulls the values-child entry (SQL NULL), so the values
   // extraction attaches the null mask derived from its `null_value` categories -- only when the
   // gate pass saw such a value, since otherwise the mask would be all-valid and thrown away.
-  auto extracted_values = extract_keys_or_values(
-    values, node_ranges, preprocessed_input, values_have_null_value, stream, mr);
+  auto extracted_values = extract_keys_or_values(values,
+                                                 node_ranges,
+                                                 node_token_ids,
+                                                 tokens,
+                                                 token_positions,
+                                                 preprocessed_input,
+                                                 values_have_null_value,
+                                                 stream,
+                                                 mr);
   CUDF_EXPECTS(extracted_keys->size() == extracted_values->size(),
                "Invalid key-value pair extraction.");
 
@@ -1621,9 +1802,16 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   auto const& is_key_or_value_node = tok.is_key_or_value_node;
 
   // Keys use the shared node-range/category computation; element ranges and categories come from
-  // the fused classifier below.
-  auto const classified = compute_node_ranges_and_categories(
-    preprocessed_input, tokens, token_positions, node_token_ids, is_key_or_value_node, stream);
+  // the fused classifier below. Value nodes need no nested-reject walk here: a refused number
+  // inside an array element is caught by `element_classify_fn`, and one that IS the value makes it
+  // a non-array, which the type-mismatch rule below already nullifies.
+  auto const classified       = compute_node_ranges_and_categories(preprocessed_input,
+                                                             tokens,
+                                                             token_positions,
+                                                             node_token_ids,
+                                                             is_key_or_value_node,
+                                                             /*classify_nested_reject=*/false,
+                                                             stream);
   auto const& node_ranges     = classified.ranges;
   auto const& node_categories = classified.categories;
 
@@ -1663,12 +1851,26 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   // element validity source.
   CUDF_EXPECTS(!elements_have_null_value, "Unexpected null-value category on the element path.");
 
-  auto extracted_keys = extract_keys_or_values(
-    keys, node_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  auto extracted_keys = extract_keys_or_values(keys,
+                                               node_ranges,
+                                               node_token_ids,
+                                               tokens,
+                                               token_positions,
+                                               preprocessed_input,
+                                               /*attach_null_value_mask=*/false,
+                                               stream,
+                                               mr);
 
   // Extract element strings with the shared extractor (a 0-null STRING column); attach mask #2.
-  auto extracted_elements = extract_keys_or_values(
-    elements, element_ranges, preprocessed_input, /*attach_null_value_mask=*/false, stream, mr);
+  auto extracted_elements = extract_keys_or_values(elements,
+                                                   element_ranges,
+                                                   node_token_ids,
+                                                   tokens,
+                                                   token_positions,
+                                                   preprocessed_input,
+                                                   /*attach_null_value_mask=*/false,
+                                                   stream,
+                                                   mr);
   {
     // Mask #2 over only the selected (element-flagged) nodes, in element document order, matching
     // the order `extract_keys_or_values` emits.

--- a/src/main/cpp/src/json_utils.hpp
+++ b/src/main/cpp/src/json_utils.hpp
@@ -44,14 +44,14 @@ struct json_parse_options {
  * `MapType[StringType, StringType]` (Jackson semantics): string keys/values are de-quoted and
  * JSON-unescaped; floats re-render via Java `Double.toString`; integer leading zeros and `-0` are
  * stripped; the `NaN`/`Infinity` spellings become their quoted canonical forms; a nested
- * object/array value keeps its verbatim raw JSON bytes. A value that is the JSON `null` literal
- * keeps its pair but nulls the corresponding entry of the values child.
+ * object/array value is re-serialized compactly. A value that is the JSON `null` literal keeps
+ * its pair but nulls the corresponding entry of the values child.
  *
  * A row is nullified when the input row is null, empty, whitespace only, or not a valid JSON
- * object, or when any of its values is a number the JSON parser refuses. The parser caps a number's
- * digit count -- signs, `.`, `e`/`E`, and leading zeros excluded -- and applies that cap to
- * integers and floats alike; a number past it makes the record a Spark bad record, so the whole row
- * becomes null instead of that value rendering.
+ * object, or when it holds a number the JSON parser refuses -- as a value or anywhere inside a
+ * nested one. The parser caps a number's digit count -- signs, `.`, `e`/`E`, and leading zeros
+ * excluded -- and applies that cap to integers and floats alike; a number past it makes the record
+ * a Spark bad record, so the whole row becomes null instead of that value rendering.
  */
 std::unique_ptr<cudf::column> from_json_to_raw_map(
   cudf::strings_column_view const& input,
@@ -72,9 +72,9 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(
  * entire outer map row is nullified, matching Spark `from_json`. An array element that is the
  * literal `null` produces a null element; every other element is rendered like the
  * `from_json_to_raw_map` values (strings de-quoted and unescaped, numbers re-rendered, nested
- * objects/arrays keep their verbatim raw JSON bytes). A number the JSON parser refuses nullifies
- * the whole row as an array element just as it does as a direct value. Row-level
- * null/empty/invalid handling is otherwise identical to `from_json_to_raw_map`.
+ * objects/arrays re-serialized compactly). A number the JSON parser refuses nullifies the whole
+ * row as an array element, or anywhere inside a nested one, just as it does as a direct value.
+ * Row-level null/empty/invalid handling is otherwise identical to `from_json_to_raw_map`.
  */
 std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   cudf::strings_column_view const& input,

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -48,9 +48,9 @@ namespace {
 
 // One (key, value) entry of a raw-map row, in the exact textual content the raw-map engine emits.
 // A string value (or key) is stored WITHOUT surrounding quotes and JSON-unescaped; a non-string
-// scalar carries its Spark-rendered text, while a nested object or array is still stored verbatim
-// (see the RawMapOpt_* contract block below). A `std::nullopt` value models a SQL NULL value slot:
-// a JSON `null` value keeps the pair but nulls the corresponding entry of the values child.
+// value carries its Spark-rendered text (see the RawMapOpt_* contract block below). A
+// `std::nullopt` value models a SQL NULL value slot: a JSON `null` value keeps the pair but nulls
+// the corresponding entry of the values child.
 using kv = std::pair<std::string, std::optional<std::string>>;
 
 // Build the expected `LIST<STRUCT<STRING,STRING>>` raw-map column directly from host data.
@@ -253,7 +253,8 @@ TEST_F(FromJsonTest, RawMapOpt_UnquotedControlCharactersStrict)
 //     `\uXXXX` -> UTF-8, ...); escape-free strings are byte-identical to the raw extraction.
 //   * Numbers are re-rendered: floats via Java `Double.toString`; integer leading zeros and `-0`
 //     are stripped; `NaN`/`Infinity` spellings become their QUOTED canonical forms.
-//   * A nested object/array value keeps its VERBATIM raw JSON bytes (copied unchanged).
+//   * A nested object/array value is re-serialized compactly (whitespace dropped, inner strings
+//     re-escaped, inner numbers re-rendered); a nested `null` stays the literal `null`.
 //   * A JSON `null` VALUE keeps the pair but nulls the values-child entry (SQL NULL).
 //   * `true`/`false` and already-canonical scalars are byte-identical to the input.
 //   * A populated object yields a non-null list of its (key, value) pairs in INPUT TEXTUAL order;
@@ -735,6 +736,172 @@ TEST_F(FromJsonTest, RawMapOpt_Render_NonNumeric)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
+// Nested object/array values re-serialize compactly: whitespace dropped, inner strings re-escaped
+// (`\t` stays escaped, `\uXXXX` decodes to UTF-8), inner lenient numbers re-rendered, and a nested
+// `null` stays the literal `null`. The last row covers empty containers nested INSIDE a value,
+// which close on the token immediately after their open.
+TEST_F(FromJsonTest, RawMapOpt_Render_Nested)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":{ "a" : 1 , "b" : [ 2 , 3 ] }})",
+                                       R"({"k":[007, NaN, 1.50, "x y"]})",
+                                       R"({"k":{"s":"a\tb","u":"中"}})",
+                                       R"({"k":[null,true,false]})",
+                                       R"({"k":{}})",
+                                       R"({"k":[]})",
+                                       R"({"k":{"a":[ ],"b":{ },"c":[[]]}})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"k", R"({"a":1,"b":[2,3]})"}},
+                                               {{"k", R"([7,"NaN",1.5,"x y"])"}},
+                                               {{"k", "{\"s\":\"a\\tb\",\"u\":\"中\"}"}},
+                                               {{"k", R"([null,true,false])"}},
+                                               {{"k", "{}"}},
+                                               {{"k", "[]"}},
+                                               {{"k", R"({"a":[],"b":{},"c":[[]]})"}}},
+                                              all_valid(7));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Re-escape round-trip inside a nested value: the inner strings are unescaped and RE-escaped, so
+// `\uXXXX` and a surrogate pair become raw UTF-8 and `\/` collapses to `/`, while `\"`, `\\` and
+// `\t` come back byte-identical. The escaped KEY takes the same path as the inner string values.
+TEST_F(FromJsonTest, RawMapOpt_Render_NestedStringEscapes)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":{"q\"k":"a\"b","bs":"p\\q",)"
+                                       R"("u":"\u4e2d\u56FD","e":"\ud83d\uDE00",)"
+                                       R"("sl":"x\/y","t":"a\tb"}})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"k",
+                             "{\"q\\\"k\":\"a\\\"b\",\"bs\":\"p\\\\q\",\"u\":\"中国\","
+                             "\"e\":\"\U0001F600\",\"sl\":\"x/y\",\"t\":\"a\\tb\"}"}}},
+                          all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Nested value deeper than 64 levels (the in-tree `json_parser` depth cap): the token-walk
+// renderer has no depth limit, so a 70-deep value must re-render, not error. The innermost lenient
+// scalar proves the walker composes with the number re-render at depth.
+TEST_F(FromJsonTest, RawMapOpt_Render_DeepNestedValue)
+{
+  constexpr int depth  = 70;
+  auto const open      = std::string(depth, '[');
+  auto const close     = std::string(depth, ']');
+  auto const input_col = cudf::test::strings_column_wrapper{"{\"k\":" + open + "007" + close + "}"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"k", open + "7" + close}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Companion to RawMapOpt_Render_DeepNestedValue (which stresses nesting DEPTH): a single nested
+// object VALUE with many sibling fields stresses render_nested's token-walk WIDTH, proving its
+// two-pass size and write passes agree over thousands of structural tokens -- a mismatch would
+// overflow the chars buffer.
+TEST_F(FromJsonTest, RawMapOpt_Render_WideNestedValue)
+{
+  constexpr int num_fields = 2000;
+  std::string obj          = R"({"k":{)";
+  std::string expected_val = "{";
+  for (int i = 0; i < num_fields; ++i) {
+    if (i > 0) {
+      obj += ",";
+      expected_val += ",";
+    }
+    obj += std::format(R"("f{}":{})", i, i);
+    expected_val += std::format(R"("f{}":{})", i, i);
+  }
+  obj += "}}";
+  expected_val += "}";
+
+  auto const input_col = cudf::test::strings_column_wrapper{obj};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"k", expected_val}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Multi-block companion to the nested render tests above: enough rows that the nested arm of
+// `transform_fn` and the compaction that carries each node's token id both run across many thread
+// blocks. The rendered length varies per row (the digit count of the lenient inner integer), so a
+// two-pass sizing mismatch cannot cancel out. `RawMapOpt_StressInvariantsWithBadRows` below is the
+// other large map input, but every node there is verbatim, so it takes the raw fast path instead.
+TEST_F(FromJsonTest, RawMapOpt_Render_NestedManyRows)
+{
+  constexpr int num_rows = 50000;
+  std::vector<std::string> input_rows;
+  std::vector<std::vector<kv>> expected_rows;
+  input_rows.reserve(num_rows);
+  expected_rows.reserve(num_rows);
+  for (int r = 0; r < num_rows; ++r) {
+    input_rows.push_back(std::format(R"({{"k":{{ "a" : 00{0} , "b" : "x\ty" }}}})", r));
+    expected_rows.push_back({{"k", std::format(R"({{"a":{0},"b":"x\ty"}})", r)}});
+  }
+
+  auto const input_col = cudf::test::strings_column_wrapper(input_rows.begin(), input_rows.end());
+  auto const expected  = make_expected_raw_map(expected_rows, all_valid(num_rows));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(cudf::strings_column_view{input_col}), *expected);
+}
+
+// The digit cap reaches INSIDE a nested value: a number the parser refuses makes the record a Spark
+// bad record wherever it sits, so a nested value holding one nulls its whole row exactly as a
+// top-level value does. Row 0 keeps every arm at the cap to pin that the boundary did not move.
+TEST_F(FromJsonTest, RawMapOpt_Reject_NestedInnerDigitCapBoundary)
+{
+  auto const at_cap = digits(max_num_digits);
+  auto const over   = digits(max_num_digits + 1);
+  auto const input_col =
+    cudf::test::strings_column_wrapper{// Row 0: at the cap inside an object and inside a list.
+                                       R"({"o":{"a":)" + at_cap + R"(},"l":[)" + at_cap + "]}",
+                                       // Row 1: one digit over, inside an object -> row null.
+                                       R"({"o":{"a":)" + over + "}}",
+                                       // Row 2: one digit over, inside a list -> row null.
+                                       R"({"l":[1,)" + over + "]}",
+                                       // Row 3: one digit over, three levels deep -> row null.
+                                       R"({"d":{"x":[{"y":)" + over + "}]}}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"o", R"({"a":)" + at_cap + "}"}, {"l", "[" + at_cap + "]"}}, {}, {}, {}},
+    {true, false, false, false});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 3);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  for (cudf::size_type row = 1; row < 4; ++row) {
+    SCOPED_TRACE(std::format("row={}", row));
+    EXPECT_TRUE(row_is_null(result->view(), row));
+  }
+}
+
+// A refused number nested inside a value nulls the row even when valid pairs already rendered
+// before it, and leaves its neighbours untouched. The nulled row has materialized pairs, so the
+// outer list would carry a non-empty null without the sanitation step -- which
+// `CUDF_TEST_EXPECT_COLUMNS_EQUAL` would catch as an offsets mismatch.
+TEST_F(FromJsonTest, RawMapOpt_Reject_NestedInnerAfterValidPairs)
+{
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"ok":"keep"})",
+    R"({"a":"drop","n":{"deep":)" + over + R"(},"z":"drop too"})",
+    R"({"ok2":"keep2"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"ok", "keep"}}, {}, {{"ok2", "keep2"}}}, {true, false, true});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 1);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_FALSE(row_is_null(result->view(), 2));
+}
+
 // All-canonical, escape-free column: every key/value classifies verbatim, so the extraction takes
 // the raw-copy fast path (the transform gate stays FALSE) and the output is byte-identical to the
 // input ranges. Covers escape-free strings, integers, booleans, an empty object, and duplicate
@@ -1094,7 +1261,7 @@ TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryValueNullMask)
 //     row is nullified (Spark row-level bad-record semantics), even if other keys are valid arrays.
 //   * element = Spark-rendered like the string-map values: strings de-quoted and JSON-unescaped;
 //     numbers re-rendered (float canonical, leading-zero strip, quoted NaN/Infinity); nested
-//     object/array elements keep their VERBATIM raw JSON bytes; bools byte-identical.
+//     object/array elements re-serialized compactly; bools byte-identical.
 //   * element = literal `null` -> NULL element (mask #2); a JSON STRING "null" stays valid.
 //   * element = number past the JSON parser's digit cap -> Spark BAD RECORD: the WHOLE row is
 //     nullified, exactly as for a string-map value (a rejected number sitting directly as a value
@@ -1271,27 +1438,33 @@ TEST_F(FromJsonTest, RawMapArray_EmptyObject)
 //   * value = scalar (string/number/bool) or object (NOT an array, NOT null) -> WHOLE ROW null.
 // Each case is its own row so the kept-vs-nullified rows are pinned independently. The
 // `true`/`false` rows pin that a scalar boolean value takes the same hard-mismatch path as
-// string/number/object.
+// string/number/object. The last row is a number past the parser's digit cap sitting DIRECTLY as
+// the value: it nulls the row through this same category-blind mismatch rule, never through the
+// reject category, which is why the array path needs no nested-reject walk on value nodes.
 TEST_F(FromJsonTest, RawMapArray_NonArrayValuesNullInnerList)
 {
+  auto const over_int  = digits(max_num_digits + 1);
   auto const input_col = cudf::test::strings_column_wrapper{R"({"a":null})",
                                                             R"({"a":"s"})",
                                                             R"({"a":9})",
                                                             R"({"a":{"x":"y"}})",
                                                             R"({"a":true})",
-                                                            R"({"a":false})"};
+                                                            R"({"a":false})",
+                                                            R"({"a":)" + over_int + "}"};
   auto const input     = cudf::strings_column_view{input_col};
 
-  // Row 0 kept (null inner list); rows 1-5 are hard type mismatches -> whole row null. The pairs of
+  // Row 0 kept (null inner list); rows 1-6 are hard type mismatches -> whole row null. The pairs of
   // the nullified rows are ignored by `make_expected_raw_map_array`, so their content is
   // irrelevant.
-  auto const expected = make_expected_raw_map_array({{{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}}},
-                                                    {true, false, false, false, false, false});
+  auto const expected =
+    make_expected_raw_map_array({{{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}}},
+                                {true, false, false, false, false, false, false});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
@@ -1312,9 +1485,8 @@ TEST_F(FromJsonTest, RawMapArray_TypeMismatchValueNullsRow)
 }
 
 // One array mixing literal `null`, the STRING "null", a number, both bools, and nested obj/array
-// elements. Pins mask #2 (literal null -> null element) + de-quote together. The number, bools,
-// and nested `{"x":1}`/`[2,3]` elements are copied verbatim (already canonical), so only the
-// strings are de-quoted/unescaped.
+// elements. Pins mask #2 (literal null -> null element) + rendering + de-quote together. The
+// nested `{"x":1}` and `[2,3]` elements are already compact, so their re-render is byte-identical.
 TEST_F(FromJsonTest, RawMapArray_MixedElementKinds)
 {
   auto const input_col =
@@ -1511,6 +1683,75 @@ TEST_F(FromJsonTest, RawMapArray_Render_FloatElements)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
+// Nested object/array ELEMENTS re-serialize compactly (whitespace dropped, inner strings
+// re-escaped, inner lenient numbers re-rendered). The empty object and empty array elements
+// close on the token immediately after their open.
+TEST_F(FromJsonTest, RawMapArray_Render_NestedElements)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":[{ "x" : 1 }, [ 2 , 3 ], { }, [ ], [007, "a b"]]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({R"({"x":1})", "[2,3]", "{}", "[]", R"([7,"a b"])"})}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Array mirror of RawMapOpt_Render_NestedStringEscapes: the inner strings and the escaped KEY of
+// a nested ELEMENT take the same unescape-then-RE-escape walk, so `\uXXXX` and a surrogate pair
+// become raw UTF-8 and `\/` collapses to `/`, while `\"`, `\\` and `\t` come back byte-identical.
+TEST_F(FromJsonTest, RawMapArray_Render_NestedElementStringEscapes)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":[{"q\"k":"a\"b","bs":"p\\q",)"
+                                       R"("u":"\u4e2d\u56FD","e":"\ud83d\uDE00",)"
+                                       R"("sl":"x\/y","t":"a\tb"}]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map_array({{{"k",
+                                   arr({"{\"q\\\"k\":\"a\\\"b\",\"bs\":\"p\\\\q\",\"u\":\"中国\","
+                                        "\"e\":\"\U0001F600\",\"sl\":\"x/y\",\"t\":\"a\\tb\"}"})}}},
+                                all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Nested element deeper than 64 levels (the in-tree `json_parser` depth cap): the token-walk
+// renderer has no depth limit, so a 70-deep element must re-render, not error.
+TEST_F(FromJsonTest, RawMapArray_Render_DeepNestedElement)
+{
+  constexpr int depth  = 70;
+  auto const open      = std::string(depth, '[');
+  auto const close     = std::string(depth, ']');
+  auto const input_col = cudf::test::strings_column_wrapper{"{\"k\":[" + open + "1" + close + "]}"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map_array({{{"k", arr({open + "1" + close})}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Array-path mirror of RawMapOpt_Render_NestedManyRows: enough rows that the nested arm of
+// `transform_fn` runs across many thread blocks on the ELEMENT extraction, which passes its own
+// element ranges and categories. The rendered length varies per row so a two-pass sizing mismatch
+// cannot cancel out.
+TEST_F(FromJsonTest, RawMapArray_Render_NestedElementsManyRows)
+{
+  constexpr int num_rows = 50000;
+  std::vector<std::string> input_rows;
+  std::vector<std::vector<kva>> expected_rows;
+  input_rows.reserve(num_rows);
+  expected_rows.reserve(num_rows);
+  for (int r = 0; r < num_rows; ++r) {
+    input_rows.push_back(std::format(R"({{"k":[{{ "a" : 00{0} }}, [ "x\ty" ]]}})", r));
+    expected_rows.push_back({{"k", arr({std::format(R"({{"a":{0}}})", r), R"(["x\ty"])"})}});
+  }
+
+  auto const input_col = cudf::test::strings_column_wrapper(input_rows.begin(), input_rows.end());
+  auto const expected  = make_expected_raw_map_array(expected_rows, all_valid(num_rows));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(cudf::strings_column_view{input_col}), *expected);
+}
+
 // All-canonical, escape-free column (clean strings/ints/bools, an empty array): every key/element
 // classifies verbatim, so the extraction takes the raw-copy fast path (the transform gate stays
 // FALSE) and the output is byte-identical to the raw extraction.
@@ -1590,8 +1831,8 @@ TEST_F(FromJsonTest, RawMapArray_Reject_ElementDigitCapBoundary)
 // A refused ELEMENT nullifies the whole row even when it sits among valid elements and valid keys,
 // and leaves neighbouring rows untouched. The nulled row has materialized pairs, so the outer list
 // would carry a non-empty null without the sanitation step -- `CUDF_TEST_EXPECT_COLUMNS_EQUAL`
-// compares offsets and would fail. A refused number sitting DIRECTLY as a value needs no case of
-// its own: it is already a hard type mismatch (see `RawMapArray_NonArrayValuesNullInnerList`).
+// compares offsets and would fail. A refused number sitting DIRECTLY as a value needs no case
+// here: it is already a hard type mismatch, pinned by `RawMapArray_NonArrayValuesNullInnerList`.
 TEST_F(FromJsonTest, RawMapArray_Reject_ElementNullsWholeRow)
 {
   auto const over      = digits(max_num_digits + 1);
@@ -1608,6 +1849,29 @@ TEST_F(FromJsonTest, RawMapArray_Reject_ElementNullsWholeRow)
   EXPECT_FALSE(row_is_null(result->view(), 0));
   EXPECT_TRUE(row_is_null(result->view(), 1));
   EXPECT_FALSE(row_is_null(result->view(), 2));
+}
+
+// The element mirror of the nested-inner reject: an element that is itself a nested object/array
+// holding a refused number nulls the whole row, at the cap it renders. Both classification paths
+// reach the same sink, so the two engines cannot drift on where the digit cap applies.
+TEST_F(FromJsonTest, RawMapArray_Reject_NestedElementInner)
+{
+  auto const at_cap    = digits(max_num_digits);
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{R"({"k":[{"a":)" + at_cap + "}]}",
+                                                            R"({"k":[{"a":)" + over + "}]}",
+                                                            R"({"k":["ok",[1,)" + over + "]]}"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({R"({"a":)" + at_cap + "}"})}}, {}, {}}, {true, false, false});
+  auto const result = raw_map_array(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 2);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_TRUE(row_is_null(result->view(), 2));
 }
 
 // Whitespace around values: insignificant whitespace is not part of the element bytes. The

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -253,7 +253,8 @@ TEST_F(FromJsonTest, RawMapOpt_UnquotedControlCharactersStrict)
 //     `\uXXXX` -> UTF-8, ...); escape-free strings are byte-identical to the raw extraction.
 //   * Numbers are re-rendered: floats via Java `Double.toString`; integer leading zeros and `-0`
 //     are stripped; `NaN`/`Infinity` spellings become their QUOTED canonical forms.
-//   * A nested object/array value keeps its VERBATIM raw JSON bytes (copied unchanged).
+//   * A nested object/array value is re-serialized compactly (whitespace dropped, inner strings
+//     re-escaped, inner numbers re-rendered); a nested `null` stays the literal `null`.
 //   * A JSON `null` VALUE keeps the pair but nulls the values-child entry (SQL NULL).
 //   * `true`/`false` and already-canonical scalars are byte-identical to the input.
 //   * A populated object yields a non-null list of its (key, value) pairs in INPUT TEXTUAL order;
@@ -735,6 +736,172 @@ TEST_F(FromJsonTest, RawMapOpt_Render_NonNumeric)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
 }
 
+// Nested object/array values re-serialize compactly: whitespace dropped, inner strings re-escaped
+// (`\t` stays escaped, `\uXXXX` decodes to UTF-8), inner lenient numbers re-rendered, and a nested
+// `null` stays the literal `null`. The last row covers empty containers nested INSIDE a value,
+// which close on the token immediately after their open.
+TEST_F(FromJsonTest, RawMapOpt_Render_Nested)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":{ "a" : 1 , "b" : [ 2 , 3 ] }})",
+                                       R"({"k":[007, NaN, 1.50, "x y"]})",
+                                       R"({"k":{"s":"a\tb","u":"中"}})",
+                                       R"({"k":[null,true,false]})",
+                                       R"({"k":{}})",
+                                       R"({"k":[]})",
+                                       R"({"k":{"a":[ ],"b":{ },"c":[[]]}})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"k", R"({"a":1,"b":[2,3]})"}},
+                                               {{"k", R"([7,"NaN",1.5,"x y"])"}},
+                                               {{"k", "{\"s\":\"a\\tb\",\"u\":\"中\"}"}},
+                                               {{"k", R"([null,true,false])"}},
+                                               {{"k", "{}"}},
+                                               {{"k", "[]"}},
+                                               {{"k", R"({"a":[],"b":{},"c":[[]]})"}}},
+                                              all_valid(7));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Re-escape round-trip inside a nested value: the inner strings are unescaped and RE-escaped, so
+// `\uXXXX` and a surrogate pair become raw UTF-8 and `\/` collapses to `/`, while `\"`, `\\` and
+// `\t` come back byte-identical. The escaped KEY takes the same path as the inner string values.
+TEST_F(FromJsonTest, RawMapOpt_Render_NestedStringEscapes)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":{"q\"k":"a\"b","bs":"p\\q",)"
+                                       R"("u":"\u4e2d\u56FD","e":"\ud83d\uDE00",)"
+                                       R"("sl":"x\/y","t":"a\tb"}})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"k",
+                             "{\"q\\\"k\":\"a\\\"b\",\"bs\":\"p\\\\q\",\"u\":\"中国\","
+                             "\"e\":\"\U0001F600\",\"sl\":\"x/y\",\"t\":\"a\\tb\"}"}}},
+                          all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Nested value deeper than 64 levels (the in-tree `json_parser` depth cap): the token-walk
+// renderer has no depth limit, so a 70-deep value must re-render, not error. The innermost lenient
+// scalar proves the walker composes with the number re-render at depth.
+TEST_F(FromJsonTest, RawMapOpt_Render_DeepNestedValue)
+{
+  constexpr int depth  = 70;
+  auto const open      = std::string(depth, '[');
+  auto const close     = std::string(depth, ']');
+  auto const input_col = cudf::test::strings_column_wrapper{"{\"k\":" + open + "007" + close + "}"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"k", open + "7" + close}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Companion to RawMapOpt_Render_DeepNestedValue (which stresses nesting DEPTH): a single nested
+// object VALUE with many sibling fields stresses render_nested's token-walk WIDTH, proving its
+// two-pass size and write passes agree over thousands of structural tokens -- a mismatch would
+// overflow the chars buffer.
+TEST_F(FromJsonTest, RawMapOpt_Render_WideNestedValue)
+{
+  constexpr int num_fields = 2000;
+  std::string obj          = R"({"k":{)";
+  std::string expected_val = "{";
+  for (int i = 0; i < num_fields; ++i) {
+    if (i > 0) {
+      obj += ",";
+      expected_val += ",";
+    }
+    obj += std::format(R"("f{}":{})", i, i);
+    expected_val += std::format(R"("f{}":{})", i, i);
+  }
+  obj += "}}";
+  expected_val += "}";
+
+  auto const input_col = cudf::test::strings_column_wrapper{obj};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map({{{"k", expected_val}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
+
+// Multi-block companion to the nested render tests above: enough rows that the nested arm of
+// `transform_fn` and the compaction that carries each node's token id both run across many thread
+// blocks. The rendered length varies per row (the digit count of the lenient inner integer), so a
+// two-pass sizing mismatch cannot cancel out. `RawMapOpt_StressInvariantsWithBadRows` below is the
+// other large map input, but every node there is verbatim, so it takes the raw fast path instead.
+TEST_F(FromJsonTest, RawMapOpt_Render_NestedManyRows)
+{
+  constexpr int num_rows = 50000;
+  std::vector<std::string> input_rows;
+  std::vector<std::vector<kv>> expected_rows;
+  input_rows.reserve(num_rows);
+  expected_rows.reserve(num_rows);
+  for (int r = 0; r < num_rows; ++r) {
+    input_rows.push_back(std::format(R"({{"k":{{ "a" : 00{0} , "b" : "x\ty" }}}})", r));
+    expected_rows.push_back({{"k", std::format(R"({{"a":{0},"b":"x\ty"}})", r)}});
+  }
+
+  auto const input_col = cudf::test::strings_column_wrapper(input_rows.begin(), input_rows.end());
+  auto const expected  = make_expected_raw_map(expected_rows, all_valid(num_rows));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(cudf::strings_column_view{input_col}), *expected);
+}
+
+// The digit cap reaches INSIDE a nested value: a number the parser refuses makes the record a Spark
+// bad record wherever it sits, so a nested value holding one nulls its whole row exactly as a
+// top-level value does. Row 0 keeps every arm at the cap to pin that the boundary did not move.
+TEST_F(FromJsonTest, RawMapOpt_Reject_NestedInnerDigitCapBoundary)
+{
+  auto const at_cap = digits(max_num_digits);
+  auto const over   = digits(max_num_digits + 1);
+  auto const input_col =
+    cudf::test::strings_column_wrapper{// Row 0: at the cap inside an object and inside a list.
+                                       R"({"o":{"a":)" + at_cap + R"(},"l":[)" + at_cap + "]}",
+                                       // Row 1: one digit over, inside an object -> row null.
+                                       R"({"o":{"a":)" + over + "}}",
+                                       // Row 2: one digit over, inside a list -> row null.
+                                       R"({"l":[1,)" + over + "]}",
+                                       // Row 3: one digit over, three levels deep -> row null.
+                                       R"({"d":{"x":[{"y":)" + over + "}]}}"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map(
+    {{{"o", R"({"a":)" + at_cap + "}"}, {"l", "[" + at_cap + "]"}}, {}, {}, {}},
+    {true, false, false, false});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 3);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  for (cudf::size_type row = 1; row < 4; ++row) {
+    SCOPED_TRACE(std::format("row={}", row));
+    EXPECT_TRUE(row_is_null(result->view(), row));
+  }
+}
+
+// A refused number nested inside a value nulls the row even when valid pairs already rendered
+// before it, and leaves its neighbours untouched. The nulled row has materialized pairs, so the
+// outer list would carry a non-empty null without the sanitation step -- which
+// `CUDF_TEST_EXPECT_COLUMNS_EQUAL` would catch as an offsets mismatch.
+TEST_F(FromJsonTest, RawMapOpt_Reject_NestedInnerAfterValidPairs)
+{
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{
+    R"({"ok":"keep"})",
+    R"({"a":"drop","n":{"deep":)" + over + R"(},"z":"drop too"})",
+    R"({"ok2":"keep2"})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"ok", "keep"}}, {}, {{"ok2", "keep2"}}}, {true, false, true});
+  auto const result = raw_map(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 1);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_FALSE(row_is_null(result->view(), 2));
+}
+
 // All-canonical, escape-free column: every key/value classifies verbatim, so the extraction takes
 // the raw-copy fast path (the transform gate stays FALSE) and the output is byte-identical to the
 // input ranges. Covers escape-free strings, integers, booleans, an empty object, and duplicate
@@ -1094,7 +1261,7 @@ TEST_F(FromJsonTest, RawMapOpt_WarpBoundaryValueNullMask)
 //     row is nullified (Spark row-level bad-record semantics), even if other keys are valid arrays.
 //   * element = Spark-rendered like the string-map values: strings de-quoted and JSON-unescaped;
 //     numbers re-rendered (float canonical, leading-zero strip, quoted NaN/Infinity); nested
-//     object/array elements keep their VERBATIM raw JSON bytes; bools byte-identical.
+//     object/array elements re-serialized compactly; bools byte-identical.
 //   * element = literal `null` -> NULL element (mask #2); a JSON STRING "null" stays valid.
 //   * element = number past the JSON parser's digit cap -> Spark BAD RECORD: the WHOLE row is
 //     nullified, exactly as for a string-map value (a rejected number sitting directly as a value
@@ -1271,27 +1438,33 @@ TEST_F(FromJsonTest, RawMapArray_EmptyObject)
 //   * value = scalar (string/number/bool) or object (NOT an array, NOT null) -> WHOLE ROW null.
 // Each case is its own row so the kept-vs-nullified rows are pinned independently. The
 // `true`/`false` rows pin that a scalar boolean value takes the same hard-mismatch path as
-// string/number/object.
+// string/number/object. The last row is a number past the parser's digit cap sitting DIRECTLY as
+// the value: it nulls the row through this same category-blind mismatch rule, never through the
+// reject category, which is why the array path needs no nested-reject walk on value nodes.
 TEST_F(FromJsonTest, RawMapArray_NonArrayValuesNullInnerList)
 {
+  auto const over_int  = digits(max_num_digits + 1);
   auto const input_col = cudf::test::strings_column_wrapper{R"({"a":null})",
                                                             R"({"a":"s"})",
                                                             R"({"a":9})",
                                                             R"({"a":{"x":"y"}})",
                                                             R"({"a":true})",
-                                                            R"({"a":false})"};
+                                                            R"({"a":false})",
+                                                            R"({"a":)" + over_int + "}"};
   auto const input     = cudf::strings_column_view{input_col};
 
-  // Row 0 kept (null inner list); rows 1-5 are hard type mismatches -> whole row null. The pairs of
+  // Row 0 kept (null inner list); rows 1-6 are hard type mismatches -> whole row null. The pairs of
   // the nullified rows are ignored by `make_expected_raw_map_array`, so their content is
   // irrelevant.
-  auto const expected = make_expected_raw_map_array({{{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}},
-                                                     {{"a", null_arr()}}},
-                                                    {true, false, false, false, false, false});
+  auto const expected =
+    make_expected_raw_map_array({{{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}},
+                                 {{"a", null_arr()}}},
+                                {true, false, false, false, false, false, false});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
@@ -1312,9 +1485,8 @@ TEST_F(FromJsonTest, RawMapArray_TypeMismatchValueNullsRow)
 }
 
 // One array mixing literal `null`, the STRING "null", a number, both bools, and nested obj/array
-// elements. Pins mask #2 (literal null -> null element) + de-quote together. The number, bools,
-// and nested `{"x":1}`/`[2,3]` elements are copied verbatim (already canonical), so only the
-// strings are de-quoted/unescaped.
+// elements. Pins mask #2 (literal null -> null element) + rendering + de-quote together. The
+// nested `{"x":1}` and `[2,3]` elements are already compact, so their re-render is byte-identical.
 TEST_F(FromJsonTest, RawMapArray_MixedElementKinds)
 {
   auto const input_col =
@@ -1511,6 +1683,75 @@ TEST_F(FromJsonTest, RawMapArray_Render_FloatElements)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
 }
 
+// Nested object/array ELEMENTS re-serialize compactly (whitespace dropped, inner strings
+// re-escaped, inner lenient numbers re-rendered). The empty object and empty array elements
+// close on the token immediately after their open.
+TEST_F(FromJsonTest, RawMapArray_Render_NestedElements)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":[{ "x" : 1 }, [ 2 , 3 ], { }, [ ], [007, "a b"]]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({R"({"x":1})", "[2,3]", "{}", "[]", R"([7,"a b"])"})}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Array mirror of RawMapOpt_Render_NestedStringEscapes: the inner strings and the escaped KEY of
+// a nested ELEMENT take the same unescape-then-RE-escape walk, so `\uXXXX` and a surrogate pair
+// become raw UTF-8 and `\/` collapses to `/`, while `\"`, `\\` and `\t` come back byte-identical.
+TEST_F(FromJsonTest, RawMapArray_Render_NestedElementStringEscapes)
+{
+  auto const input_col =
+    cudf::test::strings_column_wrapper{R"({"k":[{"q\"k":"a\"b","bs":"p\\q",)"
+                                       R"("u":"\u4e2d\u56FD","e":"\ud83d\uDE00",)"
+                                       R"("sl":"x\/y","t":"a\tb"}]})"};
+  auto const input = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map_array({{{"k",
+                                   arr({"{\"q\\\"k\":\"a\\\"b\",\"bs\":\"p\\\\q\",\"u\":\"中国\","
+                                        "\"e\":\"\U0001F600\",\"sl\":\"x/y\",\"t\":\"a\\tb\"}"})}}},
+                                all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Nested element deeper than 64 levels (the in-tree `json_parser` depth cap): the token-walk
+// renderer has no depth limit, so a 70-deep element must re-render, not error.
+TEST_F(FromJsonTest, RawMapArray_Render_DeepNestedElement)
+{
+  constexpr int depth  = 70;
+  auto const open      = std::string(depth, '[');
+  auto const close     = std::string(depth, ']');
+  auto const input_col = cudf::test::strings_column_wrapper{"{\"k\":[" + open + "1" + close + "]}"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map_array({{{"k", arr({open + "1" + close})}}}, all_valid(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(input), *expected);
+}
+
+// Array-path mirror of RawMapOpt_Render_NestedManyRows: enough rows that the nested arm of
+// `transform_fn` runs across many thread blocks on the ELEMENT extraction, which passes its own
+// element ranges and categories. The rendered length varies per row so a two-pass sizing mismatch
+// cannot cancel out.
+TEST_F(FromJsonTest, RawMapArray_Render_NestedElementsManyRows)
+{
+  constexpr int num_rows = 50000;
+  std::vector<std::string> input_rows;
+  std::vector<std::vector<kva>> expected_rows;
+  input_rows.reserve(num_rows);
+  expected_rows.reserve(num_rows);
+  for (int r = 0; r < num_rows; ++r) {
+    input_rows.push_back(std::format(R"({{"k":[{{ "a" : 00{0} }}, [ "x\ty" ]]}})", r));
+    expected_rows.push_back({{"k", arr({std::format(R"({{"a":{0}}})", r), R"(["x\ty"])"})}});
+  }
+
+  auto const input_col = cudf::test::strings_column_wrapper(input_rows.begin(), input_rows.end());
+  auto const expected  = make_expected_raw_map_array(expected_rows, all_valid(num_rows));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map_array(cudf::strings_column_view{input_col}), *expected);
+}
+
 // All-canonical, escape-free column (clean strings/ints/bools, an empty array): every key/element
 // classifies verbatim, so the extraction takes the raw-copy fast path (the transform gate stays
 // FALSE) and the output is byte-identical to the raw extraction.
@@ -1590,8 +1831,8 @@ TEST_F(FromJsonTest, RawMapArray_Reject_ElementDigitCapBoundary)
 // A refused ELEMENT nullifies the whole row even when it sits among valid elements and valid keys,
 // and leaves neighbouring rows untouched. The nulled row has materialized pairs, so the outer list
 // would carry a non-empty null without the sanitation step -- `CUDF_TEST_EXPECT_COLUMNS_EQUAL`
-// compares offsets and would fail. A refused number sitting DIRECTLY as a value needs no case of
-// its own: it is already a hard type mismatch (see `RawMapArray_NonArrayValuesNullInnerList`).
+// compares offsets and would fail. A refused number sitting DIRECTLY as a value needs no case
+// here: it is already a hard type mismatch, pinned by `RawMapArray_NonArrayValuesNullInnerList`.
 TEST_F(FromJsonTest, RawMapArray_Reject_ElementNullsWholeRow)
 {
   auto const over      = digits(max_num_digits + 1);
@@ -1608,6 +1849,29 @@ TEST_F(FromJsonTest, RawMapArray_Reject_ElementNullsWholeRow)
   EXPECT_FALSE(row_is_null(result->view(), 0));
   EXPECT_TRUE(row_is_null(result->view(), 1));
   EXPECT_FALSE(row_is_null(result->view(), 2));
+}
+
+// The element mirror of the nested-inner reject: an element that is itself a nested object/array
+// holding a refused number nulls the whole row, at the cap it renders. Both classification paths
+// reach the same sink, so the two engines cannot drift on where the digit cap applies.
+TEST_F(FromJsonTest, RawMapArray_Reject_NestedElementInner)
+{
+  auto const at_cap    = digits(max_num_digits);
+  auto const over      = digits(max_num_digits + 1);
+  auto const input_col = cudf::test::strings_column_wrapper{R"({"k":[{"a":)" + at_cap + "}]}",
+                                                            R"({"k":[{"a":)" + over + "}]}",
+                                                            R"({"k":["ok",[1,)" + over + "]]}"};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected = make_expected_raw_map_array(
+    {{{"k", arr({R"({"a":)" + at_cap + "}"})}}, {}, {}}, {true, false, false});
+  auto const result = raw_map_array(input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
+
+  EXPECT_EQ(result->null_count(), 2);
+  EXPECT_FALSE(row_is_null(result->view(), 0));
+  EXPECT_TRUE(row_is_null(result->view(), 1));
+  EXPECT_TRUE(row_is_null(result->view(), 2));
 }
 
 // Whitespace around values: insignificant whitespace is not part of the element bytes. The

--- a/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
@@ -157,15 +157,15 @@ public class JSONUtils {
    * rendered to match Spark's `from_json` for the schema {@code MapType[StringType, StringType]}
    * (Jackson semantics): string keys/values are de-quoted and JSON-unescaped; floats re-render via
    * Java `Double.toString`; integer leading zeros and `-0` are stripped; the `NaN`/`Infinity`
-   * spellings become their quoted canonical forms; a nested object/array value keeps its verbatim
-   * raw JSON bytes. A JSON `null` value keeps its pair but nulls the corresponding entry of the
-   * values child.
+   * spellings become their quoted canonical forms; a nested object/array value is re-serialized
+   * compactly. A JSON `null` value keeps its pair but nulls the corresponding entry of the values
+   * child.
    * <p/>
    * A row is nullified when the input row is null, empty, whitespace only, or not a valid JSON
-   * object, or when any of its values is a number the JSON parser refuses. The parser caps a
-   * number's digit count (signs, `.`, `e`/`E`, and leading zeros excluded) and applies that cap to
-   * integers and floats alike; a number past it makes the record a Spark bad record, so the whole
-   * row becomes null instead of that value rendering.
+   * object, or when it holds a number the JSON parser refuses -- as a value or anywhere inside a
+   * nested one. The parser caps a number's digit count (signs, `.`, `e`/`E`, and leading zeros
+   * excluded) and applies that cap to integers and floats alike; a number past it makes the record
+   * a Spark bad record, so the whole row becomes null instead of that value rendering.
    *
    * @param input The input strings column in which each row specifies a json object
    * @param opts The options for parsing JSON strings
@@ -186,14 +186,15 @@ public class JSONUtils {
    * rendered to match Spark's `from_json` StringType conversion (Jackson semantics): string
    * keys/values/elements are de-quoted and JSON-unescaped; floats re-render via Java
    * `Double.toString`; integer leading zeros and `-0` are stripped; the `NaN`/`Infinity` spellings
-   * become their quoted canonical forms; nested objects/arrays keep their verbatim raw JSON bytes.
+   * become their quoted canonical forms; nested objects/arrays are re-serialized compactly.
    * <p/>
    * For BOTH value types, a row is nullified when the input row is null, empty, whitespace only, or
    * not a valid JSON object, or when any number in it is one the JSON parser refuses. The parser
    * caps a number's digit count (signs, `.`, `e`/`E`, and leading zeros excluded) and applies that
    * cap to integers and floats alike; a number past it makes the record a Spark bad record, so the
-   * whole row becomes null instead of that number rendering -- as an array element just as much as
-   * a direct value. This is independent of the array-schema type-mismatch rule described below.
+   * whole row becomes null instead of that number rendering -- as an array element, or anywhere
+   * inside a nested value, just as much as a direct value. This is independent of the array-schema
+   * type-mismatch rule described below.
    * <p/>
    * The {@code valueType} parameter selects how each JSON value is interpreted and therefore the
    * shape of the output map column:<br>

--- a/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
@@ -95,7 +95,7 @@ public class FromJsonToRawMapTest {
          ColumnVector expectedKeys = ColumnVector.fromStrings("Zipcode", "ZipCodeType", "City",
              "State", "category", "index", "author", "title", "price");
          ColumnVector expectedValues = ColumnVector.fromStrings("704", "STANDARD", "PARC PARQUE",
-             "PR", "reference", "[4,{},null,{\"a\":[{ }, {}] } ]", "Nigel Rees", "{}[], " +
+             "PR", "reference", "[4,{},null,{\"a\":[{},{}]}]", "Nigel Rees", "{}[], " +
                  "<=semantic-symbols-string", "8.95");
          ColumnVector expectedStructs = ColumnVector.makeStruct(expectedKeys, expectedValues);
          ColumnVector expectedOffsets = ColumnVector.fromInts(0, 4, 4, 4, 9);
@@ -199,9 +199,9 @@ public class FromJsonToRawMapTest {
 
   // ===== MAP<STRING,ARRAY<STRING>> (array-valued map) =====
 
-  // ARRAY_OF_STRING: a single object whose one key maps to a two-element string array. Elements are
-  // de-quoted and JSON-unescaped; both elements here are escape-free, so {"k":["a","b"]} yields one
-  // non-null row holding the pair (k -> ["a", "b"]).
+  // ARRAY_OF_STRING: a single object whose one key maps to a two-element string array. The engine
+  // renders each element the way Spark does, which for a plain string is just de-quoting, so
+  // {"k":["a","b"]} yields one non-null row holding the pair (k -> ["a", "b"]).
   @Test
   void testExtractRawMapArrayFromJsonString() {
     List<HostColumnVector.StructData> row0 =


### PR DESCRIPTION
Fix the `from_json` API for re-serializing nested object and array raw-map values to mach with the output of Apache Spark: whitespace removed, inner strings re-escaped, inner numbers re-rendered, document key order preserved. With this layer, the GPU output matches Spark for every value kind, on both the `MAP<STRING,STRING>` and `MAP<STRING,ARRAY<STRING>>` schemas.

Example for output of type `MAP<STRING,STRING>`:

| Input | GPU before (wrong) | GPU after (matches Spark) |
|---|---|---|
| `{"k":{ "a" : 1 , "b" : [ 2 , 3 ] }}` | `{ "a" : 1 , "b" : [ 2 , 3 ] }` | `{"a":1,"b":[2,3]}` |
| `{"k":[007, NaN, 1.50, "x y"]}` | `[007, NaN, 1.50, "x y"]` | `[7,"NaN",1.5,"x y"]` |
| `{"k":[null,true,false]}` | `[null,true,false]` | `[null,true,false]` |
| `{"k":{ }}` | `{ }` | `{}` |
| `{"k":{"a":<1001 digits>}}` | the raw digits | the whole row is NULL |

The last row extends the previous PR's rule to nested values: a number past the parser's digit cap makes the record a Spark bad record wherever it sits, so a nested value holding one nullifies its whole row rather than rendering the digits.

Depends on `Canonicalize from_json raw-map numbers and nulls` — it calls the scalar renderers and reuses the categories that PR introduces, with the two earlier PRs required transitively. It should also land after the shared `json_parser` unicode-escape fix.

Partially contribute to https://github.com/NVIDIA/cudf-spark/issues/15240.

Depends on:
 * https://github.com/NVIDIA/cudf-spark-jni/pull/4949

### Performance

Ratio is this PR stacked on its parents, divided by the GPU time of unmodified `main` - above 1.00 is slower.

| Benchmark | Cells | Median | Best | Worst |
|---|---|---|---|---|
| `..._null_density` | 4 | 1.058x | 1.056x | 1.065x |
| `..._value_width` | 4 | 1.058x | 0.910x | 1.427x |
| `..._key_name_len` | 3 | 1.058x | 1.041x | 1.065x |
| `..._micro_size` | 4 | 1.053x | 1.015x | 1.065x |
| `from_json_to_raw_map` | 24 | 1.037x | 0.988x | 1.115x |
| `..._array_values` | 18 | 1.035x | 1.000x | 1.063x |
| `..._row_shape` | 3 | 1.034x | 0.830x | 1.366x |
| `..._array_values_key_name_len` | 3 | 1.022x | 1.015x | 1.026x |
| `..._array_values_type_mismatch` | 3 | 1.020x | 1.018x | 1.030x |
| `..._array_values_keys_per_row` | 3 | 1.018x | 1.017x | 1.022x |
| `..._array_values_null_density` | 9 | 1.017x | 1.008x | 1.025x |

**Overall: 78 cells, median 1.031x, best 0.830x, worst 1.427x slower.**  The two outliers, `value_width=1000` at `1.427x` and `row_shape=few_wide` at `1.366x`, are the widest-value shapes, where a bulk copy is replaced by per-character copy — the unavoidable price of returning what Spark returns, since the old path was a fast copy of a semantically wrong answer. This PR's own layer costs `1.003x`; the rest is inherited from its parents.
