### PR TITLE
Clean up reinterpret_cast

### DIFF
--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -43,6 +43,7 @@
 #include <cooperative_groups.h>
 #include <cuda/barrier>
 #include <cuda/functional>
+#include <cuda/std/bit>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
@@ -526,7 +527,7 @@ CUDF_KERNEL void copy_to_rows_fixed_width_optimized(size_type const start_row,
         // so we have to rewrite the addresses to make sure that it is 4 byte aligned
         int8_t* valid_byte        = &row_vld_tmp[col_index / 8];
         size_type byte_bit_offset = col_index % 8;
-        uint64_t fixup_bytes      = reinterpret_cast<uint64_t>(valid_byte) % 4;
+        uint64_t fixup_bytes      = cuda::std::bit_cast<uint64_t>(valid_byte) % 4;
         int32_t* valid_int        = reinterpret_cast<int32_t*>(valid_byte - fixup_bytes);
         size_type int_bit_offset  = byte_bit_offset + (fixup_bytes * 8);
         // Now copy validity for the column

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -40,6 +40,7 @@
 
 #include <cub/device/device_memcpy.cuh>
 #include <cuda/functional>
+#include <cuda/std/bit>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <thrust/binary_search.h>
@@ -1380,7 +1381,7 @@ __global__ void copy_validity(cudf::device_span<assemble_batch> batches)
 
   // how many leading bytes we have. that is, how many bytes will be read by the initial read, which
   // accounts for misaligned source buffers.
-  int const leading_bytes = (4 - (reinterpret_cast<uint64_t>(batch.src) % 4));
+  int const leading_bytes = (4 - (cuda::std::bit_cast<uint64_t>(batch.src) % 4));
   int remaining_rows      = batch.validity_row_count;
 
   // - if the address is misaligned, load byte-by-byte and only store up to that many bits/rows off

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -37,6 +37,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/launch>
+#include <cuda/std/bit>
 #include <cuda/std/chrono>
 #include <cuda/std/functional>
 #include <thrust/binary_search.h>
@@ -643,7 +644,8 @@ __device__ static void stage_side_transitions(int64_t const* __restrict__ g_tran
   int32_t* s_offsets = nullptr;
 
   if (fits && trans_count > 0) {
-    ptr     = reinterpret_cast<char*>(align_up(reinterpret_cast<uintptr_t>(ptr), alignof(int64_t)));
+    ptr =
+      cuda::std::bit_cast<char*>(align_up(cuda::std::bit_cast<uintptr_t>(ptr), alignof(int64_t)));
     s_trans = reinterpret_cast<int64_t*>(ptr);
     ptr += trans_count * sizeof(int64_t);
     s_offsets = reinterpret_cast<int32_t*>(ptr);


### PR DESCRIPTION
Follow-up to https://github.com/NVIDIA/cudf-spark-jni/pull/4957.

Replace pointer-to-integer and integer-to-pointer `reinterpret_cast` expressions used for address alignment calculations with `cuda::std::bit_cast`.

The casts intentionally preserve pointer bits on the supported 64-bit CUDA targets. Raw storage-to-typed-pointer casts are outside this PR because replacing those mechanically would not address alignment, lifetime, or aliasing requirements.
