### PR TITLE
Clean up casts, including reinterpret_cast

### DIFF
--- a/src/main/cpp/src/bloom_filter.cu
+++ b/src/main/cpp/src/bloom_filter.cu
@@ -314,13 +314,13 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(int version,
   rmm::device_buffer buf{static_cast<size_t>(buf_size), stream, mr};
 
   bloom_filter_header header{version, num_hashes, bloom_filter_longs};
-  pack_bloom_filter_header({reinterpret_cast<uint8_t*>(buf.data()), static_cast<size_t>(buf_size)},
+  pack_bloom_filter_header({static_cast<uint8_t*>(buf.data()), static_cast<size_t>(buf_size)},
                            header,
                            stream,
                            (version == bloom_filter_version_1 ? 0 : seed));
 
-  CUDF_CUDA_TRY(cudaMemsetAsync(
-    reinterpret_cast<uint8_t*>(buf.data()) + hdr_size, 0, bloom_filter_size, stream));
+  CUDF_CUDA_TRY(
+    cudaMemsetAsync(static_cast<uint8_t*>(buf.data()) + hdr_size, 0, bloom_filter_size, stream));
 
   return std::make_unique<cudf::list_scalar>(
     cudf::column(
@@ -417,11 +417,10 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_merge(cudf::column_view const& b
 
   rmm::device_buffer buf{static_cast<size_t>(buf_size), stream, mr};
   pack_bloom_filter_header(
-    {reinterpret_cast<uint8_t*>(buf.data()), static_cast<size_t>(buf_size)}, header, stream, seed);
+    {static_cast<uint8_t*>(buf.data()), static_cast<size_t>(buf_size)}, header, stream, seed);
 
   auto src = lcv.child().data<uint8_t>() + hdr_size;
-  auto dst =
-    reinterpret_cast<cudf::bitmask_type*>(reinterpret_cast<uint8_t*>(buf.data()) + hdr_size);
+  auto dst = reinterpret_cast<cudf::bitmask_type*>(static_cast<uint8_t*>(buf.data()) + hdr_size);
 
   cudf::size_type num_words = header.num_longs * 2;
   thrust::transform(

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -417,7 +417,7 @@ std::unique_ptr<cudf::column> cast_strings_to_integers(cudf::column_view const& 
       : cudf::column_view{cudf::data_type{cudf::type_id::STRING},
                           input_sv.size(),
                           input_sv.chars_begin(stream),
-                          reinterpret_cast<cudf::bitmask_type const*>(null_mask.data()),
+                          static_cast<cudf::bitmask_type const*>(null_mask.data()),
                           null_count,
                           input_sv.offset(),
                           std::vector<cudf::column_view>{input_sv.offsets()}};

--- a/src/main/cpp/src/hash/hash.cuh
+++ b/src/main/cpp/src/hash/hash.cuh
@@ -30,6 +30,12 @@
 #include <thrust/reverse.h>
 
 namespace spark_rapids_jni {
+
+struct java_big_decimal_bytes {
+  cuda::std::array<cuda::std::byte, sizeof(__int128_t)> bytes;
+  cudf::size_type length;
+};
+
 /**
  * Normalization of floating point NaNs, passthrough for all other values.
  */
@@ -59,12 +65,10 @@ T __device__ inline normalize_nans_and_zeros(T const& key)
  *
  * @param key The cudf decimal value
  *
- * @returns A 128 bit value containing the converted decimal bits and a length
- *          representing the relevant number of bytes in the value.
+ * @returns The converted decimal bytes and the relevant number of bytes in the value.
  *
  */
-__device__ __inline__ cuda::std::pair<__int128_t, cudf::size_type> to_java_bigdecimal(
-  numeric::decimal128 key)
+__device__ __inline__ java_big_decimal_bytes to_java_bigdecimal(numeric::decimal128 key)
 {
   // java.math.BigDecimal.valueOf(unscaled_value, _scale).unscaledValue().toByteArray()
   // https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala#L381
@@ -104,6 +108,6 @@ __device__ __inline__ cuda::std::pair<__int128_t, cudf::size_type> to_java_bigde
   cuda::std::array<cuda::std::byte, key_size> big_endian_data{};
   thrust::reverse_copy(thrust::seq, data.begin(), data.begin() + length, big_endian_data.begin());
 
-  return {cuda::std::bit_cast<__int128_t>(big_endian_data), length};
+  return {big_endian_data, length};
 }
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash/hash.cuh
+++ b/src/main/cpp/src/hash/hash.cuh
@@ -20,6 +20,8 @@
 #include <cudf/utilities/default_stream.hpp>
 
 #include <cuda/std/algorithm>
+#include <cuda/std/array>
+#include <cuda/std/bit>
 #include <cuda/std/cmath>
 #include <cuda/std/cstddef>
 #include <cuda/std/iterator>
@@ -68,7 +70,7 @@ __device__ __inline__ cuda::std::pair<__int128_t, cudf::size_type> to_java_bigde
   // https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala#L381
   __int128_t const val               = key.value();
   constexpr cudf::size_type key_size = sizeof(__int128_t);
-  cuda::std::byte const* data        = reinterpret_cast<cuda::std::byte const*>(&val);
+  auto const data = cuda::std::bit_cast<cuda::std::array<cuda::std::byte, key_size>>(val);
 
   // Small negative values start with 0xff..., small positive values start with 0x00...
   bool const is_negative           = val < 0;
@@ -76,8 +78,8 @@ __device__ __inline__ cuda::std::pair<__int128_t, cudf::size_type> to_java_bigde
 
   // If the value can be represented with a shorter than 16-byte integer, the
   // leading bytes of the little-endian value are truncated and are not hashed.
-  auto const reverse_begin = cuda::std::reverse_iterator(data + key_size);
-  auto const reverse_end   = cuda::std::reverse_iterator(data);
+  auto const reverse_begin = cuda::std::reverse_iterator(data.end());
+  auto const reverse_end   = cuda::std::reverse_iterator(data.begin());
   auto const first_nonzero_byte =
     thrust::find_if_not(thrust::seq,
                         reverse_begin,
@@ -85,8 +87,8 @@ __device__ __inline__ cuda::std::pair<__int128_t, cudf::size_type> to_java_bigde
                         [zero_value](cuda::std::byte const& v) { return v == zero_value; })
       .base();
   // Max handles special case of 0 and -1 which would shorten to 0 length otherwise
-  cudf::size_type length =
-    cuda::std::max(1, static_cast<cudf::size_type>(cuda::std::distance(data, first_nonzero_byte)));
+  cudf::size_type length = cuda::std::max(
+    1, static_cast<cudf::size_type>(cuda::std::distance(data.begin(), first_nonzero_byte)));
 
   // Preserve the 2's complement sign bit by adding a byte back on if necessary.
   // e.g. 0x0000ff would shorten to 0x00ff. The 0x00 byte is retained to
@@ -99,10 +101,9 @@ __device__ __inline__ cuda::std::pair<__int128_t, cudf::size_type> to_java_bigde
   }
 
   // Convert to big endian by reversing the range of nonzero bytes. Only those bytes are hashed.
-  __int128_t big_endian_value = 0;
-  auto big_endian_data        = reinterpret_cast<cuda::std::byte*>(&big_endian_value);
-  thrust::reverse_copy(thrust::seq, data, data + length, big_endian_data);
+  cuda::std::array<cuda::std::byte, key_size> big_endian_data{};
+  thrust::reverse_copy(thrust::seq, data.begin(), data.begin() + length, big_endian_data.begin());
 
-  return {big_endian_value, length};
+  return {cuda::std::bit_cast<__int128_t>(big_endian_data), length};
 }
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash/hive_hash.cu
+++ b/src/main/cpp/src/hash/hive_hash.cu
@@ -26,6 +26,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/bit>
 #include <cuda/std/type_traits>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tabulate.h>
@@ -111,32 +112,29 @@ hive_hash_value_t __device__ inline hive_hash_function<int64_t>::operator()(
 template <>
 hive_hash_value_t __device__ inline hive_hash_function<float>::operator()(float const& key) const
 {
-  auto normalized = spark_rapids_jni::normalize_nans(key);
-  auto* p_int     = reinterpret_cast<int32_t const*>(&normalized);
-  return compute_int(*p_int);
+  auto const normalized = spark_rapids_jni::normalize_nans(key);
+  return compute_int(cuda::std::bit_cast<int32_t>(normalized));
 }
 
 template <>
 hive_hash_value_t __device__ inline hive_hash_function<double>::operator()(double const& key) const
 {
-  auto normalized = spark_rapids_jni::normalize_nans(key);
-  auto* p_long    = reinterpret_cast<int64_t const*>(&normalized);
-  return compute_long(*p_long);
+  auto const normalized = spark_rapids_jni::normalize_nans(key);
+  return compute_long(cuda::std::bit_cast<int64_t>(normalized));
 }
 
 template <>
 hive_hash_value_t __device__ inline hive_hash_function<cudf::timestamp_D>::operator()(
   cudf::timestamp_D const& key) const
 {
-  auto* p_int = reinterpret_cast<int32_t const*>(&key);
-  return compute_int(*p_int);
+  return compute_int(key.time_since_epoch().count());
 }
 
 template <>
 hive_hash_value_t __device__ inline hive_hash_function<cudf::timestamp_us>::operator()(
   cudf::timestamp_us const& key) const
 {
-  auto time_as_long            = *reinterpret_cast<int64_t const*>(&key);
+  auto const time_as_long      = key.time_since_epoch().count();
   constexpr int MICRO_PER_SEC  = 1000000;
   constexpr int NANO_PER_MICRO = 1000;
 

--- a/src/main/cpp/src/hash/murmur_hash.cuh
+++ b/src/main/cpp/src/hash/murmur_hash.cuh
@@ -203,9 +203,8 @@ template <>
 murmur_hash_value_type __device__ inline MurmurHash3_32<numeric::decimal128>::operator()(
   numeric::decimal128 const& key) const
 {
-  auto [java_d, length] = to_java_bigdecimal(key);
-  auto const bytes = cuda::std::bit_cast<cuda::std::array<cuda::std::byte, sizeof(java_d)>>(java_d);
-  return compute_bytes(bytes.data(), length);
+  auto const java_d = to_java_bigdecimal(key);
+  return compute_bytes(java_d.bytes.data(), java_d.length);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash/murmur_hash.cuh
+++ b/src/main/cpp/src/hash/murmur_hash.cuh
@@ -22,6 +22,9 @@
 #include <cudf/strings/string_view.hpp>
 #include <cudf/types.hpp>
 
+#include <cuda/std/array>
+#include <cuda/std/bit>
+
 namespace spark_rapids_jni {
 
 using murmur_hash_value_type = int32_t;
@@ -66,7 +69,8 @@ struct MurmurHash3_32 {
   template <typename T>
   result_type __device__ inline compute(T const& key) const
   {
-    return compute_bytes(reinterpret_cast<cuda::std::byte const*>(&key), sizeof(T));
+    auto const bytes = cuda::std::bit_cast<cuda::std::array<cuda::std::byte, sizeof(T)>>(key);
+    return compute_bytes(bytes.data(), bytes.size());
   }
 
   result_type __device__ inline compute_remaining_bytes(cuda::std::byte const* data,
@@ -200,8 +204,8 @@ murmur_hash_value_type __device__ inline MurmurHash3_32<numeric::decimal128>::op
   numeric::decimal128 const& key) const
 {
   auto [java_d, length] = to_java_bigdecimal(key);
-  auto bytes            = reinterpret_cast<cuda::std::byte*>(&java_d);
-  return compute_bytes(bytes, length);
+  auto const bytes = cuda::std::bit_cast<cuda::std::array<cuda::std::byte, sizeof(java_d)>>(java_d);
+  return compute_bytes(bytes.data(), length);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash/xxhash64.cu
+++ b/src/main/cpp/src/hash/xxhash64.cu
@@ -25,6 +25,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/array>
 #include <cuda/std/bit>
 #include <cuda/std/utility>
 #include <thrust/tabulate.h>
@@ -73,7 +74,8 @@ struct XXHash_64 {
   template <typename T>
   result_type __device__ inline compute(T const& key) const
   {
-    return compute_bytes(reinterpret_cast<cuda::std::byte const*>(&key), sizeof(T));
+    auto const bytes = cuda::std::bit_cast<cuda::std::array<cuda::std::byte, sizeof(T)>>(key);
+    return compute_bytes(bytes.data(), bytes.size());
   }
 
   result_type __device__ inline compute_remaining_bytes(cuda::std::byte const* data,
@@ -269,8 +271,8 @@ hash_value_type __device__ inline XXHash_64<numeric::decimal128>::operator()(
   numeric::decimal128 const& key) const
 {
   auto [java_d, length] = to_java_bigdecimal(key);
-  auto bytes            = reinterpret_cast<cuda::std::byte*>(&java_d);
-  return compute_bytes(bytes, length);
+  auto const bytes = cuda::std::bit_cast<cuda::std::array<cuda::std::byte, sizeof(java_d)>>(java_d);
+  return compute_bytes(bytes.data(), length);
 }
 
 /**

--- a/src/main/cpp/src/hash/xxhash64.cu
+++ b/src/main/cpp/src/hash/xxhash64.cu
@@ -25,6 +25,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/bit>
 #include <cuda/std/utility>
 #include <thrust/tabulate.h>
 
@@ -56,7 +57,7 @@ struct XXHash_64 {
     uint32_t result = static_cast<uint32_t>(block[0]) | (static_cast<uint32_t>(block[1]) << 8) |
                       (static_cast<uint32_t>(block[2]) << 16) |
                       (static_cast<uint32_t>(block[3]) << 24);
-    return reinterpret_cast<T const*>(&result)[0];
+    return cuda::std::bit_cast<T>(result);
   }
 
   __device__ inline hash_value_type getblock64(cuda::std::byte const* data,
@@ -64,7 +65,7 @@ struct XXHash_64 {
   {
     uint64_t result = static_cast<uint64_t>(getblock32<uint32_t>(data, offset)) |
                       static_cast<uint64_t>(getblock32<uint32_t>(data, offset + 4)) << 32;
-    return reinterpret_cast<hash_value_type const*>(&result)[0];
+    return cuda::std::bit_cast<hash_value_type>(result);
   }
 
   result_type __device__ inline operator()(Key const& key) const { return compute(key); }

--- a/src/main/cpp/src/hash/xxhash64.cu
+++ b/src/main/cpp/src/hash/xxhash64.cu
@@ -270,9 +270,8 @@ template <>
 hash_value_type __device__ inline XXHash_64<numeric::decimal128>::operator()(
   numeric::decimal128 const& key) const
 {
-  auto [java_d, length] = to_java_bigdecimal(key);
-  auto const bytes = cuda::std::bit_cast<cuda::std::array<cuda::std::byte, sizeof(java_d)>>(java_d);
-  return compute_bytes(bytes.data(), length);
+  auto const java_d = to_java_bigdecimal(key);
+  return compute_bytes(java_d.bytes.data(), java_d.length);
 }
 
 /**

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -343,7 +343,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
           std::vector<cudf::bitmask_type const*>{
             // Don't use values.null_mask(), to make sure no slicing.
             values_and_frequencies.front()->view().null_mask(),
-            reinterpret_cast<cudf::bitmask_type const*>(null_mask.data())},
+            static_cast<cudf::bitmask_type const*>(null_mask.data())},
           std::vector<cudf::size_type>{0, 0},
           values.size(),
           stream,

--- a/src/main/cpp/src/iceberg/iceberg_bucket.cu
+++ b/src/main/cpp/src/iceberg/iceberg_bucket.cu
@@ -31,6 +31,8 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuco/detail/hash_functions/murmurhash3.cuh>
+#include <cuda/std/array>
+#include <cuda/std/bit>
 #include <cuda/std/limits>
 #include <thrust/tabulate.h>
 
@@ -75,7 +77,8 @@ class iceberg_murmur_hash3_32 {
   __device__ static inline int32_t hash_long(int64_t input)
   {
     // Hash the 8 bytes of the long value in little-endian order
-    return hash_bytes(reinterpret_cast<uint8_t const*>(&input), 8);
+    auto const bytes = cuda::std::bit_cast<cuda::std::array<uint8_t, sizeof(input)>>(input);
+    return hash_bytes(bytes.data(), static_cast<int32_t>(bytes.size()));
   }
 
   /**

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -274,7 +274,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
       : cudf::column_view{cudf::data_type{cudf::type_id::STRING},
                           input.size(),
                           input.chars_begin(stream),
-                          reinterpret_cast<cudf::bitmask_type const*>(null_mask->data()),
+                          static_cast<cudf::bitmask_type const*>(null_mask->data()),
                           null_count,
                           input.offset(),
                           std::vector<cudf::column_view>{input.offsets()}};

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -924,8 +924,8 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
     chunk,
     input.chars_begin(stream),
     offsets_mutable_view.begin<size_type>(),
-    reinterpret_cast<size_type*>(src_offsets.data()),
-    reinterpret_cast<bitmask_type*>(null_mask.data()),
+    src_offsets.data(),
+    static_cast<bitmask_type*>(null_mask.data()),
     d_matches ? cuda::std::optional<column_device_view const>{*d_matches} : cuda::std::nullopt);
 
   // use scan to transform number of bytes into offsets
@@ -948,12 +948,12 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
   parse_uri<<<num_threadblocks, threadblock_size, 0, stream.value()>>>(
     *d_strings,
     input.chars_begin(stream),
-    reinterpret_cast<size_type*>(src_offsets.data()),
+    src_offsets.data(),
     offsets_column->view().begin<size_type>(),
     static_cast<char*>(d_out_chars.data()));
 
   auto null_count =
-    cudf::null_count(reinterpret_cast<bitmask_type*>(null_mask.data()), 0, strings_count);
+    cudf::null_count(static_cast<bitmask_type*>(null_mask.data()), 0, strings_count);
 
   return make_strings_column(strings_count,
                              std::move(offsets_column),

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -43,6 +43,7 @@
 #include <cooperative_groups.h>
 #include <cuda/barrier>
 #include <cuda/functional>
+#include <cuda/std/bit>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
@@ -526,7 +527,7 @@ CUDF_KERNEL void copy_to_rows_fixed_width_optimized(size_type const start_row,
         // so we have to rewrite the addresses to make sure that it is 4 byte aligned
         int8_t* valid_byte        = &row_vld_tmp[col_index / 8];
         size_type byte_bit_offset = col_index % 8;
-        uint64_t fixup_bytes      = reinterpret_cast<uint64_t>(valid_byte) % 4;
+        uint64_t fixup_bytes      = cuda::std::bit_cast<uint64_t>(valid_byte) % 4;
         int32_t* valid_int        = reinterpret_cast<int32_t*>(valid_byte - fixup_bytes);
         size_type int_bit_offset  = byte_bit_offset + (fixup_bytes * 8);
         // Now copy validity for the column

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -40,6 +40,7 @@
 
 #include <cub/device/device_memcpy.cuh>
 #include <cuda/functional>
+#include <cuda/std/bit>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <thrust/binary_search.h>
@@ -1380,7 +1381,7 @@ __global__ void copy_validity(cudf::device_span<assemble_batch> batches)
 
   // how many leading bytes we have. that is, how many bytes will be read by the initial read, which
   // accounts for misaligned source buffers.
-  int const leading_bytes = (4 - (reinterpret_cast<uint64_t>(batch.src) % 4));
+  int const leading_bytes = (4 - (cuda::std::bit_cast<uint64_t>(batch.src) % 4));
   int remaining_rows      = batch.validity_row_count;
 
   // - if the address is misaligned, load byte-by-byte and only store up to that many bits/rows off

--- a/src/main/cpp/src/shuffle_split.cu
+++ b/src/main/cpp/src/shuffle_split.cu
@@ -859,12 +859,11 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
   rmm::device_buffer d_indices_and_source_info(indices_size + src_buf_info_size + offset_stack_size,
                                                stream,
                                                rmm::mr::get_current_device_resource_ref());
-  auto* d_indices              = reinterpret_cast<size_type*>(d_indices_and_source_info.data());
+  auto* d_indices              = static_cast<size_type*>(d_indices_and_source_info.data());
   src_buf_info* d_src_buf_info = reinterpret_cast<src_buf_info*>(
-    reinterpret_cast<uint8_t*>(d_indices_and_source_info.data()) + indices_size);
-  size_type* d_offset_stack =
-    reinterpret_cast<size_type*>(reinterpret_cast<uint8_t*>(d_indices_and_source_info.data()) +
-                                 indices_size + src_buf_info_size);
+    static_cast<uint8_t*>(d_indices_and_source_info.data()) + indices_size);
+  size_type* d_offset_stack = reinterpret_cast<size_type*>(
+    static_cast<uint8_t*>(d_indices_and_source_info.data()) + indices_size + src_buf_info_size);
 
   // compute splits -> indices.
   h_indices[0]              = 0;
@@ -901,7 +900,7 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
   rmm::device_buffer d_buf_sizes_and_dst_info(
     partition_sizes_size + dst_buf_info_size + partition_has_validity_size, stream, temp_mr);
   partition_size_info* d_partition_sizes_unpadded =
-    reinterpret_cast<partition_size_info*>(d_buf_sizes_and_dst_info.data());
+    static_cast<partition_size_info*>(d_buf_sizes_and_dst_info.data());
   partition_size_info* d_partition_sizes = d_partition_sizes_unpadded + num_partitions;
   dst_buf_info* d_dst_buf_info           = reinterpret_cast<dst_buf_info*>(
     static_cast<uint8_t*>(d_buf_sizes_and_dst_info.data()) + partition_sizes_size);
@@ -1144,7 +1143,7 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
   pack_per_partition_metadata_kernel<<<grid.num_blocks,
                                        grid.num_threads_per_block,
                                        0,
-                                       stream.value()>>>(reinterpret_cast<uint8_t*>(dst_buf.data()),
+                                       stream.value()>>>(static_cast<uint8_t*>(dst_buf.data()),
                                                          d_partition_offsets.data(),
                                                          num_partitions,
                                                          total_flattened_columns,
@@ -1154,7 +1153,7 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
 
   // perform the copy.
   split_copy(
-    d_src_buf_info, reinterpret_cast<uint8_t*>(dst_buf.data()), num_bufs, d_dst_buf_info, stream);
+    d_src_buf_info, static_cast<uint8_t*>(dst_buf.data()), num_bufs, d_dst_buf_info, stream);
 
   // do this before the synchronize to take advantage of any gpu time we can overlap with (this
   // function only uses the cpu).

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -37,6 +37,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/launch>
+#include <cuda/std/bit>
 #include <cuda/std/chrono>
 #include <cuda/std/functional>
 #include <thrust/binary_search.h>
@@ -643,7 +644,8 @@ __device__ static void stage_side_transitions(int64_t const* __restrict__ g_tran
   int32_t* s_offsets = nullptr;
 
   if (fits && trans_count > 0) {
-    ptr     = reinterpret_cast<char*>(align_up(reinterpret_cast<uintptr_t>(ptr), alignof(int64_t)));
+    ptr =
+      cuda::std::bit_cast<char*>(align_up(cuda::std::bit_cast<uintptr_t>(ptr), alignof(int64_t)));
     s_trans = reinterpret_cast<int64_t*>(ptr);
     ptr += trans_count * sizeof(int64_t);
     s_offsets = reinterpret_cast<int32_t*>(ptr);


### PR DESCRIPTION
Follow-up to https://github.com/NVIDIA/cudf-spark-jni/pull/4957.

Clean up the `reinterpret_cast` expressions that have a safer direct replacement:

- use value-level `cuda::std::bit_cast` for hash object representations;
- use timestamp duration accessors instead of reading timestamp representations through integer pointers;
- remove redundant `parse_uri` casts and use `static_cast` for `void*` buffer conversions; and
- use `cuda::std::bit_cast` for pointer-address alignment calculations on supported 64-bit CUDA targets.

The remaining casts represent byte views or raw storage/layout pointers. They are intentionally unchanged because mechanically replacing them with pointer `bit_cast` would not address alignment, object lifetime, or aliasing requirements.
