### PR TITLE
Replace reinterpret casts in JNI sources

### DIFF
--- a/src/main/cpp/src/Aggregation64Utils.cpp
+++ b/src/main/cpp/src/Aggregation64Utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 #include "cudf_jni_apis.hpp"
 #include "dtype_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Aggregation64Utils_extractInt32Chunk(
@@ -27,7 +29,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Aggregation64Utils_extr
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto cview = reinterpret_cast<cudf::column_view const*>(j_column_view);
+    auto cview = std::bit_cast<cudf::column_view const*>(j_column_view);
     auto dtype = cudf::jni::make_data_type(j_out_dtype, 0);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::extract_chunk32_from_64bit(*cview, dtype, j_chunk_idx));
@@ -43,7 +45,7 @@ Java_com_nvidia_spark_rapids_jni_Aggregation64Utils_combineInt64SumChunks(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto tview = reinterpret_cast<cudf::table_view const*>(j_table_view);
+    auto tview = std::bit_cast<cudf::table_view const*>(j_table_view);
     std::unique_ptr<cudf::table> result =
       spark_rapids_jni::assemble64_from_sum(*tview, cudf::jni::make_data_type(j_dtype, j_scale));
     return cudf::jni::convert_table_for_return(env, result);

--- a/src/main/cpp/src/ArithmeticJni.cpp
+++ b/src/main/cpp/src/ArithmeticJni.cpp
@@ -20,6 +20,8 @@
 #include "multiply.hpp"
 #include "round_float.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_multiply(JNIEnv* env,
@@ -39,18 +41,18 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_multiply(JNI
     cudf::jni::auto_set_device(env);
 
     if (is_left_cv && is_right_cv) {
-      auto const& left_cv  = *reinterpret_cast<cudf::column_view const*>(left);
-      auto const& right_cv = *reinterpret_cast<cudf::column_view const*>(right);
+      auto const& left_cv  = *std::bit_cast<cudf::column_view const*>(left);
+      auto const& right_cv = *std::bit_cast<cudf::column_view const*>(right);
       return cudf::jni::release_as_jlong(
         spark_rapids_jni::multiply(left_cv, right_cv, ansi_enabled, is_try_mode));
     } else if (is_left_cv && !is_right_cv) {
-      auto const& left_cv      = *reinterpret_cast<cudf::column_view const*>(left);
-      auto const& right_scalar = *reinterpret_cast<cudf::scalar const*>(right);
+      auto const& left_cv      = *std::bit_cast<cudf::column_view const*>(left);
+      auto const& right_scalar = *std::bit_cast<cudf::scalar const*>(right);
       return cudf::jni::release_as_jlong(
         spark_rapids_jni::multiply(left_cv, right_scalar, ansi_enabled, is_try_mode));
     } else if (!is_left_cv && is_right_cv) {
-      auto const& left_scalar = *reinterpret_cast<cudf::scalar const*>(left);
-      auto const& right_cv    = *reinterpret_cast<cudf::column_view*>(right);
+      auto const& left_scalar = *std::bit_cast<cudf::scalar const*>(left);
+      auto const& right_cv    = *std::bit_cast<cudf::column_view*>(right);
       return cudf::jni::release_as_jlong(
         spark_rapids_jni::multiply(left_scalar, right_cv, ansi_enabled, is_try_mode));
     } else {
@@ -73,7 +75,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_round(JNIEnv
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    cudf::column_view* input     = reinterpret_cast<cudf::column_view*>(input_ptr);
+    cudf::column_view* input     = std::bit_cast<cudf::column_view*>(input_ptr);
     cudf::rounding_method method = static_cast<cudf::rounding_method>(rounding_method);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::round(*input, decimal_places, method, is_ansi_mode));

--- a/src/main/cpp/src/BloomFilterJni.cpp
+++ b/src/main/cpp/src/BloomFilterJni.cpp
@@ -20,6 +20,7 @@
 #include "jni_utils.hpp"
 #include "utilities.hpp"
 
+#include <bit>
 #include <limits>
 
 extern "C" {
@@ -47,7 +48,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_creategpu(
     auto const bloom_filter_longs = static_cast<int32_t>((bloomFilterBits + 63) / 64);
     auto bloom_filter =
       spark_rapids_jni::bloom_filter_create(version, numHashes, bloom_filter_longs, seed);
-    return reinterpret_cast<jlong>(bloom_filter.release());
+    return std::bit_cast<jlong>(bloom_filter.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -61,8 +62,8 @@ JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_put(JNIEnv* 
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::column_view const& input_column = *reinterpret_cast<cudf::column_view const*>(cv);
-    spark_rapids_jni::bloom_filter_put(*(reinterpret_cast<cudf::list_scalar*>(bloomFilter)),
+    cudf::column_view const& input_column = *std::bit_cast<cudf::column_view const*>(cv);
+    spark_rapids_jni::bloom_filter_put(*(std::bit_cast<cudf::list_scalar*>(bloomFilter)),
                                        input_column);
     return 0;
   }
@@ -78,9 +79,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_merge(JNIEn
     cudf::jni::auto_set_device(env);
 
     cudf::column_view const& input_bloom_filter =
-      *reinterpret_cast<cudf::column_view const*>(bloomFilters);
+      *std::bit_cast<cudf::column_view const*>(bloomFilters);
     auto bloom_filter = spark_rapids_jni::bloom_filter_merge(input_bloom_filter);
-    return reinterpret_cast<jlong>(bloom_filter.release());
+    return std::bit_cast<jlong>(bloom_filter.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -94,9 +95,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_probe(JNIEn
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::column_view const& input_column = *reinterpret_cast<cudf::column_view const*>(cv);
+    cudf::column_view const& input_column = *std::bit_cast<cudf::column_view const*>(cv);
     return cudf::jni::release_as_jlong(spark_rapids_jni::bloom_filter_probe(
-      input_column, *(reinterpret_cast<cudf::list_scalar*>(bloomFilter))));
+      input_column, *(std::bit_cast<cudf::list_scalar*>(bloomFilter))));
   }
   JNI_CATCH(env, 0);
 }
@@ -108,8 +109,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_probebuffer
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::column_view const& input_column = *reinterpret_cast<cudf::column_view const*>(cv);
-    auto buf                              = reinterpret_cast<uint8_t const*>(bloomFilter);
+    cudf::column_view const& input_column = *std::bit_cast<cudf::column_view const*>(cv);
+    auto buf                              = std::bit_cast<uint8_t const*>(bloomFilter);
     return cudf::jni::release_as_jlong(spark_rapids_jni::bloom_filter_probe(
       input_column, cudf::device_span<uint8_t const>{buf, static_cast<size_t>(bloomFilterSize)}));
   }

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -34,6 +34,8 @@
 #include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
 
+#include <bit>
+
 constexpr char const* JNI_CAST_ERROR_CLASS = "com/nvidia/spark/rapids/jni/CastException";
 
 #define CATCH_CAST_EXCEPTION(env, ret_val)                                                \
@@ -70,7 +72,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toInteger(
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
+    cudf::strings_column_view scv{*std::bit_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_integer(
       cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, strip, cudf::get_default_stream()));
   }
@@ -92,7 +94,7 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_toDecimal(JNIEnv* env,
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
+    cudf::strings_column_view scv{*std::bit_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_decimal(
       precision, scale, scv, ansi_enabled, strip, cudf::get_default_stream()));
   }
@@ -108,7 +110,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toFloat(
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
+    cudf::strings_column_view scv{*std::bit_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_float(
       cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, cudf::get_default_stream()));
   }
@@ -126,7 +128,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromFloat(J
   {
     cudf::jni::auto_set_device(env);
 
-    auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const& cv = *std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::release_as_jlong(spark_rapids_jni::float_to_string(
       cv, json_string, cudf::get_default_stream(), cudf::get_current_device_resource_ref()));
   }
@@ -142,7 +144,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromFloatWi
   {
     cudf::jni::auto_set_device(env);
 
-    auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const& cv = *std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::format_float(cv, digits, cudf::get_default_stream()));
   }
@@ -159,7 +161,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromDecimal
   {
     cudf::jni::auto_set_device(env);
 
-    auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const& cv = *std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::decimal_to_non_ansi_string(cv, cudf::get_default_stream()));
   }
@@ -175,7 +177,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromLongToB
   {
     cudf::jni::auto_set_device(env);
 
-    auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const& cv = *std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::long_to_binary_string(cv, cudf::get_default_stream()));
   }
@@ -197,7 +199,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegersW
     jni::auto_set_device(env);
     auto const zero_scalar   = numeric_scalar<uint64_t>(0);
     auto const res_data_type = jni::make_data_type(j_dtype, 0);
-    auto const input_view{*reinterpret_cast<column_view const*>(input_column)};
+    auto const input_view{*std::bit_cast<column_view const*>(input_column)};
     auto const validity_regex_str = [&] {
       switch (base) {
         case 10: return R"(^\s*(-?[0-9]+).*)"; break;
@@ -261,7 +263,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromInteger
   JNI_TRY
   {
     jni::auto_set_device(env);
-    auto input_view{*reinterpret_cast<column_view const*>(input_column)};
+    auto input_view{*std::bit_cast<column_view const*>(input_column)};
     auto result = [&] {
       switch (base) {
         case 10: {
@@ -292,7 +294,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_bytesToHex(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const col = *reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const col = *std::bit_cast<cudf::column_view const*>(input_column);
     // BinaryType arrives as LIST<INT8>. Reinterpret as STRING for the kernel.
     // STRING layout: data=chars bytes, children=[offsets]  (1 child)
     // LIST<INT8> layout: data=nullptr, children=[offsets, child_int8]  (2 children)
@@ -344,9 +346,9 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStringsToIntermediate
     cudf::jni::auto_set_device(env);
 
     auto const input_view =
-      cudf::strings_column_view(*reinterpret_cast<cudf::column_view const*>(input_column));
-    auto const* tz_name_to_index = reinterpret_cast<cudf::column_view const*>(tz_name_to_index_map);
-    auto const* timezone_info    = reinterpret_cast<cudf::table_view const*>(timezone_info_table);
+      cudf::strings_column_view(*std::bit_cast<cudf::column_view const*>(input_column));
+    auto const* tz_name_to_index = std::bit_cast<cudf::column_view const*>(tz_name_to_index_map);
+    auto const* timezone_info    = std::bit_cast<cudf::table_view const*>(timezone_info_table);
     auto const spark_system =
       spark_rapids_jni::spark_system(platform, majorVersion, minorVersion, patchVersion);
     return cudf::jni::release_as_jlong(
@@ -369,7 +371,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_parseDateSt
     cudf::jni::auto_set_device(env);
 
     auto const input_view =
-      cudf::strings_column_view(*reinterpret_cast<cudf::column_view const*>(input_column));
+      cudf::strings_column_view(*std::bit_cast<cudf::column_view const*>(input_column));
     return cudf::jni::release_as_jlong(spark_rapids_jni::parse_strings_to_date(input_view));
   }
   JNI_CATCH(env, 0);
@@ -385,7 +387,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimest
     cudf::jni::auto_set_device(env);
 
     auto const input_view =
-      cudf::strings_column_view(*reinterpret_cast<cudf::column_view const*>(input_column));
+      cudf::strings_column_view(*std::bit_cast<cudf::column_view const*>(input_column));
     auto const format_jstr = cudf::jni::native_jstring(env, j_format);
     auto const format      = std::string(format_jstr.get(), format_jstr.size_bytes());
     return cudf::jni::release_as_jlong(spark_rapids_jni::parse_timestamp_strings_with_format(

--- a/src/main/cpp/src/CharsetDecodeJni.cpp
+++ b/src/main/cpp/src/CharsetDecodeJni.cpp
@@ -20,6 +20,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <bit>
+
 extern "C" {
 
 /**
@@ -36,7 +38,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CharsetDecode_decodeNat
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = *reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input = *std::bit_cast<cudf::column_view const*>(input_column);
     auto result =
       spark_rapids_jni::decode_charset(input,
                                        static_cast<spark_rapids_jni::charset_type>(charset),

--- a/src/main/cpp/src/DateTimeUtilsJni.cpp
+++ b/src/main/cpp/src/DateTimeUtilsJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "datetime_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_rebaseGregorianToJulian(
@@ -27,9 +29,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_rebaseGre
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::rebase_gregorian_to_julian(*input_cv);
-    return reinterpret_cast<jlong>(output.release());
+    return std::bit_cast<jlong>(output.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -42,9 +44,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_rebaseJul
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::rebase_julian_to_gregorian(*input_cv);
-    return reinterpret_cast<jlong>(output.release());
+    return std::bit_cast<jlong>(output.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -59,9 +61,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_truncateW
   {
     cudf::jni::auto_set_device(env);
 
-    auto const datetime_cv = reinterpret_cast<cudf::column_view const*>(datetime);
-    auto const format_cv   = reinterpret_cast<cudf::column_view const*>(format);
-    return reinterpret_cast<jlong>(spark_rapids_jni::truncate(*datetime_cv, *format_cv).release());
+    auto const datetime_cv = std::bit_cast<cudf::column_view const*>(datetime);
+    auto const format_cv   = std::bit_cast<cudf::column_view const*>(format);
+    return std::bit_cast<jlong>(spark_rapids_jni::truncate(*datetime_cv, *format_cv).release());
   }
   JNI_CATCH(env, 0);
 }
@@ -75,10 +77,10 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_truncateW
   {
     cudf::jni::auto_set_device(env);
 
-    auto const datetime_cv = reinterpret_cast<cudf::column_view const*>(datetime);
+    auto const datetime_cv = std::bit_cast<cudf::column_view const*>(datetime);
     auto const format_jstr = cudf::jni::native_jstring(env, format);
     auto const format      = std::string(format_jstr.get(), format_jstr.size_bytes());
-    return reinterpret_cast<jlong>(spark_rapids_jni::truncate(*datetime_cv, format).release());
+    return std::bit_cast<jlong>(spark_rapids_jni::truncate(*datetime_cv, format).release());
   }
   JNI_CATCH(env, 0);
 }

--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "decimal_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlongArray JNICALL
@@ -32,8 +34,8 @@ Java_com_nvidia_spark_rapids_jni_DecimalUtils_multiply128(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
-    auto view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
+    auto view_a = std::bit_cast<cudf::column_view const*>(j_view_a);
+    auto view_b = std::bit_cast<cudf::column_view const*>(j_view_b);
     auto scale  = static_cast<int>(j_product_scale);
     return cudf::jni::convert_table_for_return(
       env, cudf::jni::multiply_decimal128(*view_a, *view_b, scale, cast_interim_result));
@@ -49,8 +51,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_divid
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto view_a          = reinterpret_cast<cudf::column_view const*>(j_view_a);
-    auto view_b          = reinterpret_cast<cudf::column_view const*>(j_view_b);
+    auto view_a          = std::bit_cast<cudf::column_view const*>(j_view_a);
+    auto view_b          = std::bit_cast<cudf::column_view const*>(j_view_b);
     auto scale           = static_cast<int>(j_quotient_scale);
     auto is_int_division = static_cast<bool>(j_is_int_div);
     if (is_int_division) {
@@ -72,8 +74,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_remai
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
-    auto view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
+    auto view_a = std::bit_cast<cudf::column_view const*>(j_view_a);
+    auto view_b = std::bit_cast<cudf::column_view const*>(j_view_b);
     auto scale  = static_cast<int>(j_remainder_scale);
     return cudf::jni::convert_table_for_return(
       env, cudf::jni::remainder_decimal128(*view_a, *view_b, scale));
@@ -89,8 +91,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_add12
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
-    auto const view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
+    auto const view_a = std::bit_cast<cudf::column_view const*>(j_view_a);
+    auto const view_b = std::bit_cast<cudf::column_view const*>(j_view_b);
     auto const scale  = static_cast<int>(j_target_scale);
     return cudf::jni::convert_table_for_return(env,
                                                cudf::jni::add_decimal128(*view_a, *view_b, scale));
@@ -106,8 +108,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_subtr
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
-    auto const view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
+    auto const view_a = std::bit_cast<cudf::column_view const*>(j_view_a);
+    auto const view_b = std::bit_cast<cudf::column_view const*>(j_view_b);
     auto const scale  = static_cast<int>(j_target_scale);
     return cudf::jni::convert_table_for_return(env,
                                                cudf::jni::sub_decimal128(*view_a, *view_b, scale));
@@ -122,7 +124,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_float
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto const input = std::bit_cast<cudf::column_view const*>(j_input);
     cudf::jni::native_jlongArray output(env, 2);
 
     auto [casted_col, failure_row_id] = cudf::jni::floating_point_to_decimal(

--- a/src/main/cpp/src/GpuTimeZoneDBJni.cpp
+++ b/src/main/cpp/src/GpuTimeZoneDBJni.cpp
@@ -30,8 +30,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTi
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input         = reinterpret_cast<cudf::column_view const*>(input_handle);
-    auto const timezone_info = reinterpret_cast<cudf::table_view const*>(timezone_info_handle);
+    auto const input         = std::bit_cast<cudf::column_view const*>(input_handle);
+    auto const timezone_info = std::bit_cast<cudf::table_view const*>(timezone_info_handle);
     auto const index         = static_cast<cudf::size_type>(tz_index);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::convert_timestamp_to_utc(*input, *timezone_info, index).release());
@@ -48,8 +48,8 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertUTCTimestampColumnToTimeZo
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input         = reinterpret_cast<cudf::column_view const*>(input_handle);
-    auto const timezone_info = reinterpret_cast<cudf::table_view const*>(timezone_info_handle);
+    auto const input         = std::bit_cast<cudf::column_view const*>(input_handle);
+    auto const timezone_info = std::bit_cast<cudf::table_view const*>(timezone_info_handle);
     auto const index         = static_cast<cudf::size_type>(tz_index);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::convert_utc_timestamp_to_timezone(*input, *timezone_info, index).release());
@@ -80,14 +80,14 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTimestampColumnToUTCWithTz
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_seconds = reinterpret_cast<cudf::column_view const*>(input_seconds_handle);
+    auto const input_seconds = std::bit_cast<cudf::column_view const*>(input_seconds_handle);
     auto const input_microseconds =
-      reinterpret_cast<cudf::column_view const*>(input_microseconds_handle);
-    auto const invalid       = reinterpret_cast<cudf::column_view const*>(invalid_handle);
-    auto const tz_type       = reinterpret_cast<cudf::column_view const*>(tz_type_handle);
-    auto const tz_offset     = reinterpret_cast<cudf::column_view const*>(tz_offset_handle);
-    auto const timezone_info = reinterpret_cast<cudf::table_view const*>(timezone_info_handle);
-    auto const tz_indices    = reinterpret_cast<cudf::column_view const*>(tz_indices_handle);
+      std::bit_cast<cudf::column_view const*>(input_microseconds_handle);
+    auto const invalid       = std::bit_cast<cudf::column_view const*>(invalid_handle);
+    auto const tz_type       = std::bit_cast<cudf::column_view const*>(tz_type_handle);
+    auto const tz_offset     = std::bit_cast<cudf::column_view const*>(tz_offset_handle);
+    auto const timezone_info = std::bit_cast<cudf::table_view const*>(timezone_info_handle);
+    auto const tz_indices    = std::bit_cast<cudf::column_view const*>(tz_indices_handle);
 
     return cudf::jni::ptr_as_jlong(spark_rapids_jni::convert_timestamp_to_utc(*input_seconds,
                                                                               *input_microseconds,
@@ -149,9 +149,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOr
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input              = reinterpret_cast<cudf::column_view const*>(input_handle);
-    auto const writer_tz_info_tab = reinterpret_cast<cudf::table_view const*>(writer_tz_info_table);
-    auto const reader_tz_info_tab = reinterpret_cast<cudf::table_view const*>(reader_tz_info_table);
+    auto const input              = std::bit_cast<cudf::column_view const*>(input_handle);
+    auto const writer_tz_info_tab = std::bit_cast<cudf::table_view const*>(writer_tz_info_table);
+    auto const reader_tz_info_tab = std::bit_cast<cudf::table_view const*>(reader_tz_info_table);
     auto const writer_dst         = parse_dst_rule(env, writer_dst_rule);
     cudf::jni::check_java_exception(env);
     auto const reader_dst = parse_dst_rule(env, reader_dst_rule);

--- a/src/main/cpp/src/HistogramJni.cpp
+++ b/src/main/cpp/src/HistogramJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "histogram.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_createHistogramIfValid(
@@ -29,8 +31,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_createHistogr
   {
     cudf::jni::auto_set_device(env);
 
-    auto const values      = reinterpret_cast<cudf::column_view const*>(values_handle);
-    auto const frequencies = reinterpret_cast<cudf::column_view const*>(frequencies_handle);
+    auto const values      = std::bit_cast<cudf::column_view const*>(values_handle);
+    auto const frequencies = std::bit_cast<cudf::column_view const*>(frequencies_handle);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::create_histogram_if_valid(*values, *frequencies, output_as_lists)
         .release());
@@ -48,7 +50,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_percentileFro
   {
     cudf::jni::auto_set_device(env);
 
-    auto const input       = reinterpret_cast<cudf::column_view const*>(input_handle);
+    auto const input       = std::bit_cast<cudf::column_view const*>(input_handle);
     auto const percentages = [&] {
       auto const native_percentages = cudf::jni::native_jdoubleArray(env, jpercentages);
       return std::vector<double>(native_percentages.begin(), native_percentages.end());

--- a/src/main/cpp/src/HostTableJni.cpp
+++ b/src/main/cpp/src/HostTableJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
+#include <bit>
 #include <memory>
 #include <numeric>
 #include <stdexcept>
@@ -108,7 +109,7 @@ uint8_t* build_host_column_view_async(cudf::column_view const& dev_col,
   }
   cudf::bitmask_type const* host_null_mask = nullptr;
   if (dev_col.has_nulls()) {
-    host_null_mask = reinterpret_cast<cudf::bitmask_type const*>(bp);
+    host_null_mask = std::bit_cast<cudf::bitmask_type const*>(bp);
     auto mask_size = cudf::bitmask_allocation_size_bytes(dev_col.size());
     bp             = copy_to_host_async(dev_col.null_mask(), bp, mask_size, bp_end, stream);
   }
@@ -182,8 +183,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_bufferSize(JN
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto t      = reinterpret_cast<cudf::table_view const*>(table_handle);
-    auto stream = reinterpret_cast<cudaStream_t>(jstream);
+    auto t      = std::bit_cast<cudf::table_view const*>(table_handle);
+    auto stream = std::bit_cast<cudaStream_t>(jstream);
     return static_cast<jlong>(host_buffer_size(*t, stream));
   }
   JNI_CATCH(env, 0);
@@ -196,12 +197,12 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_copyFromTable
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto table           = reinterpret_cast<cudf::table_view const*>(table_handle);
-    auto buffer          = reinterpret_cast<uint8_t*>(host_address);
+    auto table           = std::bit_cast<cudf::table_view const*>(table_handle);
+    auto buffer          = std::bit_cast<uint8_t*>(host_address);
     auto buffer_size     = static_cast<std::size_t>(host_size);
-    auto stream          = reinterpret_cast<cudaStream_t>(jstream);
+    auto stream          = std::bit_cast<cudaStream_t>(jstream);
     auto host_table_view = to_host_table_async(*table, buffer, buffer_size, stream);
-    return reinterpret_cast<jlong>(host_table_view.release());
+    return std::bit_cast<jlong>(host_table_view.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -215,7 +216,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_toDevice
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto host_table = reinterpret_cast<spark_rapids_jni::host_table_view const*>(table_handle);
+    auto host_table       = std::bit_cast<spark_rapids_jni::host_table_view const*>(table_handle);
     auto column_view_ptrs = to_device_column_views(*host_table, host_to_dev_offset);
     cudf::jni::native_jlongArray handles(env, static_cast<int>(column_view_ptrs.size()));
     std::transform(
@@ -232,7 +233,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_freeDeviceColu
   JNIEnv* env, jclass, jlong dev_column_view_handle)
 {
   JNI_NULL_CHECK(env, dev_column_view_handle, "view is null", );
-  JNI_TRY { delete reinterpret_cast<cudf::column_view*>(dev_column_view_handle); }
+  JNI_TRY { delete std::bit_cast<cudf::column_view*>(dev_column_view_handle); }
   JNI_CATCH(env, );
 }
 
@@ -241,7 +242,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_freeHostTable(
                                                                                 jlong table_handle)
 {
   JNI_NULL_CHECK(env, table_handle, "table is null", );
-  JNI_TRY { delete reinterpret_cast<host_table_view*>(table_handle); }
+  JNI_TRY { delete std::bit_cast<host_table_view*>(table_handle); }
   JNI_CATCH(env, );
 }
 

--- a/src/main/cpp/src/HyperLogLogPlusPlusHostUDFJni.cpp
+++ b/src/main/cpp/src/HyperLogLogPlusPlusHostUDFJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "hyper_log_log_plus_plus.hpp"
 #include "hyper_log_log_plus_plus_host_udf.hpp"
+
+#include <bit>
 
 extern "C" {
 
@@ -41,7 +43,7 @@ Java_com_nvidia_spark_rapids_jni_HyperLogLogPlusPlusHostUDF_createHLLPPHostUDF(J
     }();
     CUDF_EXPECTS(udf_ptr != nullptr, "Invalid HyperLogLogPlusPlus(HLLPP) UDF instance.");
 
-    return reinterpret_cast<jlong>(udf_ptr);
+    return std::bit_cast<jlong>(udf_ptr);
   }
   JNI_CATCH(env, 0);
 }
@@ -54,7 +56,7 @@ Java_com_nvidia_spark_rapids_jni_HyperLogLogPlusPlusHostUDF_estimateDistinctValu
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const sketch_view = reinterpret_cast<cudf::column_view const*>(sketches);
+    auto const sketch_view = std::bit_cast<cudf::column_view const*>(sketches);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::estimate_from_hll_sketches(*sketch_view, precision).release());
   }

--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -20,6 +20,7 @@
 
 #include <cudf/strings/strings_column_view.hpp>
 
+#include <bit>
 #include <vector>
 
 using path_instruction_type = spark_rapids_jni::path_instruction_type;
@@ -52,7 +53,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const n_column_view      = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const n_column_view      = std::bit_cast<cudf::column_view const*>(input_column);
     auto const n_strings_col_view = cudf::strings_column_view{*n_column_view};
 
     std::vector<std::tuple<path_instruction_type, std::string, int32_t>> instructions;
@@ -133,7 +134,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
       paths[i] = std::move(path);
     }
 
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(j_input);
     auto output         = spark_rapids_jni::get_json_object_multiple_paths(
       cudf::strings_column_view{*input_cv}, paths, memory_budget_bytes, parallel_override);
 
@@ -160,7 +161,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_extractRawMap
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(j_input);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::from_json_to_raw_map(
         cudf::strings_column_view{*input_cv},
@@ -188,7 +189,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_extractRawMap
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(j_input);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::from_json_to_raw_map_array_values(
         cudf::strings_column_view{*input_cv},
@@ -228,7 +229,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_fromJSONToStructs(JNIEnv* env,
   {
     cudf::jni::auto_set_device(env);
 
-    auto const input_cv     = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto const input_cv     = std::bit_cast<cudf::column_view const*>(j_input);
     auto const col_names    = cudf::jni::native_jstringArray(env, j_col_names).as_cpp_vector();
     auto const num_children = cudf::jni::native_jintArray(env, j_num_children).to_vector();
     auto const types        = cudf::jni::native_jintArray(env, j_types).to_vector();
@@ -279,7 +280,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_convertFromStrings(JNIEnv* env,
   {
     cudf::jni::auto_set_device(env);
 
-    auto const input_cv     = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto const input_cv     = std::bit_cast<cudf::column_view const*>(j_input);
     auto const num_children = cudf::jni::native_jintArray(env, j_num_children).to_vector();
     auto const types        = cudf::jni::native_jintArray(env, j_types).to_vector();
     auto const scales       = cudf::jni::native_jintArray(env, j_scales).to_vector();
@@ -311,7 +312,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_removeQuotes(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(j_input);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::remove_quotes(cudf::strings_column_view{*input_cv}, nullify_if_not_quoted)
         .release());

--- a/src/main/cpp/src/JoinPrimitivesJni.cpp
+++ b/src/main/cpp/src/JoinPrimitivesJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 #include <cudf/types.hpp>
 
 #include <rmm/device_uvector.hpp>
+
+#include <bit>
 
 namespace {
 
@@ -107,8 +109,8 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeSortMergeInnerJoin(JNIEnv*
   {
     cudf::jni::auto_set_device(env);
 
-    auto const left_keys  = reinterpret_cast<cudf::table_view const*>(j_left_keys);
-    auto const right_keys = reinterpret_cast<cudf::table_view const*>(j_right_keys);
+    auto const left_keys  = std::bit_cast<cudf::table_view const*>(j_left_keys);
+    auto const right_keys = std::bit_cast<cudf::table_view const*>(j_right_keys);
 
     auto const is_left_sorted  = j_is_left_sorted ? cudf::sorted::YES : cudf::sorted::NO;
     auto const is_right_sorted = j_is_right_sorted ? cudf::sorted::YES : cudf::sorted::NO;
@@ -133,8 +135,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nat
   {
     cudf::jni::auto_set_device(env);
 
-    auto const left_keys  = reinterpret_cast<cudf::table_view const*>(j_left_keys);
-    auto const right_keys = reinterpret_cast<cudf::table_view const*>(j_right_keys);
+    auto const left_keys  = std::bit_cast<cudf::table_view const*>(j_left_keys);
+    auto const right_keys = std::bit_cast<cudf::table_view const*>(j_right_keys);
 
     auto const nulls_equal =
       j_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
@@ -190,15 +192,15 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeFilterGatherMapsByAST(
   {
     cudf::jni::auto_set_device(env);
 
-    auto const left_table  = reinterpret_cast<cudf::table_view const*>(j_left_table);
-    auto const right_table = reinterpret_cast<cudf::table_view const*>(j_right_table);
-    auto const condition   = reinterpret_cast<cudf::jni::ast::compiled_expr const*>(j_condition);
+    auto const left_table  = std::bit_cast<cudf::table_view const*>(j_left_table);
+    auto const right_table = std::bit_cast<cudf::table_view const*>(j_right_table);
+    auto const condition   = std::bit_cast<cudf::jni::ast::compiled_expr const*>(j_condition);
 
     // Wrap buffer addresses as device_spans (zero-copy, does not take ownership)
     auto left_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_left_buffer_address), j_left_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_left_buffer_address), j_left_buffer_length);
     auto right_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_right_buffer_address), j_right_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_right_buffer_address), j_right_buffer_length);
 
     auto result = spark_rapids_jni::filter_gather_maps_by_ast(
       left_indices, right_indices, *left_table, *right_table, condition->get_top_expression());
@@ -249,9 +251,9 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeMakeLeftOuter(JNIEnv* env,
 
     // Wrap buffer addresses as device_spans (zero-copy, does not take ownership)
     auto left_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_left_buffer_address), j_left_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_left_buffer_address), j_left_buffer_length);
     auto right_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_right_buffer_address), j_right_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_right_buffer_address), j_right_buffer_length);
 
     auto result = spark_rapids_jni::make_left_outer(
       left_indices, right_indices, j_left_table_size, j_right_table_size);
@@ -298,9 +300,9 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeMakeFullOuter(JNIEnv* env,
 
     // Wrap buffer addresses as device_spans (zero-copy, does not take ownership)
     auto left_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_left_buffer_address), j_left_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_left_buffer_address), j_left_buffer_length);
     auto right_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_right_buffer_address), j_right_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_right_buffer_address), j_right_buffer_length);
 
     auto result = spark_rapids_jni::make_full_outer(
       left_indices, right_indices, j_left_table_size, j_right_table_size);
@@ -335,7 +337,7 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeMakeSemi(JNIEnv* env,
 
     // Wrap buffer address as device_span (zero-copy, does not take ownership)
     auto left_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_left_buffer_address), j_left_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_left_buffer_address), j_left_buffer_length);
 
     auto result = spark_rapids_jni::make_semi(left_indices, j_left_table_size);
 
@@ -365,7 +367,7 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeMakeAnti(JNIEnv* env,
 
     // Wrap buffer address as device_span (zero-copy, does not take ownership)
     auto left_indices =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_left_buffer_address), j_left_buffer_length);
+      wrap_buffer_as_span(std::bit_cast<void*>(j_left_buffer_address), j_left_buffer_length);
 
     auto result = spark_rapids_jni::make_anti(left_indices, j_left_table_size);
 
@@ -394,8 +396,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeGe
     cudf::jni::auto_set_device(env);
 
     // Wrap buffer address as device_span (zero-copy, does not take ownership)
-    auto gather_map =
-      wrap_buffer_as_span(reinterpret_cast<void*>(j_buffer_address), j_buffer_length);
+    auto gather_map = wrap_buffer_as_span(std::bit_cast<void*>(j_buffer_address), j_buffer_length);
 
     auto result = spark_rapids_jni::get_matched_rows(gather_map, j_table_size);
 

--- a/src/main/cpp/src/KudoGpuSerializerJni.cpp
+++ b/src/main/cpp/src/KudoGpuSerializerJni.cpp
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "shuffle_split.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlongArray JNICALL
@@ -29,7 +31,7 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_splitAndSerializeToDevic
   {
     cudf::jni::auto_set_device(env);
 
-    auto table = reinterpret_cast<cudf::table_view const*>(j_table_view);
+    auto table = std::bit_cast<cudf::table_view const*>(j_table_view);
     cudf::jni::native_jintArray const n_splits(env, j_splits);
     std::vector<cudf::size_type> splits = n_splits.to_vector<int>();
 
@@ -46,17 +48,17 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_splitAndSerializeToDevic
     // then either leak it or release the memory held by it, but that is not technically
     // the case.
     cudf::jni::native_jlongArray result(env, 6);
-    result[0] = reinterpret_cast<jlong>(split_result.partitions->data());
+    result[0] = std::bit_cast<jlong>(split_result.partitions->data());
     result[1] = static_cast<jlong>(split_result.partitions->size());
-    result[2] = reinterpret_cast<jlong>(split_result.partitions.release());
+    result[2] = std::bit_cast<jlong>(split_result.partitions.release());
 
     // split_result.offsets is an rmm::device_uvector<size_t> so we have to
     // pull out the rmm::device_buffer * from inside it to return the data in a way that
     // java can handle it.
     auto offsets = std::make_unique<rmm::device_buffer>(std::move(split_result.offsets.release()));
-    result[3]    = reinterpret_cast<jlong>(offsets->data());
+    result[3]    = std::bit_cast<jlong>(offsets->data());
     result[4]    = static_cast<jlong>(offsets->size());
-    result[5]    = reinterpret_cast<jlong>(offsets.release());
+    result[5]    = std::bit_cast<jlong>(offsets.release());
 
     return result.get_jArray();
   }
@@ -85,8 +87,8 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_assembleFromDeviceRawNat
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::device_span<uint8_t const> partitions(reinterpret_cast<uint8_t*>(part_addr), part_len);
-    cudf::device_span<size_t const> offsets(reinterpret_cast<size_t*>(offset_addr),
+    cudf::device_span<uint8_t const> partitions(std::bit_cast<uint8_t*>(part_addr), part_len);
+    cudf::device_span<size_t const> offsets(std::bit_cast<size_t*>(offset_addr),
                                             offset_len / sizeof(size_t));
 
     cudf::jni::native_jintArray nnc(env, flat_num_children);

--- a/src/main/cpp/src/ListSliceJni.cpp
+++ b/src/main/cpp/src/ListSliceJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "list_slice.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceIntInt(
@@ -29,7 +31,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
 
     // The following constructor expects that the type of the input_column is LIST.
     // If the type is not LIST, an exception will be thrown.
-    cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
+    cudf::lists_column_view lcv{*std::bit_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start, length, check_start_length));
   }
@@ -47,8 +49,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
 
     // The following constructor expects that the type of the input_column is LIST.
     // If the type is not LIST, an exception will be thrown.
-    cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
-    auto const& length_cv = *reinterpret_cast<cudf::column_view const*>(length);
+    cudf::lists_column_view lcv{*std::bit_cast<cudf::column_view const*>(input_column)};
+    auto const& length_cv = *std::bit_cast<cudf::column_view const*>(length);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start, length_cv, check_start_length));
   }
@@ -66,8 +68,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
 
     // The following constructor expects that the type of the input_column is LIST.
     // If the type is not LIST, an exception will be thrown.
-    cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
-    auto const& start_cv = *reinterpret_cast<cudf::column_view const*>(start);
+    cudf::lists_column_view lcv{*std::bit_cast<cudf::column_view const*>(input_column)};
+    auto const& start_cv = *std::bit_cast<cudf::column_view const*>(start);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start_cv, length, check_start_length));
   }
@@ -86,9 +88,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
 
     // The following constructor expects that the type of the input_column is LIST.
     // If the type is not LIST, an exception will be thrown.
-    cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
-    auto const& start_cv  = *reinterpret_cast<cudf::column_view const*>(start);
-    auto const& length_cv = *reinterpret_cast<cudf::column_view const*>(length);
+    cudf::lists_column_view lcv{*std::bit_cast<cudf::column_view const*>(input_column)};
+    auto const& start_cv  = *std::bit_cast<cudf::column_view const*>(start);
+    auto const& length_cv = *std::bit_cast<cudf::column_view const*>(length);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start_cv, length_cv, check_start_length));
   }

--- a/src/main/cpp/src/MapJni.cpp
+++ b/src/main/cpp/src/MapJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 #include "jni_utils.hpp"
 #include "map.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong Java_com_nvidia_spark_rapids_jni_Map_sort(JNIEnv* env,
@@ -31,7 +33,7 @@ JNIEXPORT jlong Java_com_nvidia_spark_rapids_jni_Map_sort(JNIEnv* env,
   {
     cudf::jni::auto_set_device(env);
     auto sort_order = is_descending ? cudf::order::DESCENDING : cudf::order::ASCENDING;
-    cudf::column_view const& map_view = *reinterpret_cast<cudf::column_view const*>(map_haldle);
+    cudf::column_view const& map_view = *std::bit_cast<cudf::column_view const*>(map_haldle);
     return cudf::jni::release_as_jlong(spark_rapids_jni::sort_map_column(map_view, sort_order));
   }
   JNI_CATCH(env, 0);

--- a/src/main/cpp/src/MapUtilsJni.cpp
+++ b/src/main/cpp/src/MapUtilsJni.cpp
@@ -18,6 +18,8 @@
 #include "jni_utils.hpp"
 #include "map_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jboolean JNICALL Java_com_nvidia_spark_rapids_jni_MapUtils_isValidMap(
@@ -27,7 +29,7 @@ JNIEXPORT jboolean JNICALL Java_com_nvidia_spark_rapids_jni_MapUtils_isValidMap(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const& input = *reinterpret_cast<cudf::column_view const*>(input_handle);
+    auto const& input = *std::bit_cast<cudf::column_view const*>(input_handle);
     return spark_rapids_jni::is_valid_map(input, static_cast<bool>(throw_on_null_key)) ? JNI_TRUE
                                                                                        : JNI_FALSE;
   }
@@ -41,7 +43,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_MapUtils_mapFromEntries
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const& input = *reinterpret_cast<cudf::column_view const*>(input_handle);
+    auto const& input = *std::bit_cast<cudf::column_view const*>(input_handle);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::map_from_entries(input, static_cast<bool>(throw_on_null_key)));
   }

--- a/src/main/cpp/src/MapZipWithUtilsJNI.cpp
+++ b/src/main/cpp/src/MapZipWithUtilsJNI.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 #include "cudf_jni_apis.hpp"
 #include "map_zip_with_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuMapZipWithUtils_mapZip(
@@ -26,8 +28,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuMapZipWithUtils_mapZ
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    cudf::lists_column_view col1{*reinterpret_cast<cudf::column_view const*>(input_column1)};
-    cudf::lists_column_view col2{*reinterpret_cast<cudf::column_view const*>(input_column2)};
+    cudf::lists_column_view col1{*std::bit_cast<cudf::column_view const*>(input_column1)};
+    cudf::lists_column_view col2{*std::bit_cast<cudf::column_view const*>(input_column2)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::map_zip(col1, col2));
   }
   JNI_CATCH(env, 0);

--- a/src/main/cpp/src/NVMLJni.cpp
+++ b/src/main/cpp/src/NVMLJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <nvml.h>
 #include <stdio.h>
 
+#include <bit>
 #include <cstdint>
 
 // NVML JNI implementation with comprehensive GPU metrics for Spark Rapids
@@ -473,14 +474,13 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetDevice
 
   if (nvml_error != NVML_SUCCESS) { return 0; }
 
-  return static_cast<jlong>(
-    reinterpret_cast<std::intptr_t>(device));  // Return the handle as a long
+  return static_cast<jlong>(std::bit_cast<std::intptr_t>(device));  // Return the handle as a long
 }
 
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetGPUInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
 
   // Use common helper to populate GPUInfo object
   nvml_result result = populate_gpu_info_from_device(env, device);
@@ -538,7 +538,7 @@ Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetAllGPUInfo(JNIEnv* env, jclass
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetDeviceInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_device_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -546,7 +546,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetDevi
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetUtilizationInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_utilization_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -554,7 +554,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetUtil
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetMemoryInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_memory_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -562,7 +562,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetMemo
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetTemperatureInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_temperature_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -570,7 +570,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetTemp
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetPowerInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_power_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -578,7 +578,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetPowe
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetClockInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_clock_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -586,7 +586,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetCloc
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetHardwareInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_hardware_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -594,7 +594,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetHard
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetPCIeInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_pcie_info(env, device);
   return create_nvml_result(env, result);
 }
@@ -602,7 +602,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetPCIe
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_nvml_NVML_nvmlGetECCInfo(
   JNIEnv* env, jclass cls, jlong deviceHandle)
 {
-  nvmlDevice_t device = reinterpret_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
+  nvmlDevice_t device = std::bit_cast<nvmlDevice_t>(static_cast<std::intptr_t>(deviceHandle));
   nvml_result result  = populate_ecc_info(env, device);
   return create_nvml_result(env, result);
 }

--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <bit>
 #include <cwctype>
 #include <limits>
 #include <sstream>
@@ -757,7 +758,7 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
     auto meta    = std::make_unique<parquet::format::FileMetaData>();
     uint32_t len = static_cast<uint32_t>(buffer_length);
     // We don't support encrypted parquet...
-    rapids::jni::deserialize_parquet_footer(reinterpret_cast<uint8_t*>(buffer), len, meta.get());
+    rapids::jni::deserialize_parquet_footer(std::bit_cast<uint8_t*>(buffer), len, meta.get());
 
     // Get the filter for the columns first...
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -822,7 +823,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_close(JNIE
 {
   JNI_TRY
   {
-    auto* ptr = reinterpret_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
+    auto* ptr = std::bit_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
     delete ptr;
   }
   JNI_CATCH(env, );
@@ -834,7 +835,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumRow
 {
   JNI_TRY
   {
-    auto* footer = reinterpret_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
+    auto* footer = std::bit_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
     long ret     = 0;
     for (auto it = footer->meta->row_groups.begin(); it != footer->meta->row_groups.end(); ++it) {
       ret = ret + it->num_rows;
@@ -850,7 +851,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumCol
 {
   JNI_TRY
   {
-    auto* footer = reinterpret_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
+    auto* footer = std::bit_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
     int ret      = 0;
     if (footer->meta->schema.size() > 0) {
       if (footer->meta->schema[0].__isset.num_children) {
@@ -868,7 +869,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_seriali
   SRJ_FUNC_RANGE();
   JNI_TRY
   {
-    auto* footer = reinterpret_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
+    auto* footer = std::bit_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
     std::shared_ptr<apache::thrift::transport::TMemoryBuffer> transportOut(
       new apache::thrift::transport::TMemoryBuffer());
     apache::thrift::protocol::TCompactProtocolFactoryT<apache::thrift::transport::TMemoryBuffer>
@@ -881,7 +882,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_seriali
 
     // 12 extra is for the MAGIC thrift_footer length MAGIC
     jobject ret = cudf::jni::allocate_host_buffer(env, buf_size + 12, false, host_memory_allocator);
-    uint8_t* ret_addr = reinterpret_cast<uint8_t*>(cudf::jni::get_host_buffer_address(env, ret));
+    uint8_t* ret_addr = std::bit_cast<uint8_t*>(cudf::jni::get_host_buffer_address(env, ret));
     ret_addr[0]       = 'P';
     ret_addr[1]       = 'A';
     ret_addr[2]       = 'R';
@@ -906,10 +907,10 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_getRowIndexOffsets(JNIEnv* env, j
 {
   JNI_TRY
   {
-    auto* footer = reinterpret_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
+    auto* footer = std::bit_cast<rapids::jni::parquet_footer_with_row_group_offsets*>(handle);
     auto const& offsets = footer->row_index_offsets;
     cudf::jni::native_jlongArray result(
-      env, reinterpret_cast<jlong const*>(offsets.data()), static_cast<int>(offsets.size()));
+      env, std::bit_cast<jlong const*>(offsets.data()), static_cast<int>(offsets.size()));
     return result.get_jArray();
   }
   JNI_CATCH(env, nullptr);

--- a/src/main/cpp/src/NumberConverterJni.cpp
+++ b/src/main/cpp/src/NumberConverterJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 #include "cudf_jni_apis.hpp"
 #include "number_converter.hpp"
+
+#include <bit>
 
 extern "C" {
 
@@ -38,15 +40,13 @@ Java_com_nvidia_spark_rapids_jni_NumberConverter_convert(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_variant     = is_input_cv
-                                     ? variant_t{*reinterpret_cast<cudf::column_view*>(input)}
-                                     : variant_t{*reinterpret_cast<cudf::string_scalar*>(input)};
+    auto const input_variant = is_input_cv ? variant_t{*std::bit_cast<cudf::column_view*>(input)}
+                                           : variant_t{*std::bit_cast<cudf::string_scalar*>(input)};
     auto const from_base_variant = is_from_cv
-                                     ? variant_t{*reinterpret_cast<cudf::column_view*>(from_base)}
+                                     ? variant_t{*std::bit_cast<cudf::column_view*>(from_base)}
                                      : variant_t{static_cast<int>(from_base)};
-    auto const to_base_variant   = is_to_cv
-                                     ? variant_t{*reinterpret_cast<cudf::column_view*>(to_base)}
-                                     : variant_t{static_cast<int>(to_base)};
+    auto const to_base_variant   = is_to_cv ? variant_t{*std::bit_cast<cudf::column_view*>(to_base)}
+                                            : variant_t{static_cast<int>(to_base)};
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::convert(input_variant, from_base_variant, to_base_variant));
   }
@@ -70,15 +70,13 @@ Java_com_nvidia_spark_rapids_jni_NumberConverter_isConvertOverflow(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_variant     = is_input_cv
-                                     ? variant_t{*reinterpret_cast<cudf::column_view*>(input)}
-                                     : variant_t{*reinterpret_cast<cudf::string_scalar*>(input)};
+    auto const input_variant = is_input_cv ? variant_t{*std::bit_cast<cudf::column_view*>(input)}
+                                           : variant_t{*std::bit_cast<cudf::string_scalar*>(input)};
     auto const from_base_variant = is_from_cv
-                                     ? variant_t{*reinterpret_cast<cudf::column_view*>(from_base)}
+                                     ? variant_t{*std::bit_cast<cudf::column_view*>(from_base)}
                                      : variant_t{static_cast<int>(from_base)};
-    auto const to_base_variant   = is_to_cv
-                                     ? variant_t{*reinterpret_cast<cudf::column_view*>(to_base)}
-                                     : variant_t{static_cast<int>(to_base)};
+    auto const to_base_variant   = is_to_cv ? variant_t{*std::bit_cast<cudf::column_view*>(to_base)}
+                                            : variant_t{static_cast<int>(to_base)};
     return spark_rapids_jni::is_convert_overflow(input_variant, from_base_variant, to_base_variant);
   }
   JNI_CATCH(env, 0);

--- a/src/main/cpp/src/ParseURIJni.cpp
+++ b/src/main/cpp/src/ParseURIJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 #include "exception_with_row_index.hpp"
 #include "parse_uri.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseProtocol(JNIEnv* env,
@@ -31,7 +33,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseProtocol(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::parse_uri_to_protocol(*input, static_cast<bool>(ansi_mode)).release());
   }
@@ -48,7 +50,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseHost(JNIE
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::parse_uri_to_host(*input, static_cast<bool>(ansi_mode)).release());
   }
@@ -65,7 +67,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQuery(JNI
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::parse_uri_to_query(*input, static_cast<bool>(ansi_mode)).release());
   }
@@ -81,7 +83,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWith
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_column);
     cudf::jni::native_jstring native_query(env, query);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::parse_uri_to_query(
@@ -100,8 +102,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWith
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
-    auto const query = reinterpret_cast<cudf::column_view const*>(query_column);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_column);
+    auto const query = std::bit_cast<cudf::column_view const*>(query_column);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::parse_uri_to_query(*input, *query, static_cast<bool>(ansi_mode)).release());
   }
@@ -118,7 +120,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parsePath(JNIE
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::parse_uri_to_path(*input, static_cast<bool>(ansi_mode)).release());
   }

--- a/src/main/cpp/src/ProtobufJni.cpp
+++ b/src/main/cpp/src/ProtobufJni.cpp
@@ -20,6 +20,8 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+#include <bit>
+
 namespace {
 
 /**
@@ -60,8 +62,7 @@ cudf::detail::host_vector<uint8_t> jni_byte_array_to_vector(JNIEnv* env, jobject
     return cudf::detail::make_host_vector<uint8_t>(0, cudf::get_default_stream());
   }
   auto vec = cudf::detail::make_host_vector<uint8_t>(len, cudf::get_default_stream());
-  std::copy(
-    reinterpret_cast<uint8_t*>(bytes), reinterpret_cast<uint8_t*>(bytes) + len, vec.begin());
+  std::copy(std::bit_cast<uint8_t*>(bytes), std::bit_cast<uint8_t*>(bytes) + len, vec.begin());
   env->ReleaseByteArrayElements(byte_arr, bytes, JNI_ABORT);
   return vec;
 }
@@ -119,7 +120,7 @@ Java_com_nvidia_spark_rapids_jni_Protobuf_decodeToStruct(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const* input = reinterpret_cast<cudf::column_view const*>(binary_input_view);
+    auto const* input = std::bit_cast<cudf::column_view const*>(binary_input_view);
 
     cudf::jni::native_jintArray n_field_numbers(env, field_numbers);
     cudf::jni::native_jintArray n_parent_indices(env, parent_indices);

--- a/src/main/cpp/src/RegexRewriteUtilsJni.cpp
+++ b/src/main/cpp/src/RegexRewriteUtilsJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 #include "jni_utils.hpp"
 #include "regex_rewrite_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_RegexRewriteUtils_literalRangePattern(
@@ -31,9 +33,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_RegexRewriteUtils_liter
   {
     cudf::jni::auto_set_device(env);
 
-    cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(input);
+    cudf::column_view* cv = std::bit_cast<cudf::column_view*>(input);
     cudf::strings_column_view scv(*cv);
-    cudf::string_scalar* ss_scalar = reinterpret_cast<cudf::string_scalar*>(target);
+    cudf::string_scalar* ss_scalar = std::bit_cast<cudf::string_scalar*>(target);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::literal_range_pattern(scv, *ss_scalar, d, start, end));
   }

--- a/src/main/cpp/src/RowConversionJni.cpp
+++ b/src/main/cpp/src/RowConversionJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 #include "dtype_utils.hpp"
 #include "row_conversion.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlongArray JNICALL
@@ -30,7 +32,7 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertToRowsFixedWidthOptimized(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    cudf::table_view const* n_input_table = reinterpret_cast<cudf::table_view const*>(input_table);
+    cudf::table_view const* n_input_table = std::bit_cast<cudf::table_view const*>(input_table);
     std::vector<std::unique_ptr<cudf::column>> cols =
       spark_rapids_jni::convert_to_rows_fixed_width_optimized(*n_input_table);
     int const num_columns = cols.size();
@@ -51,7 +53,7 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertToRows(JNIEnv* env, jclass
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    cudf::table_view const* n_input_table = reinterpret_cast<cudf::table_view const*>(input_table);
+    cudf::table_view const* n_input_table = std::bit_cast<cudf::table_view const*>(input_table);
     std::vector<std::unique_ptr<cudf::column>> cols =
       spark_rapids_jni::convert_to_rows(*n_input_table);
     int const num_columns = cols.size();
@@ -74,7 +76,7 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRowsFixedWidthOptimize
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    cudf::lists_column_view const list_input{*reinterpret_cast<cudf::column_view*>(input_column)};
+    cudf::lists_column_view const list_input{*std::bit_cast<cudf::column_view*>(input_column)};
     cudf::jni::native_jintArray n_types(env, types);
     cudf::jni::native_jintArray n_scale(env, scale);
     if (n_types.size() != n_scale.size()) {
@@ -103,7 +105,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_RowConversion_conv
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    cudf::lists_column_view const list_input{*reinterpret_cast<cudf::column_view*>(input_column)};
+    cudf::lists_column_view const list_input{*std::bit_cast<cudf::column_view*>(input_column)};
     cudf::jni::native_jintArray n_types(env, types);
     cudf::jni::native_jintArray n_scale(env, scale);
     if (n_types.size() != n_scale.size()) {

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -31,7 +31,9 @@
 #include <task_priority.hpp>
 
 #include <algorithm>
+#include <bit>
 #include <chrono>
+#include <cstdint>
 #include <exception>
 #include <format>
 #include <iostream>
@@ -1479,7 +1481,7 @@ class spark_resource_adaptor_impl {
 
       if (thread_should_be_removed) {
         JNIEnv* env = nullptr;
-        if (jvm->GetEnv(reinterpret_cast<void**>(&env), cudf::jni::MINIMUM_JNI_VERSION) == JNI_OK) {
+        if (jvm->GetEnv(std::bit_cast<void**>(&env), cudf::jni::MINIMUM_JNI_VERSION) == JNI_OK) {
           cache_thread_reg_jni(env);
           env->CallStaticVoidMethod(ThreadStateRegistry_jclass, removeThread_method, thread_id);
         }
@@ -2777,7 +2779,7 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_postCpuAllocSuccess(JNIEnv
   JNI_TRY
   {
     auto mr = get_spark_adaptor(ptr);
-    mr->cpu_postalloc_success(reinterpret_cast<void*>(addr), amount, blocking, was_recursive);
+    mr->cpu_postalloc_success(std::bit_cast<void*>(addr), amount, blocking, was_recursive);
   }
   JNI_CATCH(env, );
 }
@@ -2801,7 +2803,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_cpu
   JNI_TRY
   {
     auto mr = get_spark_adaptor(ptr);
-    mr->cpu_dealloc(reinterpret_cast<void*>(addr), amount);
+    mr->cpu_dealloc(std::bit_cast<void*>(addr), amount);
   }
   JNI_CATCH(env, );
 }
@@ -2896,7 +2898,8 @@ Java_com_nvidia_spark_rapids_jni_RmmSparkDeallocationFailureTest_00024Child_trig
 
     auto const tid = static_cast<long>(pthread_self());
     adaptor->start_dedicated_task_thread(tid, 1);
-    adaptor->deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, reinterpret_cast<void*>(0x1), 1);
+    adaptor->deallocate(
+      cuda::stream_ref{cudaStream_t{nullptr}}, std::bit_cast<void*>(std::uintptr_t{1}), 1);
   }
   JNI_CATCH(env, );
 }

--- a/src/main/cpp/src/StringUtilsJni.cpp
+++ b/src/main/cpp/src/StringUtilsJni.cpp
@@ -18,6 +18,8 @@
 #include "reverse_strings.hpp"
 #include "uuid.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_StringUtils_randomUUIDs(JNIEnv* env,
@@ -40,7 +42,7 @@ Java_com_nvidia_spark_rapids_jni_StringUtils_reverseStrings(JNIEnv* env, jclass,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = reinterpret_cast<cudf::column_view const*>(input_handle);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_handle);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::reverse_strings(cudf::strings_column_view{*input}));
   }

--- a/src/main/cpp/src/SubStringIndexJni.cpp
+++ b/src/main/cpp/src/SubStringIndexJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "substring_index.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuSubstringIndexUtils_substringIndex(
@@ -27,9 +29,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuSubstringIndexUtils_
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input               = reinterpret_cast<cudf::column_view const*>(strings_handle);
+    auto const input               = std::bit_cast<cudf::column_view const*>(strings_handle);
     auto const strings_column      = cudf::strings_column_view{*input};
-    cudf::string_scalar* ss_scalar = reinterpret_cast<cudf::string_scalar*>(delimiter);
+    cudf::string_scalar* ss_scalar = std::bit_cast<cudf::string_scalar*>(delimiter);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::substring_index(strings_column, *ss_scalar, count));
   }

--- a/src/main/cpp/src/hash/HashJni.cpp
+++ b/src/main/cpp/src/hash/HashJni.cpp
@@ -21,6 +21,8 @@
 
 #include <zlib.h>
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_Hash_getMaxStackDepth(JNIEnv* env, jclass)
@@ -86,7 +88,7 @@ Java_com_nvidia_spark_rapids_jni_Hash_sha224NullsPreserved(JNIEnv* env, jclass, 
   {
     cudf::jni::auto_set_device(env);
     return cudf::jni::release_as_jlong(spark_rapids_jni::sha224_nulls_preserved(
-      *reinterpret_cast<cudf::column_view const*>(column_handle)));
+      *std::bit_cast<cudf::column_view const*>(column_handle)));
   }
   JNI_CATCH(env, 0);
 }
@@ -99,7 +101,7 @@ Java_com_nvidia_spark_rapids_jni_Hash_sha256NullsPreserved(JNIEnv* env, jclass, 
   {
     cudf::jni::auto_set_device(env);
     return cudf::jni::release_as_jlong(spark_rapids_jni::sha256_nulls_preserved(
-      *reinterpret_cast<cudf::column_view const*>(column_handle)));
+      *std::bit_cast<cudf::column_view const*>(column_handle)));
   }
   JNI_CATCH(env, 0);
 }
@@ -112,7 +114,7 @@ Java_com_nvidia_spark_rapids_jni_Hash_sha384NullsPreserved(JNIEnv* env, jclass, 
   {
     cudf::jni::auto_set_device(env);
     return cudf::jni::release_as_jlong(spark_rapids_jni::sha384_nulls_preserved(
-      *reinterpret_cast<cudf::column_view const*>(column_handle)));
+      *std::bit_cast<cudf::column_view const*>(column_handle)));
   }
   JNI_CATCH(env, 0);
 }
@@ -125,7 +127,7 @@ Java_com_nvidia_spark_rapids_jni_Hash_sha512NullsPreserved(JNIEnv* env, jclass, 
   {
     cudf::jni::auto_set_device(env);
     return cudf::jni::release_as_jlong(spark_rapids_jni::sha512_nulls_preserved(
-      *reinterpret_cast<cudf::column_view const*>(column_handle)));
+      *std::bit_cast<cudf::column_view const*>(column_handle)));
   }
   JNI_CATCH(env, 0);
 }
@@ -150,7 +152,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_hostCrc32(
   }
   JNI_TRY
   {
-    auto const buffer_addr = reinterpret_cast<unsigned char*>(buffer_handle);
+    auto const buffer_addr = std::bit_cast<unsigned char*>(buffer_handle);
     return crc32(static_cast<uLong>(crc), buffer_addr, static_cast<uInt>(len));
   }
   JNI_CATCH(env, 0);

--- a/src/main/cpp/src/iceberg/IcebergBucketJni.cpp
+++ b/src/main/cpp/src/iceberg/IcebergBucketJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 #include "iceberg/iceberg_bucket.hpp"
 #include "jni_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergBucket_computeBucket(
@@ -28,7 +30,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergBucket_c
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input_column);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::compute_bucket(*input_cv, num_buckets, cudf::get_default_stream()));
   }

--- a/src/main/cpp/src/iceberg/IcebergDateTimeUtilJni.cpp
+++ b/src/main/cpp/src/iceberg/IcebergDateTimeUtilJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #include "cudf_jni_apis.hpp"
 #include "iceberg/iceberg_datetime_util.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergDateTimeUtil_yearsFromEpoch(
@@ -27,9 +29,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergDateTime
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::years_from_epoch(*input_cv);
-    return reinterpret_cast<jlong>(output.release());
+    return std::bit_cast<jlong>(output.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -44,9 +46,9 @@ Java_com_nvidia_spark_rapids_jni_iceberg_IcebergDateTimeUtil_monthsFromEpoch(JNI
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::months_from_epoch(*input_cv);
-    return reinterpret_cast<jlong>(output.release());
+    return std::bit_cast<jlong>(output.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -59,9 +61,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergDateTime
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::days_from_epoch(*input_cv);
-    return reinterpret_cast<jlong>(output.release());
+    return std::bit_cast<jlong>(output.release());
   }
   JNI_CATCH(env, 0);
 }
@@ -74,9 +76,9 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergDateTime
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::hours_from_epoch(*input_cv);
-    return reinterpret_cast<jlong>(output.release());
+    return std::bit_cast<jlong>(output.release());
   }
   JNI_CATCH(env, 0);
 }

--- a/src/main/cpp/src/iceberg/IcebergTruncateJni.cpp
+++ b/src/main/cpp/src/iceberg/IcebergTruncateJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 #include "iceberg/iceberg_truncate.hpp"
 #include "jni_utils.hpp"
 
+#include <bit>
+
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergTruncate_truncate(
@@ -28,7 +30,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_iceberg_IcebergTruncate
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input_cv = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const input_cv = std::bit_cast<cudf::column_view const*>(input_column);
     auto const type_id  = input_cv->type().id();
     // Switch on type_id to call appropriate truncate function
     switch (type_id) {


### PR DESCRIPTION
Follow-up to https://github.com/NVIDIA/cudf-spark-jni/pull/4956.

### Description

Replace all 191 remaining `reinterpret_cast` expressions in JNI entry-point sources under `src/main/cpp/src` with C++20 `std::bit_cast`. This consistently expresses JNI native-handle bit conversions with compile-time size and type constraints and prevents the same Sonar `cpp:S3630` finding from recurring as existing JNI code is modified.

The integer sentinel conversion is first widened to `std::uintptr_t` so its size matches the target pointer type. Required `<bit>` includes and 2026 copyright updates are included.

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
