### PR TITLE
Optimize row-column conversion

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -290,6 +290,7 @@ add_library(
   src/regex_rewrite_utils.cu
   src/reverse_strings.cu
   src/row_conversion.cu
+  src/row_conversion_jit.cpp
   src/round_float.cu
   src/shuffle_assemble.cu
   src/shuffle_split.cu
@@ -327,6 +328,9 @@ target_include_directories(
           "${JNI_INCLUDE_DIRS}"
           "${CUDFJNI_INCLUDE_DIRS}"
           "${CUDAToolkit_INCLUDE_DIRS}"
+          # librtcx installs rtcx.hpp/hash.hpp under include/rtcx, and rtcx.hpp includes its
+          # sibling as <hash.hpp>, so the subdirectory itself must be on the include path.
+          "${CUDF_INSTALL_DIR}/include/rtcx"
 )
 
 target_compile_definitions(
@@ -366,6 +370,13 @@ if(HIDE_PRIVATE_CUDA_SYMBOLS)
             "LINKER:--exclude-libs,libnvcomp_static.a"
   )
 endif()
+# librtcx (with static NVRTC + nvJitLink) is already absorbed into this library through
+# cudf::cudf, so this link is belt-and-braces only. cudf exports the target from its static
+# build alone, so a shared-libcudf configure must not fail on it.
+if(TARGET rtcx::rtcx)
+  target_link_libraries(spark_rapids_jni PRIVATE rtcx::rtcx)
+endif()
+
 rapids_cuda_set_runtime(spark_rapids_jni USE_STATIC ON)
 set_target_properties(spark_rapids_jni PROPERTIES LINK_LANGUAGE "CXX")
 # For backwards-compatibility with the cudf Java bindings and RAPIDS accelerated UDFs,

--- a/src/main/cpp/benchmarks/row_conversion.cpp
+++ b/src/main/cpp/benchmarks/row_conversion.cpp
@@ -16,132 +16,384 @@
 
 #include "common/generate_input.hpp"
 
-#include <cudf_test/column_utilities.hpp>
-
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda_runtime_api.h>
 
 #include <nvbench/nvbench.cuh>
 #include <row_conversion.hpp>
 
-void fixed_width(nvbench::state& state)
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+// Benchmark grid for the four public row-conversion APIs. Six benchmarks (to/from rows ×
+// fixed/wide/strings) cover the Spark plugin's routing keys: the 100-column and 1536-byte
+// fixed-width-optimized gates, multi-batch row output, the null-mask-absent branch, and string
+// schemas. A fixed-width-optimized cell skips itself when its row exceeds 1536 bytes. Timed
+// regions contain exactly the labeled conversion: to-rows cells run one conversion per iteration,
+// from-rows cells convert pre-generated row batches back.
+
+namespace {
+
+enum class direction { to_rows, from_rows };
+
+// The fixed-width-optimized kernels stage whole rows in the default 48 KB shared-memory budget
+// with at least one 32-thread warp per block, so rows above 48 KB / 32 = 1536 bytes throw.
+constexpr int64_t max_fixed_opt_row_bytes = 48 * 1024 / 32;
+
+// 9-type cycle of the pre-rewrite benchmark, kept because the grid's boundary arithmetic
+// (~1400-byte rows at 256 columns, the 1536-byte crossing at 320) is derived on it.
+std::vector<cudf::type_id> const default_cycle = {cudf::type_id::INT8,
+                                                  cudf::type_id::INT32,
+                                                  cudf::type_id::INT16,
+                                                  cudf::type_id::INT64,
+                                                  cudf::type_id::INT32,
+                                                  cudf::type_id::BOOL8,
+                                                  cudf::type_id::UINT16,
+                                                  cudf::type_id::UINT8,
+                                                  cudf::type_id::UINT64};
+
+// FNV-1a over the benchmark name and axis values. std::hash is not stable across standard
+// libraries; an unstable seed would bench different data per build and inflate A/B gate noise.
+constexpr uint64_t fnv1a(std::string_view text, uint64_t hash = 0xcbf29ce484222325ULL)
 {
-  cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
-  auto const direction = state.get_string("direction");
-  auto const table     = create_random_table(cycle_dtypes({cudf::type_id::INT8,
-                                                           cudf::type_id::INT32,
-                                                           cudf::type_id::INT16,
-                                                           cudf::type_id::INT64,
-                                                           cudf::type_id::INT32,
-                                                           cudf::type_id::BOOL8,
-                                                           cudf::type_id::UINT16,
-                                                           cudf::type_id::UINT8,
-                                                           cudf::type_id::UINT64},
-                                                      212),
-                                         row_count{n_rows});
-
-  std::vector<cudf::data_type> schema;
-  cudf::size_type bytes_per_row = 0;
-  for (int i = 0; i < table->num_columns(); ++i) {
-    auto t = table->get_column(i).type();
-    schema.push_back(t);
-    bytes_per_row += cudf::size_of(t);
+  for (unsigned char const c : text) {
+    hash = (hash ^ c) * 0x100000001b3ULL;
   }
-
-  auto rows = spark_rapids_jni::convert_to_rows_fixed_width_optimized(table->view());
-
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    if (direction == "to row") {
-      auto _rows = spark_rapids_jni::convert_to_rows_fixed_width_optimized(table->view());
-    } else {
-      for (auto const& r : rows) {
-        cudf::lists_column_view const l(r->view());
-        auto out = spark_rapids_jni::convert_from_rows_fixed_width_optimized(l, schema);
-      }
-    }
-  });
-
-  state.add_buffer_size(n_rows, "trc", "Total Rows");
-  state.add_global_memory_reads<int64_t>(bytes_per_row * table->num_rows());
+  return hash;
 }
 
-static void variable_or_fixed_width(nvbench::state& state)
+template <typename... AxisValues>
+unsigned deterministic_seed(std::string_view bench_name, AxisValues const&... values)
 {
-  cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
-  auto const direction       = state.get_string("direction");
-  auto const include_strings = state.get_string("strings");
+  auto hash       = fnv1a(bench_name);
+  auto const fold = [&hash](auto const& value) {
+    hash = fnv1a("|", hash);
+    if constexpr (std::is_arithmetic_v<std::remove_cvref_t<decltype(value)>>) {
+      hash = fnv1a(std::to_string(value), hash);
+    } else {
+      hash = fnv1a(value, hash);
+    }
+  };
+  (fold(values), ...);
+  return static_cast<unsigned>(hash ^ (hash >> 32));
+}
 
-  if (n_rows > 1 * 1024 * 1024 && include_strings == "include strings") {
-    state.skip("Too many rows for strings will cause memory issues");
+std::vector<cudf::data_type> make_schema(std::vector<cudf::type_id> const& types)
+{
+  std::vector<cudf::data_type> schema;
+  schema.reserve(types.size());
+  std::ranges::transform(
+    types, std::back_inserter(schema), [](cudf::type_id id) { return cudf::data_type{id}; });
+  return schema;
+}
+
+// Mirrors the JCUDF layout math in row_conversion.cu (compute_fixed_width_layout and
+// compute_column_information): each fixed-width column packs at an offset aligned to its own
+// element size, a string column packs an 8-byte offset/length pair at 4-byte alignment, and
+// ceil(columns / 8) validity bytes follow unaligned.
+int64_t jcudf_fixed_and_validity_bytes(std::vector<cudf::data_type> const& schema)
+{
+  int64_t offset = 0;
+  for (auto const& type : schema) {
+    bool const is_string = type.id() == cudf::type_id::STRING;
+    auto const size      = is_string ? int64_t{8} : static_cast<int64_t>(cudf::size_of(type));
+    auto const alignment = is_string ? int64_t{4} : size;
+    offset               = (offset + alignment - 1) / alignment * alignment + size;
+  }
+  return offset + (static_cast<int64_t>(schema.size()) + 7) / 8;
+}
+
+// Complete fixed-width JCUDF row: data plus validity, padded to the 8-byte row alignment.
+int64_t jcudf_row_size(std::vector<cudf::data_type> const& schema)
+{
+  return (jcudf_fixed_and_validity_bytes(schema) + 7) / 8 * 8;
+}
+
+// Bytes a conversion reads from a realized table: element data, string chars and offsets, and
+// whichever null masks are actually present.
+int64_t realized_table_bytes(cudf::table_view const& table)
+{
+  auto const mask_bytes = static_cast<int64_t>((table.num_rows() + 7) / 8);
+  int64_t bytes         = 0;
+  for (auto const& col : table) {
+    if (col.type().id() == cudf::type_id::STRING) {
+      auto const strings = cudf::strings_column_view{col};
+      bytes += strings.chars_size(cudf::get_default_stream());
+      bytes += static_cast<int64_t>(strings.offsets().size()) *
+               static_cast<int64_t>(cudf::size_of(strings.offsets().type()));
+    } else {
+      bytes += static_cast<int64_t>(col.size()) * static_cast<int64_t>(cudf::size_of(col.type()));
+    }
+    if (col.nullable()) { bytes += mask_bytes; }
+  }
+  return bytes;
+}
+
+// Bytes convert_from_rows* writes when rebuilding this table: it always allocates a null mask
+// per output column and rebuilds string offsets as int32, independent of the input's masks.
+int64_t reconstructed_table_bytes(cudf::table_view const& table)
+{
+  auto const num_rows   = static_cast<int64_t>(table.num_rows());
+  auto const mask_bytes = (num_rows + 7) / 8;
+  int64_t bytes         = 0;
+  for (auto const& col : table) {
+    if (col.type().id() == cudf::type_id::STRING) {
+      auto const strings = cudf::strings_column_view{col};
+      bytes += strings.chars_size(cudf::get_default_stream());
+      bytes += (num_rows + 1) * static_cast<int64_t>(sizeof(int32_t));
+    } else {
+      bytes += num_rows * static_cast<int64_t>(cudf::size_of(col.type()));
+    }
+    bytes += mask_bytes;
+  }
+  return bytes;
+}
+
+int64_t total_row_buffer_bytes(std::vector<std::unique_ptr<cudf::column>> const& row_batches)
+{
+  int64_t bytes = 0;
+  for (auto const& batch : row_batches) {
+    bytes += cudf::lists_column_view{batch->view()}.child().size();
+  }
+  return bytes;
+}
+
+void run_fixed_width_bench(nvbench::state& state,
+                           direction dir,
+                           bool use_fixed_opt,
+                           cudf::size_type num_rows,
+                           std::vector<cudf::type_id> const& types,
+                           std::optional<double> null_probability,
+                           unsigned seed)
+{
+  auto const schema   = make_schema(types);
+  auto const row_size = jcudf_row_size(schema);
+  if (use_fixed_opt && row_size > max_fixed_opt_row_bytes) {
+    state.skip("row size exceeds the fixed-width-optimized 1536-byte limit");
     return;
   }
 
-  std::vector<cudf::type_id> const table_types = [&]() -> std::vector<cudf::type_id> {
-    if (include_strings == "include strings") {
-      return {cudf::type_id::INT8,
-              cudf::type_id::INT32,
-              cudf::type_id::INT16,
-              cudf::type_id::INT64,
-              cudf::type_id::INT32,
-              cudf::type_id::BOOL8,
-              cudf::type_id::STRING,
-              cudf::type_id::UINT16,
-              cudf::type_id::UINT8,
-              cudf::type_id::UINT64};
-    } else {
-      return {cudf::type_id::INT8,
-              cudf::type_id::INT32,
-              cudf::type_id::INT16,
-              cudf::type_id::INT64,
-              cudf::type_id::INT32,
-              cudf::type_id::BOOL8,
-              cudf::type_id::UINT16,
-              cudf::type_id::UINT8,
-              cudf::type_id::UINT64};
-    }
-  }();
+  // Independent draws per element: the generator's default sample-pool-with-run-lengths mode
+  // would repeat 2000 values in runs of ~4, an artifact this grid deliberately avoids.
+  data_profile const profile =
+    data_profile_builder().cardinality(0).avg_run_length(1).null_probability(null_probability);
+  auto table = create_random_table(types, row_count{num_rows}, profile, seed);
 
-  auto const table = create_random_table(cycle_dtypes(table_types, 155), row_count{n_rows});
-
-  std::vector<cudf::data_type> schema;
-  cudf::size_type bytes_per_row = 0;
-  cudf::size_type string_bytes  = 0;
-  for (int i = 0; i < table->num_columns(); ++i) {
-    auto t = table->get_column(i).type();
-    schema.push_back(t);
-    if (is_fixed_width(t)) {
-      bytes_per_row += cudf::size_of(t);
-    } else if (t.id() == cudf::type_id::STRING) {
-      auto sc = cudf::strings_column_view(table->get_column(i));
-      string_bytes += sc.chars_size(cudf::get_default_stream());
-    }
+  // Decimal columns carry a generated scale, so the from-rows schema must come from the table.
+  std::vector<cudf::data_type> realized_schema;
+  realized_schema.reserve(types.size());
+  for (auto const& col : table->view()) {
+    realized_schema.push_back(col.type());
   }
 
-  auto rows = spark_rapids_jni::convert_to_rows(table->view());
+  // Exact for fixed-width schemas: every row occupies the same padded size in every batch.
+  auto const row_buffer_bytes = row_size * num_rows;
+  state.add_element_count(num_rows, "rows");
 
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto new_rows = spark_rapids_jni::convert_to_rows(table->view());
-    if (direction == "to row") {
-      auto _rows = spark_rapids_jni::convert_to_rows(table->view());
-    } else {
-      for (auto const& r : rows) {
-        cudf::lists_column_view const l(r->view());
-        auto out = spark_rapids_jni::convert_from_rows(l, schema);
+  if (dir == direction::to_rows) {
+    state.add_global_memory_reads<int8_t>(realized_table_bytes(table->view()));
+    state.add_global_memory_writes<int8_t>(row_buffer_bytes);
+    // Setup ran on cudf's default stream and the timed region runs on nvbench's; under per-thread
+    // default stream nothing orders the two, so drain setup before anything is measured.
+    cudf::get_default_stream().synchronize();
+    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      auto const stream = rmm::cuda_stream_view{launch.get_stream()};
+      auto const row_batches =
+        use_fixed_opt
+          ? spark_rapids_jni::convert_to_rows_fixed_width_optimized(table->view(), stream)
+          : spark_rapids_jni::convert_to_rows(table->view(), stream);
+    });
+  } else {
+    auto const row_batches =
+      use_fixed_opt ? spark_rapids_jni::convert_to_rows_fixed_width_optimized(table->view())
+                    : spark_rapids_jni::convert_to_rows(table->view());
+    // This setup conversion also runs on the default stream; drain it before the timed region.
+    cudf::get_default_stream().synchronize();
+    state.add_global_memory_reads<int8_t>(row_buffer_bytes);
+    state.add_global_memory_writes<int8_t>(reconstructed_table_bytes(table->view()));
+    table.reset();  // the timed loop needs only the row batches and the schema
+    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      auto const stream = rmm::cuda_stream_view{launch.get_stream()};
+      for (auto const& batch : row_batches) {
+        cudf::lists_column_view const list{batch->view()};
+        auto const out = use_fixed_opt
+                           ? spark_rapids_jni::convert_from_rows_fixed_width_optimized(
+                               list, realized_schema, stream)
+                           : spark_rapids_jni::convert_from_rows(list, realized_schema, stream);
       }
-    }
-  });
-
-  state.add_buffer_size(n_rows, "trc", "Total Rows");
-  state.add_global_memory_reads<int64_t>(bytes_per_row * table->num_rows());
+    });
+  }
 }
 
-NVBENCH_BENCH(fixed_width)
-  .set_name("Fixed Width Only")
-  .add_int64_axis("num_rows", {1 * 1024 * 1024, 4 * 1024 * 1024})
-  .add_string_axis("direction", {"to row", "from row"});
+void run_strings_bench(nvbench::state& state, direction dir, std::string_view bench_name)
+{
+  auto const num_rows       = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const avg_string_len = state.get_int64("avg_string_len");
+  auto const string_cols    = static_cast<cudf::size_type>(state.get_int64("string_cols"));
+  auto const seed           = deterministic_seed(bench_name, num_rows, avg_string_len, string_cols);
 
-NVBENCH_BENCH(variable_or_fixed_width)
-  .set_name("Fixed or Variable Width")
-  .add_int64_axis("num_rows", {1 * 1024 * 1024, 4 * 1024 * 1024})
-  .add_string_axis("direction", {"to row", "from row"})
-  .add_string_axis("strings", {"include strings", "no strings"});
+  // Eight fixed-width columns (leading types of the default cycle) followed by string columns.
+  std::vector<cudf::type_id> types(default_cycle.begin(), default_cycle.begin() + 8);
+  types.insert(types.end(), string_cols, cudf::type_id::STRING);
+  auto const schema = make_schema(types);
+
+  // Independent draws per element (see run_fixed_width_bench); for strings a repeated sample
+  // pool would additionally make the char-copy kernels artificially cache-hot.
+  data_profile const profile =
+    data_profile_builder().cardinality(0).avg_run_length(1).null_probability(0.1).distribution(
+      cudf::type_id::STRING, distribution_id::NORMAL, int64_t{0}, 2 * avg_string_len);
+  auto table = create_random_table(types, row_count{num_rows}, profile, seed);
+
+  std::vector<cudf::data_type> realized_schema;
+  realized_schema.reserve(types.size());
+  for (auto const& col : table->view()) {
+    realized_schema.push_back(col.type());
+  }
+
+  // One up-front conversion supplies the exact row-buffer size (per-row string payloads make it
+  // data-dependent) and, for from-rows, the timed input batches.
+  auto row_batches            = spark_rapids_jni::convert_to_rows(table->view());
+  auto const row_buffer_bytes = total_row_buffer_bytes(row_batches);
+  state.add_element_count(num_rows, "rows");
+
+  // Setup ran on cudf's default stream and the timed regions run on nvbench's; under per-thread
+  // default stream nothing orders the two, so drain setup before anything is measured.
+  cudf::get_default_stream().synchronize();
+
+  if (dir == direction::to_rows) {
+    state.add_global_memory_reads<int8_t>(realized_table_bytes(table->view()));
+    state.add_global_memory_writes<int8_t>(row_buffer_bytes);
+    row_batches.clear();  // keep each iteration's transient row buffer as the only live copy
+    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      auto const stream = rmm::cuda_stream_view{launch.get_stream()};
+      auto const out    = spark_rapids_jni::convert_to_rows(table->view(), stream);
+    });
+  } else {
+    state.add_global_memory_reads<int8_t>(row_buffer_bytes);
+    state.add_global_memory_writes<int8_t>(reconstructed_table_bytes(table->view()));
+    table.reset();  // the timed loop needs only the row batches and the schema
+    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      auto const stream = rmm::cuda_stream_view{launch.get_stream()};
+      for (auto const& batch : row_batches) {
+        cudf::lists_column_view const list{batch->view()};
+        auto const out = spark_rapids_jni::convert_from_rows(list, realized_schema, stream);
+      }
+    });
+  }
+}
+
+}  // namespace
+
+static void to_rows_fixed(nvbench::state& state)
+{
+  auto const num_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const num_columns = static_cast<cudf::size_type>(state.get_int64("num_columns"));
+  auto const path        = state.get_string("path");
+  run_fixed_width_bench(state,
+                        direction::to_rows,
+                        path == "fixed_opt",
+                        num_rows,
+                        cycle_dtypes(default_cycle, num_columns),
+                        0.1,
+                        deterministic_seed("to_rows_fixed", num_rows, num_columns, path));
+}
+
+static void from_rows_fixed(nvbench::state& state)
+{
+  auto const num_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const num_columns = static_cast<cudf::size_type>(state.get_int64("num_columns"));
+  auto const path        = state.get_string("path");
+  run_fixed_width_bench(state,
+                        direction::from_rows,
+                        path == "fixed_opt",
+                        num_rows,
+                        cycle_dtypes(default_cycle, num_columns),
+                        0.1,
+                        deterministic_seed("from_rows_fixed", num_rows, num_columns, path));
+}
+
+static void to_rows_wide(nvbench::state& state)
+{
+  auto const num_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const num_columns = static_cast<cudf::size_type>(state.get_int64("num_columns"));
+  auto const nulls       = state.get_string("nulls");
+  auto const null_probability =
+    nulls == "none" ? std::optional<double>{} : std::optional<double>{std::stod(nulls)};
+  run_fixed_width_bench(state,
+                        direction::to_rows,
+                        false,
+                        num_rows,
+                        cycle_dtypes(default_cycle, num_columns),
+                        null_probability,
+                        deterministic_seed("to_rows_wide", num_rows, num_columns, nulls));
+}
+
+static void from_rows_wide(nvbench::state& state)
+{
+  auto const num_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const num_columns = static_cast<cudf::size_type>(state.get_int64("num_columns"));
+  auto const nulls       = state.get_string("nulls");
+  auto const null_probability =
+    nulls == "none" ? std::optional<double>{} : std::optional<double>{std::stod(nulls)};
+  run_fixed_width_bench(state,
+                        direction::from_rows,
+                        false,
+                        num_rows,
+                        cycle_dtypes(default_cycle, num_columns),
+                        null_probability,
+                        deterministic_seed("from_rows_wide", num_rows, num_columns, nulls));
+}
+
+static void to_rows_strings(nvbench::state& state)
+{
+  run_strings_bench(state, direction::to_rows, "to_rows_strings");
+}
+
+static void from_rows_strings(nvbench::state& state)
+{
+  run_strings_bench(state, direction::from_rows, "from_rows_strings");
+}
+
+NVBENCH_BENCH(to_rows_fixed)
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  .add_int64_axis("num_columns", {2, 10, 96, 128, 212, 256})
+  .add_string_axis("path", {"general", "fixed_opt"});
+
+NVBENCH_BENCH(from_rows_fixed)
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  .add_int64_axis("num_columns", {2, 10, 96, 128, 212, 256})
+  .add_string_axis("path", {"general", "fixed_opt"});
+
+NVBENCH_BENCH(to_rows_wide)
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  .add_int64_axis("num_columns", {212, 320})
+  .add_string_axis("nulls", {"none", "0.1"});
+
+NVBENCH_BENCH(from_rows_wide)
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  .add_int64_axis("num_columns", {212, 320})
+  .add_string_axis("nulls", {"none", "0.1"});
+
+NVBENCH_BENCH(to_rows_strings)
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  .add_int64_axis("avg_string_len", {16, 128})
+  .add_int64_axis("string_cols", {2, 8});
+
+NVBENCH_BENCH(from_rows_strings)
+  .add_int64_axis("num_rows", {32'768, 262'144, 2'097'152, 16'777'216})
+  .add_int64_axis("avg_string_len", {16, 128})
+  .add_int64_axis("string_cols", {2, 8});

--- a/src/main/cpp/src/RowConversionJni.cpp
+++ b/src/main/cpp/src/RowConversionJni.cpp
@@ -68,7 +68,7 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertToRows(JNIEnv* env, jclass
 
 JNIEXPORT jlongArray JNICALL
 Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRowsFixedWidthOptimized(
-  JNIEnv* env, jclass, jlong input_column, jintArray types, jintArray scale)
+  JNIEnv* env, jclass, jlong input_column, jintArray types, jintArray scale, jboolean all_valid)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, types, "types is null", 0);
@@ -89,15 +89,20 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRowsFixedWidthOptimize
                    n_scale.begin(),
                    std::back_inserter(types_vec),
                    [](jint type, jint scale) { return cudf::jni::make_data_type(type, scale); });
+    // The false case must call the incumbent overload rather than pass a vector of `true`: for a
+    // zero-column schema that vector is empty, and `none_of` over an empty range is true, which
+    // would take the fast path for a caller that declared nothing.
     std::unique_ptr<cudf::table> result =
-      spark_rapids_jni::convert_from_rows_fixed_width_optimized(list_input, types_vec);
+      all_valid ? spark_rapids_jni::convert_from_rows_fixed_width_optimized(
+                    list_input, types_vec, std::vector<bool>(types_vec.size(), false))
+                : spark_rapids_jni::convert_from_rows_fixed_width_optimized(list_input, types_vec);
     return cudf::jni::convert_table_for_return(env, result);
   }
   JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRows(
-  JNIEnv* env, jclass, jlong input_column, jintArray types, jintArray scale)
+  JNIEnv* env, jclass, jlong input_column, jintArray types, jintArray scale, jboolean all_valid)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, types, "types is null", 0);
@@ -118,8 +123,11 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_RowConversion_conv
                    n_scale.begin(),
                    std::back_inserter(types_vec),
                    [](jint type, jint scale) { return cudf::jni::make_data_type(type, scale); });
+    // A branch, not a constructed vector: `none_of` over an empty schema would be true.
     std::unique_ptr<cudf::table> result =
-      spark_rapids_jni::convert_from_rows(list_input, types_vec);
+      all_valid ? spark_rapids_jni::convert_from_rows(
+                    list_input, types_vec, std::vector<bool>(types_vec.size(), false))
+                : spark_rapids_jni::convert_from_rows(list_input, types_vec);
     return cudf::jni::convert_table_for_return(env, result);
   }
   JNI_CATCH(env, 0);

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -16,23 +16,23 @@
 
 #include "nvtx_ranges.hpp"
 #include "row_conversion.hpp"
+#include "row_conversion_jit.hpp"
 #include "utilities/iterator.cuh"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
-#include <cudf/detail/utilities/vector_factories.hpp>
-#include <cudf/filling.hpp>
 #include <cudf/lists/lists_column_device_view.cuh>
 #include <cudf/null_mask.hpp>
-#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/pinned_memory.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -41,37 +41,61 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cooperative_groups.h>
+#include <cuda/atomic>
 #include <cuda/barrier>
 #include <cuda/functional>
+#include <cuda/std/bit>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
 #include <thrust/binary_search.h>
 #include <thrust/scan.h>
+#include <thrust/tabulate.h>
+
+#include <strings.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdarg>
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <iterator>
 #include <limits>
 #include <optional>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace {
 
 constexpr auto JCUDF_ROW_ALIGNMENT = 8;
 
+// Local because `cudf::detail::warp_size` is a private libcudf internal this repo may not use.
+constexpr auto WARP_SIZE = 32;
+
 constexpr auto MAX_BATCH_SIZE = std::numeric_limits<cudf::size_type>::max();
 
 constexpr auto BLOCK_SIZE = 1024;
 
-// Number of rows each block processes in the two kernels. Tuned via nsight
-constexpr auto NUM_STRING_ROWS_PER_BLOCK_TO_ROWS   = BLOCK_SIZE;
-constexpr auto NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS = 64;
-constexpr auto MIN_STRING_BLOCKS                   = 32;
-constexpr auto MAX_STRING_BLOCKS                   = MAX_BATCH_SIZE;
+// Number of rows each block processes in the string to-rows kernel. Tuned via nsight
+constexpr auto NUM_STRING_ROWS_PER_BLOCK_TO_ROWS = BLOCK_SIZE;
+constexpr auto MAX_STRING_BLOCKS                 = MAX_BATCH_SIZE;
+
+// From-rows string copy engine geometry: four warps per block, matching cudf's strings-gather
+constexpr auto STRING_COPY_WARPS_PER_BLOCK = 4;
+constexpr auto STRING_COPY_BLOCK_SIZE      = STRING_COPY_WARPS_PER_BLOCK * 32;
+
+// Grid x-dimension cap of the warp-per-string from-rows kernel; its warps grid-stride over rows
+constexpr auto MAX_STRING_COPY_BLOCKS = 65536;
+
+// Mean string length above which the from-rows string copy picks the warp-per-string kernel
+constexpr auto STRING_COPY_AVG_LEN_SWITCH = 32;
+
+// Strings staged per block by the char-parallel from-rows kernel
+constexpr auto STRING_COPY_STRINGS_PER_BLOCK = 32;
 
 }  // anonymous namespace
 
@@ -79,8 +103,6 @@ constexpr auto MAX_STRING_BLOCKS                   = MAX_BATCH_SIZE;
 #pragma nv_diag_suppress static_var_with_dynamic_init
 
 using namespace cudf;
-using detail::make_device_uvector;
-using detail::make_device_uvector_async;
 using rmm::device_uvector;
 
 namespace spark_rapids_jni {
@@ -164,9 +186,8 @@ struct tile_info {
                                        JCUDF_ROW_ALIGNMENT);
   }
 
-  // Real, un-padded data width spanned by this tile. Used as the memcpy_async length when
-  // writing the shared tile out to global memory (and when reading it in for the from-rows
-  // direction). Writing only the actual bytes prevents the JCUDF_ROW_ALIGNMENT rounding in
+  // Real, un-padded data width spanned by this tile. Bounds the write of the shared tile out to
+  // global memory: writing only the actual bytes prevents the JCUDF_ROW_ALIGNMENT rounding in
   // get_shared_row_size() from spilling into the next tile's output region — a race that can
   // corrupt data non-deterministically when the cumulative size at the tile boundary is not
   // an 8-byte multiple (e.g. an odd number of INT32 columns in the first tile).
@@ -198,11 +219,120 @@ struct row_batch {
  *
  */
 struct batch_data {
-  device_uvector<size_type> batch_row_offsets;       // offsets to each row in incoming data
-  device_uvector<size_type> d_batch_row_boundaries;  // row numbers for the start of each batch
+  device_uvector<size_type> batch_row_offsets;  // offsets to each row in incoming data
   std::vector<size_type>
     batch_row_boundaries;              // row numbers for the start of each batch: 0, 1500, 2700
   std::vector<row_batch> row_batches;  // information about each batch such as byte count
+};
+
+/**
+ * @brief Packs per-conversion host metadata into pinned memory, one batched H2D copy per pack.
+ *
+ * Pinned staging is required, not an optimization: a pageable async copy either degrades to
+ * synchronous (pre CUDA 13) or reads its host source only when the stream executes it (CUDA 13+),
+ * outliving the staging vector.
+ *
+ * Pinned-pool reuse is stream-ordered, which orders device work but never a host `memcpy`
+ * against a queued copy, so both directions need an explicit event: the destructor waits on the
+ * upload event before the block returns to the pool, and `upload` drains once before its host
+ * write because the block it just took may still be a previous owner's copy source.
+ */
+class staging_arena {
+ public:
+  explicit staging_arena(rmm::cuda_stream_view stream) : _stream{stream} {}
+
+  staging_arena(staging_arena const&)            = delete;
+  staging_arena& operator=(staging_arena const&) = delete;
+
+  ~staging_arena()
+  {
+    // Errors are ignored: destructors must not throw, and a failure would surface on the stream.
+    for (auto& round : _rounds) {
+      cudaEventSynchronize(round.event);
+      cudaEventDestroy(round.event);
+    }
+  }
+
+  /**
+   * @brief Copies the given host arrays into one pinned block at 16-byte-aligned offsets and
+   * enqueues a single H2D copy of that block on the arena stream.
+   *
+   * @tparam Ts element type of each packed array; every one must be trivially copyable and no
+   * more strictly aligned than PACK_ALIGNMENT
+   * @param arrays host arrays to pack, in the order their device pointers are returned
+   * @return one device pointer per input array, valid for stream-ordered use while the arena
+   * lives; empty arrays yield nullptr
+   */
+  template <typename... Ts>
+  std::tuple<Ts*...> upload(std::vector<Ts> const&... arrays)
+  {
+    // The packing memcpy and the returned casts are only defined under these two bounds.
+    static_assert((std::is_trivially_copyable_v<Ts> && ...));
+    static_assert(((alignof(Ts) <= PACK_ALIGNMENT) && ...));
+
+    std::array<std::size_t, sizeof...(Ts)> offsets{};
+    std::size_t total = 0;
+    {
+      std::size_t i = 0;
+      ((offsets[i++] = total,
+        total += cudf::util::round_up_safe(arrays.size() * sizeof(Ts), PACK_ALIGNMENT)),
+       ...);
+    }
+    if (total == 0) { return {static_cast<Ts*>(nullptr)...}; }
+
+    upload_round round{
+      rmm::device_buffer{
+        total, _stream, rmm::device_async_resource_ref{cudf::get_pinned_memory_resource()}},
+      rmm::device_buffer{total, _stream, cudf::get_current_device_resource_ref()},
+      nullptr};
+
+    // The block may still be a previous owner's copy source, which pool ordering does not cover.
+    _stream.synchronize();
+
+    {
+      auto* const pinned_base = static_cast<char*>(round.pinned.data());
+      std::size_t i           = 0;
+      auto pack               = [&](void const* src, std::size_t bytes) {
+        if (bytes > 0) { std::memcpy(pinned_base + offsets[i], src, bytes); }
+        ++i;
+      };
+      (pack(arrays.data(), arrays.size() * sizeof(Ts)), ...);
+    }
+
+    try {
+      CUDF_CUDA_TRY(cudaMemcpyAsync(
+        round.device.data(), round.pinned.data(), total, cudaMemcpyHostToDevice, _stream.value()));
+      CUDF_CUDA_TRY(cudaEventCreateWithFlags(&round.event, cudaEventDisableTiming));
+      CUDF_CUDA_TRY(cudaEventRecord(round.event, _stream.value()));
+      _rounds.push_back(std::move(round));
+    } catch (...) {
+      // The copy may already be enqueued; retire it before the buffers are freed.
+      cudaStreamSynchronize(_stream.value());
+      if (round.event != nullptr) { cudaEventDestroy(round.event); }
+      throw;
+    }
+
+    auto* const device_base = static_cast<char*>(_rounds.back().device.data());
+    return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+      return std::tuple<Ts*...>{
+        (arrays.empty() ? nullptr : reinterpret_cast<Ts*>(device_base + offsets[Is]))...};
+    }(std::index_sequence_for<Ts...>{});
+  }
+
+ private:
+  // Covers the alignment of every packed element type: size_type, pointers, tile_info and
+  // input_offsetalator.
+  static constexpr std::size_t PACK_ALIGNMENT = 16;
+
+  // Cleanup lives solely in the arena destructor, so vector reallocation may shallow-move rounds.
+  struct upload_round {
+    rmm::device_buffer pinned;  // host-writable: allocated from the pinned pool
+    rmm::device_buffer device;
+    cudaEvent_t event;
+  };
+
+  rmm::cuda_stream_view _stream;
+  std::vector<upload_round> _rounds;
 };
 
 /**
@@ -210,53 +340,50 @@ struct batch_data {
  *
  * @param tbl table from which to compute row size information
  * @param fixed_width_and_validity_size size of fixed-width and validity data in this table
+ * @param arena staging arena the offset iterators are uploaded through
  * @param stream cuda stream on which to operate
- * @return pair of device vector of size_types of the row sizes of the table and a device vector of
- * offsets into the string column
+ * @return pair of device vector of size_types of the row sizes of the table and a device span of
+ * offsets into the string columns, valid while the arena lives
  */
-std::pair<rmm::device_uvector<size_type>, rmm::device_uvector<cudf::detail::input_offsetalator>>
+std::pair<rmm::device_uvector<size_type>, device_span<cudf::detail::input_offsetalator>>
 build_string_row_offsets(table_view const& tbl,
                          size_type fixed_width_and_validity_size,
+                         staging_arena& arena,
                          rmm::cuda_stream_view stream)
 {
   auto const num_rows = tbl.num_rows();
   rmm::device_uvector<size_type> d_row_sizes(num_rows, stream);
   thrust::uninitialized_fill(rmm::exec_policy(stream), d_row_sizes.begin(), d_row_sizes.end(), 0);
 
-  auto d_offsets_iterators = [&]() {
-    std::vector<cudf::detail::input_offsetalator> offsets_iterators;
-    auto itr = cuda::make_transform_iterator(
-      tbl.begin(), [](auto const& col) -> cudf::detail::input_offsetalator {
-        return cudf::detail::offsetalator_factory::make_input_iterator(
-          strings_column_view(col).offsets(), col.offset());
-      });
-    auto stencil = cuda::make_transform_iterator(
-      tbl.begin(), [](auto const& col) -> bool { return !is_fixed_width(col.type()); });
-    thrust::copy_if(thrust::host,
-                    itr,
-                    itr + tbl.num_columns(),
-                    stencil,
-                    std::back_inserter(offsets_iterators),
-                    cuda::std::identity{});
-    return make_device_uvector(
-      offsets_iterators, stream, rmm::mr::get_current_device_resource_ref());
-  }();
+  std::vector<cudf::detail::input_offsetalator> offsets_iterators;
+  auto itr = cuda::make_transform_iterator(
+    tbl.begin(), [](auto const& col) -> cudf::detail::input_offsetalator {
+      return cudf::detail::offsetalator_factory::make_input_iterator(
+        strings_column_view(col).offsets(), col.offset());
+    });
+  auto stencil = cuda::make_transform_iterator(
+    tbl.begin(), [](auto const& col) -> bool { return !is_fixed_width(col.type()); });
+  thrust::copy_if(thrust::host,
+                  itr,
+                  itr + tbl.num_columns(),
+                  stencil,
+                  std::back_inserter(offsets_iterators),
+                  cuda::std::identity{});
+  auto* const d_offsets_iterators = std::get<0>(arena.upload(offsets_iterators));
 
-  auto const num_columns = static_cast<size_type>(d_offsets_iterators.size());
+  auto const num_columns = static_cast<size_type>(offsets_iterators.size());
 
-  thrust::for_each(rmm::exec_policy(stream),
-                   cuda::make_counting_iterator(0),
-                   cuda::make_counting_iterator(num_columns * num_rows),
-                   [d_offsets_iterators = d_offsets_iterators.data(),
-                    num_columns,
-                    num_rows,
-                    d_row_sizes = d_row_sizes.data()] __device__(auto element_idx) {
-                     auto const row = element_idx % num_rows;
-                     auto const col = element_idx / num_rows;
-                     auto const val =
-                       d_offsets_iterators[col][row + 1] - d_offsets_iterators[col][row];
-                     atomicAdd(&d_row_sizes[row], val);
-                   });
+  thrust::for_each(
+    rmm::exec_policy(stream),
+    cuda::make_counting_iterator(0),
+    cuda::make_counting_iterator(num_columns * num_rows),
+    [d_offsets_iterators, num_columns, num_rows, d_row_sizes = d_row_sizes.data()] __device__(
+      auto element_idx) {
+      auto const row = element_idx % num_rows;
+      auto const col = element_idx / num_rows;
+      auto const val = d_offsets_iterators[col][row + 1] - d_offsets_iterators[col][row];
+      atomicAdd(&d_row_sizes[row], val);
+    });
 
   // transform the row sizes to include fixed width size and alignment
   thrust::transform(rmm::exec_policy(stream),
@@ -269,7 +396,9 @@ build_string_row_offsets(table_view const& tbl,
                                                            JCUDF_ROW_ALIGNMENT);
                       }));
 
-  return {std::move(d_row_sizes), std::move(d_offsets_iterators)};
+  return {
+    std::move(d_row_sizes),
+    device_span<cudf::detail::input_offsetalator>{d_offsets_iterators, offsets_iterators.size()}};
 }
 
 /**
@@ -316,7 +445,8 @@ struct fixed_width_row_offset_functor {
  * @param input_offset_in_row offset to each row of data
  * @param num_bytes total number of bytes in the incoming data
  * @param output_data array of pointers to the output data
- * @param output_nm array of pointers to the output null masks
+ * @param output_nm array of pointers to the output null masks, or nullptr when the caller has
+ * observed that the rows carry no nulls — the kernel then skips its validity phase entirely
  * @param input_data pointing to the incoming row data
  */
 CUDF_KERNEL void copy_from_rows_fixed_width_optimized(size_type const num_rows,
@@ -425,12 +555,16 @@ CUDF_KERNEL void copy_from_rows_fixed_width_optimized(size_type const num_rows,
           }
         }
 
-        bitmask_type* nm          = output_nm[col_index];
-        int8_t* valid_byte        = &row_vld_tmp[col_index / 8];
-        size_type byte_bit_offset = col_index % 8;
-        int predicate             = *valid_byte & (1 << byte_bit_offset);
-        uint32_t bitmask          = __ballot_sync(active_mask, predicate);
-        if (row_index % 32 == 0) { nm[word_index(row_index)] = bitmask; }
+        // The trusted all-valid path passes output_nm == nullptr; the guard is a kernel argument,
+        // so every thread of active_mask skips the ballot together and no mask is written.
+        if (output_nm != nullptr) {
+          bitmask_type* nm          = output_nm[col_index];
+          int8_t* valid_byte        = &row_vld_tmp[col_index / 8];
+          size_type byte_bit_offset = col_index % 8;
+          int predicate             = *valid_byte & (1 << byte_bit_offset);
+          uint32_t bitmask          = __ballot_sync(active_mask, predicate);
+          if (row_index % 32 == 0) { nm[word_index(row_index)] = bitmask; }
+        }
       }  // end column loop
     }  // end row copy
     // wait for the row_group to be totally copied before starting on the next row group
@@ -611,8 +745,17 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(size_type const num_
   auto const warp  = cooperative_groups::tiled_partition<cudf::detail::warp_size>(group);
   extern __shared__ int8_t shared_data[];
 
-  __shared__ cuda::barrier<cuda::thread_scope_block> tile_barrier;
-  if (group.thread_rank() == 0) { init(&tile_barrier, group.size()); }
+  // Tile-relative indices of the first and last columns with a non-null data pointer. Columns
+  // with a null pointer are variable-width (offset,length) slots whose final bytes
+  // `copy_strings_to_rows` writes later on this stream, so the row drain below can skip the
+  // leading and trailing runs of them. No cuda::barrier is needed: the drain uses plain stores,
+  // which complete when the kernel exits.
+  __shared__ size_type first_live_col_shared;
+  __shared__ size_type last_live_col_shared;
+  if (group.thread_rank() == 0) {
+    first_live_col_shared = cuda::std::numeric_limits<size_type>::max();
+    last_live_col_shared  = -1;
+  }
   group.sync();
 
   auto const tile                   = tile_infos[blockIdx.x];
@@ -643,6 +786,14 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(size_type const num_
     if (col_ptr == nullptr) {
       // variable-width data column
       continue;
+    }
+
+    // One lane per column extends the live-column span over the columns this warp writes.
+    if (warp.thread_rank() == 0) {
+      cuda::atomic_ref<size_type, cuda::thread_scope_block> first_live{first_live_col_shared};
+      cuda::atomic_ref<size_type, cuda::thread_scope_block> last_live{last_live_col_shared};
+      first_live.fetch_min(relative_col, cuda::memory_order_relaxed);
+      last_live.fetch_max(relative_col, cuda::memory_order_relaxed);
     }
 
     for (int relative_row = warp.thread_rank(); relative_row < num_tile_rows;
@@ -687,23 +838,61 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(size_type const num_
   auto const tile_output_buffer = output_data[tile.batch_number];
   auto const row_batch_start = tile.batch_number == 0 ? 0 : batch_row_boundaries[tile.batch_number];
 
-  // no async copies above waiting on the barrier, so we sync the group here to ensure all copies to
-  // shared memory are completed before copying data out
+  // ensure all shared-memory writes (staged elements and the live-column bounds) land before the
+  // row drain reads them
   group.sync();
 
-  // each warp takes a row
-  for (int copy_row = warp.meta_group_rank(); copy_row < tile.num_rows();
-       copy_row += warp.meta_group_size()) {
-    auto const src = &shared_data[tile_row_size * copy_row];
-    auto const dst = tile_output_buffer + row_offsets(copy_row + tile.start_row, row_batch_start) +
-                     starting_column_offset;
-    // Use actual_row_size (un-padded) so the JCUDF_ROW_ALIGNMENT rounding inside the shared
-    // tile never reaches into the next tile's output region — see tile_info::get_actual_row_size.
-    cuda::memcpy_async(warp, dst, src, actual_row_size, tile_barrier);
-  }
+  // Leading and trailing runs of variable-width columns pack their 8-byte (offset,length) slots
+  // gap-free against the tile's byte edges, and `copy_strings_to_rows` overwrites every slot
+  // afterwards on this stream, so the drain skips exactly those dead bytes. Alignment holes
+  // beside fixed-width columns stay inside the drained span, and bounding by the un-padded
+  // actual_row_size keeps this tile's alignment rounding out of the next tile's output region.
+  if (first_live_col_shared <= last_live_col_shared) {
+    constexpr size_type slot_size = sizeof(uint32_t) + sizeof(uint32_t);
+    auto const drain_begin        = slot_size * first_live_col_shared;
+    auto const drain_end = actual_row_size - slot_size * (num_tile_cols - 1 - last_live_col_shared);
+    auto const drain_bytes = drain_end - drain_begin;
+    // One tile-uniform destination phase decides the word width: row offsets and drain_begin are
+    // both 8-byte multiples, so dst % 8 == starting_column_offset % 8 for every row, while the
+    // shared source is always 8-byte aligned (the shared row stride is an 8-byte multiple). The
+    // column march only opens a band on an 8- or 4-byte phase, so the byte fallback is defensive.
+    auto const dst_phase = starting_column_offset & (JCUDF_ROW_ALIGNMENT - 1);
+    auto const lane      = static_cast<size_type>(warp.thread_rank());
 
-  // wait on the last copies to complete
-  tile_barrier.arrive_and_wait();
+    // each warp takes a row
+    for (int copy_row = warp.meta_group_rank(); copy_row < tile.num_rows();
+         copy_row += warp.meta_group_size()) {
+      auto const src = &shared_data[tile_row_size * copy_row + drain_begin];
+      auto const dst = tile_output_buffer +
+                       row_offsets(copy_row + tile.start_row, row_batch_start) +
+                       starting_column_offset + drain_begin;
+      if (dst_phase == 0) {
+        auto const num_words = drain_bytes / static_cast<size_type>(sizeof(int64_t));
+        for (auto word = lane; word < num_words; word += warp.size()) {
+          reinterpret_cast<int64_t*>(dst)[word] = reinterpret_cast<int64_t const*>(src)[word];
+        }
+        for (auto byte = num_words * static_cast<size_type>(sizeof(int64_t)) + lane;
+             byte < drain_bytes;
+             byte += warp.size()) {
+          dst[byte] = src[byte];
+        }
+      } else if ((dst_phase & 3) == 0) {
+        auto const num_words = drain_bytes / static_cast<size_type>(sizeof(int32_t));
+        for (auto word = lane; word < num_words; word += warp.size()) {
+          reinterpret_cast<int32_t*>(dst)[word] = reinterpret_cast<int32_t const*>(src)[word];
+        }
+        for (auto byte = num_words * static_cast<size_type>(sizeof(int32_t)) + lane;
+             byte < drain_bytes;
+             byte += warp.size()) {
+          dst[byte] = src[byte];
+        }
+      } else {
+        for (auto byte = lane; byte < drain_bytes; byte += warp.size()) {
+          dst[byte] = src[byte];
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -897,7 +1086,7 @@ __launch_bounds__(block_size) CUDF_KERNEL
  * @tparam RowOffsetFunctor iterator that gives the size of a specific row of the table.
  * @param num_rows total number of rows in the table
  * @param num_columns total number of columns in the table
- * @param shmem_used_per_tile amount of shared memory that is used by a tile
+ * @param shmem_used_per_tile shared-memory budget the tiles were shaped against; unused here
  * @param row_offsets offset to a specific row in the input data
  * @param batch_row_boundaries row numbers for batch starts
  * @param output_data pointers to column data
@@ -920,85 +1109,68 @@ __launch_bounds__(block_size) CUDF_KERNEL
                       device_span<tile_info const> tile_infos,
                       int8_t const* input_data)
 {
-  // We are going to copy the data in two passes.
-  // The first pass copies a chunk of data into shared memory.
-  // The second pass copies that chunk from shared memory out to the final location.
-
-  // Because shared memory is limited we copy a subset of the rows at a time. This has been broken
-  // up for us in the tile_info struct, so we don't have any calculation to do here, but it is
-  // important to note.
-
-  // To speed up some of the random access memory we do, we copy col_sizes and col_offsets to shared
-  // memory for each of the tiles that we work on
-
+  // Direct gather: no shared staging, no synchronization. Warp lanes walk consecutive rows of
+  // one column so the stores coalesce, while the strided row reads rely on L1, where a sector
+  // fetched for one column is re-hit by neighbouring columns of the same rows. The host requests
+  // a max-L1 carveout for this kernel, which the driver may decline.
   auto const group = cooperative_groups::this_thread_block();
   auto const warp  = cooperative_groups::tiled_partition<cudf::detail::warp_size>(group);
-  extern __shared__ int8_t shared[];
 
-  // Initialize cuda barriers for each tile.
-  __shared__ cuda::barrier<cuda::thread_scope_block> tile_barrier;
-  if (group.thread_rank() == 0) { init(&tile_barrier, group.size()); }
-  group.sync();
+  auto const tile            = tile_infos[blockIdx.x];
+  auto const rows_in_tile    = tile.num_rows();
+  auto const cols_in_tile    = tile.num_cols();
+  auto const row_batch_start = tile.batch_number == 0 ? 0 : batch_row_boundaries[tile.batch_number];
 
-  {
-    auto const fetch_tile            = tile_infos[blockIdx.x];
-    auto const fetch_tile_start_row  = fetch_tile.start_row;
-    auto const starting_col_offset   = col_offsets[fetch_tile.start_col];
-    auto const fetch_tile_row_size   = fetch_tile.get_shared_row_size(col_offsets, col_sizes);
-    auto const fetch_actual_row_size = fetch_tile.get_actual_row_size(col_offsets, col_sizes);
-    auto const row_batch_start =
-      fetch_tile.batch_number == 0 ? 0 : batch_row_boundaries[fetch_tile.batch_number];
+  for (int relative_row = warp.thread_rank(); relative_row < rows_in_tile;
+       relative_row += warp.size()) {
+    auto const absolute_row = relative_row + tile.start_row;
+    // One row-offset functor evaluation per row, held in a register across the column sweep.
+    auto const row_start = row_offsets(absolute_row, row_batch_start);
 
-    for (int absolute_row = warp.meta_group_rank() + fetch_tile.start_row;
-         absolute_row <= fetch_tile.end_row;
-         absolute_row += warp.meta_group_size()) {
-      warp.sync();
-      auto shared_offset = (absolute_row - fetch_tile_start_row) * fetch_tile_row_size;
-      auto dst           = &shared[shared_offset];
-      auto src = &input_data[row_offsets(absolute_row, row_batch_start) + starting_col_offset];
-      // Shared stride stays padded (8-aligned for fast access); only fetch the bytes that
-      // actually belong to this tile so we never reach past the tile's column range.
-      cuda::memcpy_async(warp, dst, src, fetch_actual_row_size, tile_barrier);
-    }
-  }
+    for (int relative_col = warp.meta_group_rank(); relative_col < cols_in_tile;
+         relative_col += warp.meta_group_size()) {
+      auto const absolute_col = relative_col + tile.start_col;
+      auto const column_size  = col_sizes[absolute_col];
 
-  {
-    auto const tile          = tile_infos[blockIdx.x];
-    auto const rows_in_tile  = tile.num_rows();
-    auto const cols_in_tile  = tile.num_cols();
-    auto const tile_row_size = tile.get_shared_row_size(col_offsets, col_sizes);
+      int8_t const* src = &input_data[row_start + col_offsets[absolute_col]];
+      int8_t* dst       = &output_data[absolute_col][absolute_row * column_size];
 
-    // ensure our data is ready
-    tile_barrier.arrive_and_wait();
-
-    // Now we copy from shared memory to final destination. The data is laid out in rows in shared
-    // memory, so the reads for a column will be "vertical". Because of this and the different sizes
-    // for each column, this portion is handled on row/column basis. to prevent each thread working
-    // on a single row and also to ensure that all threads can do work in the case of more threads
-    // than rows, we do a global index instead of a double for loop with col/row.
-    for (int relative_row = warp.thread_rank(); relative_row < rows_in_tile;
-         relative_row += warp.size()) {
-      auto const absolute_row             = relative_row + tile.start_row;
-      auto const shared_memory_row_offset = tile_row_size * relative_row;
-
-      for (int relative_col = warp.meta_group_rank(); relative_col < cols_in_tile;
-           relative_col += warp.meta_group_size()) {
-        auto const absolute_col = relative_col + tile.start_col;
-
-        auto const shared_memory_offset =
-          col_offsets[absolute_col] - col_offsets[tile.start_col] + shared_memory_row_offset;
-        auto const column_size = col_sizes[absolute_col];
-
-        int8_t* shmem_src = &shared[shared_memory_offset];
-        int8_t* dst       = &output_data[absolute_col][absolute_row * column_size];
-
-        cuda::memcpy_async(dst, shmem_src, column_size, tile_barrier);
+      // Full-width copies are safe: JCUDF row starts are 8-byte aligned with each column's offset
+      // aligned to its element size, and dst is an rmm allocation base plus an element-size
+      // multiple.
+      switch (column_size) {
+        case 2: {
+          int16_t const* short_col_input   = reinterpret_cast<int16_t const*>(src);
+          *reinterpret_cast<int16_t*>(dst) = *short_col_input;
+          break;
+        }
+        case 4: {
+          int32_t const* int_col_input     = reinterpret_cast<int32_t const*>(src);
+          *reinterpret_cast<int32_t*>(dst) = *int_col_input;
+          break;
+        }
+        case 8: {
+          int64_t const* long_col_input    = reinterpret_cast<int64_t const*>(src);
+          *reinterpret_cast<int64_t*>(dst) = *long_col_input;
+          break;
+        }
+        case 1: *dst = *src; break;
+        case 16: {
+          // decimal128: rows are only 8-byte aligned, so read two 8-byte halves and emit them as
+          // one 16-byte store to the 16-byte-aligned destination.
+          int64_t const* long_col_input      = reinterpret_cast<int64_t const*>(src);
+          *reinterpret_cast<longlong2*>(dst) = longlong2{long_col_input[0], long_col_input[1]};
+          break;
+        }
+        default: {
+          for (int i = 0; i < column_size; ++i) {
+            dst[i] = src[i];
+          }
+          break;
+        }
       }
     }
   }
-
-  // wait on the last copies to complete
-  tile_barrier.arrive_and_wait();
 }
 
 /**
@@ -1008,13 +1180,15 @@ __launch_bounds__(block_size) CUDF_KERNEL
  * @tparam RowOffsetFunctor iterator that gives the size of a specific row of the table.
  * @param num_rows total number of rows in the table
  * @param num_columns total number of columns in the table
- * @param shmem_used_per_tile amount of shared memory that is used by a tile
+ * @param shmem_used_per_tile dynamic shared memory allocated for this launch; the per-column
+ * counters are placed inside it, so a larger value than the launch reserves overruns `shared[]`
  * @param row_offsets offset to the first column a specific row in the input data
  * @param batch_row_boundaries row numbers for batch starts
  * @param output_nm pointers to null masks for columns
  * @param validity_offsets offset into input data row for validity data
  * @param tile_infos information about the tiles of work
  * @param input_data pointer to input data
+ * @param valid_counts per-column valid-row counts, accumulated atomically across all tiles
  *
  */
 template <int block_size, typename RowOffsetFunctor>
@@ -1027,7 +1201,8 @@ __launch_bounds__(block_size) CUDF_KERNEL
                                bitmask_type** output_nm,
                                size_type const validity_offset,
                                device_span<tile_info const> tile_infos,
-                               int8_t const* input_data)
+                               int8_t const* input_data,
+                               size_type* valid_counts)
 {
   extern __shared__ int8_t shared[];
 
@@ -1070,6 +1245,21 @@ __launch_bounds__(block_size) CUDF_KERNEL
   auto const validity_data_col_length = num_sections_y * 4;  // words to bytes
   auto const total_sections           = num_sections_x * num_sections_y;
 
+  // Per-column valid-bit counters live in the dynamic-shmem tail past the validity words;
+  // shmem_used_per_tile is the dynamic-shmem allocation at both launch sites, making the
+  // block-uniform fit check exact. A tile shape with no tail slack (none produced by
+  // build_validity_tile_infos for 48KB-class limits) falls back to per-word global adds.
+  auto const validity_bytes  = validity_data_col_length * num_tile_cols;
+  auto const counts_bytes    = static_cast<size_type>(sizeof(size_type)) * num_tile_cols;
+  bool const counts_in_shmem = validity_bytes + counts_bytes <= shmem_used_per_tile;
+  auto const shared_counts   = reinterpret_cast<size_type*>(&shared[validity_bytes]);
+  if (counts_in_shmem) {
+    for (int i = group.thread_rank(); i < num_tile_cols; i += block_size) {
+      shared_counts[i] = 0;
+    }
+  }
+  group.sync();
+
   // the tile is divided into sections. A warp operates on a section at a time.
   for (int my_section_idx = warp.meta_group_rank(); my_section_idx < total_sections;
        my_section_idx += warp.meta_group_size()) {
@@ -1092,7 +1282,9 @@ __launch_bounds__(block_size) CUDF_KERNEL
       // so every thread that is participating in the warp has a byte, but it's row-based data and
       // we need it in column-based. So we shuffle the bits around to make the bytes we actually
       // write.
-      for (int i = 0, byte_mask = 0x1; (i < cols_per_read) && ((relative_col + i) < num_columns);
+      // Bound by the tile's own column count so a phantom word past the last real column is
+      // neither written nor counted.
+      for (int i = 0, byte_mask = 0x1; (i < cols_per_read) && ((relative_col + i) < num_tile_cols);
            ++i, byte_mask <<= 1) {
         auto const validity_data = __ballot_sync(participation_mask, my_byte & byte_mask);
         // lead thread in each warp writes data
@@ -1100,6 +1292,16 @@ __launch_bounds__(block_size) CUDF_KERNEL
           auto const validity_write_offset =
             validity_data_col_length * (relative_col + i) + relative_row / cols_per_read;
           *reinterpret_cast<bitmask_type*>(&shared[validity_write_offset]) = validity_data;
+          // Tail bits of a partial section are ballot zeros, so popc adds in-range rows only.
+          if (counts_in_shmem) {
+            cuda::atomic_ref<size_type, cuda::thread_scope_block> ref(
+              shared_counts[relative_col + i]);
+            ref.fetch_add(cuda::std::popcount(validity_data), cuda::memory_order_relaxed);
+          } else {
+            cuda::atomic_ref<size_type, cuda::thread_scope_device> ref(
+              valid_counts[tile_start_col + relative_col + i]);
+            ref.fetch_add(cuda::std::popcount(validity_data), cuda::memory_order_relaxed);
+          }
         }
       }
     }
@@ -1110,6 +1312,14 @@ __launch_bounds__(block_size) CUDF_KERNEL
 
   // make sure entire tile has finished copy
   group.sync();
+
+  // Flush this tile's counters; totals accumulate atomically across tiles per output column.
+  if (counts_in_shmem) {
+    for (int i = group.thread_rank(); i < num_tile_cols; i += block_size) {
+      cuda::atomic_ref<size_type, cuda::thread_scope_device> ref(valid_counts[tile_start_col + i]);
+      ref.fetch_add(shared_counts[i], cuda::memory_order_relaxed);
+    }
+  }
 
   for (int relative_col = warp.meta_group_rank(); relative_col < num_tile_cols;
        relative_col += warp.meta_group_size()) {
@@ -1126,67 +1336,181 @@ __launch_bounds__(block_size) CUDF_KERNEL
   shared_tile_barrier.arrive_and_wait();
 }
 
+// Load 16B from a potentially unaligned address via aligned 4B words funnel-shifted into place.
+// Reads bytes in [ptr - 3, ptr + 20), so callers must keep that window inside the source buffer.
+__forceinline__ __device__ uint4 load_uint4(char const* ptr)
+{
+  auto const offset       = reinterpret_cast<std::uintptr_t>(ptr) % 4;
+  auto const* aligned_ptr = reinterpret_cast<unsigned int const*>(ptr - offset);
+  auto const shift        = offset * 8;
+
+  uint4 regs = {aligned_ptr[0], aligned_ptr[1], aligned_ptr[2], aligned_ptr[3]};
+  uint tail  = 0;
+  if (shift) { tail = aligned_ptr[4]; }
+
+  regs.x = __funnelshift_r(regs.x, regs.y, shift);
+  regs.y = __funnelshift_r(regs.y, regs.z, shift);
+  regs.z = __funnelshift_r(regs.z, regs.w, shift);
+  regs.w = __funnelshift_r(regs.w, tail, shift);
+
+  return regs;
+}
+
 /**
- * @brief copies string data from jcudf row format to cudf columns
+ * @brief copies string data from jcudf row format to cudf columns, one output byte per thread
  *
- * @tparam block_size number of threads in a block.
- * @tparam RowOffsetFunctor iterator for row offsets into the destination data
+ * Port of cudf's strings-gather char-parallel kernel: each block stages the offsets window and the
+ * source address of each of its strings in shared memory, then threads write consecutive output
+ * bytes, binary-searching the window for the owning string. Suited to short strings, where dense
+ * byte stores beat one-warp-per-string copies. Columns map to blockIdx.y.
+ *
+ * @tparam strings_per_block number of strings each block copies
+ * @tparam RowOffsetFunctor iterator for row offsets into the input jcudf row data
  * @param row_offsets offsets for each row in input data
  * @param string_row_offsets offset data into jcudf row data for each string
- * @param string_lengths length of each incoming string in each column
  * @param string_column_offsets offset column data for cudf column
  * @param string_col_data output cudf string column data
  * @param row_data jcudf row data
  * @param num_rows number of rows in data
  * @param num_string_columns number of string columns in the table
  */
-template <int block_size, typename RowOffsetFunctor>
-__launch_bounds__(block_size) CUDF_KERNEL
-  void copy_strings_from_rows(RowOffsetFunctor row_offsets,
-                              int32_t** string_row_offsets,
-                              int32_t** string_lengths,
-                              size_type** string_column_offsets,
-                              char** string_col_data,
-                              int8_t const* row_data,
-                              size_type const num_rows,
-                              size_type const num_string_columns)
+template <int strings_per_block, typename RowOffsetFunctor>
+__launch_bounds__(STRING_COPY_BLOCK_SIZE) CUDF_KERNEL
+  void copy_strings_from_rows_char_parallel(RowOffsetFunctor row_offsets,
+                                            int32_t** string_row_offsets,
+                                            size_type** string_column_offsets,
+                                            char** string_col_data,
+                                            int8_t const* row_data,
+                                            size_type const num_rows,
+                                            size_type const num_string_columns)
 {
-  // Each warp takes a tile, which is a single column and up to ROWS_PER_BLOCK rows. A tile will not
-  // wrap around the bottom of the table. The warp will copy the strings for each row in the tile.
-  // Traversing in row-major order to coalesce the offsets and size reads.
-  auto my_block = cooperative_groups::this_thread_block();
-  auto warp     = cooperative_groups::tiled_partition<cudf::detail::warp_size>(my_block);
+  // Offsets window plus per-string source addresses, staged so the per-byte loop does one
+  // shared-memory lookup per side instead of three dependent global loads.
+  __shared__ size_type block_offsets[strings_per_block + 1];
+  __shared__ char const* block_src[strings_per_block];
 
-  // The barrier must be __shared__, initialized, and waited on; see the matching comment in
-  // copy_strings_to_rows.
-  __shared__ cuda::barrier<cuda::thread_scope_block> block_barrier;
-  if (my_block.thread_rank() == 0) { init(&block_barrier, my_block.size()); }
-  my_block.sync();
+  auto const begin_row         = static_cast<size_type>(blockIdx.x) * strings_per_block;
+  auto const num_block_strings = cuda::std::min(strings_per_block, num_rows - begin_row);
+  if (num_block_strings <= 0) { return; }
 
-  // workaround for not being able to take a reference to a constexpr host variable
-  auto const ROWS_PER_BLOCK = NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS;
-  auto const tiles_per_col  = cudf::util::div_rounding_up_unsafe(num_rows, ROWS_PER_BLOCK);
-  auto const starting_tile  = blockIdx.x * warp.meta_group_size() + warp.meta_group_rank();
-  auto const num_tiles      = tiles_per_col * num_string_columns;
-  auto const tile_stride    = warp.meta_group_size() * gridDim.x;
-  // Each warp will copy strings in its tile. This is handled by all the threads of a warp passing
-  // the same parameters to async_memcpy and all threads in the warp participating in the copy.
-  for (auto my_tile = starting_tile; my_tile < num_tiles; my_tile += tile_stride) {
-    auto const starting_row = (my_tile % tiles_per_col) * ROWS_PER_BLOCK;
-    auto const col          = my_tile / tiles_per_col;
-    auto const str_len      = string_lengths[col];
-    auto const str_row_off  = string_row_offsets[col];
-    auto const str_col_off  = string_column_offsets[col];
-    auto str_col_data       = string_col_data[col];
-    for (int row = starting_row; row < starting_row + ROWS_PER_BLOCK && row < num_rows; ++row) {
-      auto const src = &row_data[row_offsets(row, 0) + str_row_off[row]];
-      auto dst       = &str_col_data[str_col_off[row]];
+  for (auto col = blockIdx.y; col < static_cast<uint32_t>(num_string_columns); col += gridDim.y) {
+    auto const str_col_off = string_column_offsets[col];
+    auto const str_row_off = string_row_offsets[col];
+    for (size_type idx = threadIdx.x; idx <= num_block_strings; idx += blockDim.x) {
+      auto const row     = begin_row + idx;
+      block_offsets[idx] = str_col_off[row];
+      if (idx < num_block_strings) {
+        block_src[idx] =
+          reinterpret_cast<char const*>(row_data) + row_offsets(row, 0) + str_row_off[row];
+      }
+    }
+    __syncthreads();
 
-      cuda::memcpy_async(warp, dst, src, str_len[row], block_barrier);
+    auto const out_chars = string_col_data[col];
+    for (int64_t out_ibyte = static_cast<int64_t>(block_offsets[0]) + threadIdx.x;
+         out_ibyte < block_offsets[num_block_strings];
+         out_ibyte += blockDim.x) {
+      // Find the string owning this output byte in the staged window
+      auto const string_idx = static_cast<size_type>(cuda::std::distance(
+        block_offsets,
+        cuda::std::prev(thrust::upper_bound(thrust::seq,
+                                            block_offsets,
+                                            block_offsets + num_block_strings,
+                                            static_cast<size_type>(out_ibyte)))));
+      out_chars[out_ibyte]  = block_src[string_idx][out_ibyte - block_offsets[string_idx]];
+    }
+
+    // The shared window is reused per column iteration; the condition is block-uniform
+    if (col + gridDim.y < static_cast<uint32_t>(num_string_columns)) { __syncthreads(); }
+  }
+}
+
+/**
+ * @brief copies string data from jcudf row format to cudf columns, one warp per string
+ *
+ * Port of cudf's strings-gather string-parallel kernel: a warp cooperatively stores its string
+ * through 16B-aligned uint4 writes, funnel-shifting unaligned source words into place, with
+ * bytewise head/tail fixups. Suited to long strings. Columns map to blockIdx.y; warps grid-stride
+ * over the rows of a column.
+ *
+ * @tparam RowOffsetFunctor iterator for row offsets into the input jcudf row data
+ * @param row_offsets offsets for each row in input data
+ * @param string_row_offsets offset data into jcudf row data for each string
+ * @param string_column_offsets offset column data for cudf column
+ * @param string_col_data output cudf string column data
+ * @param row_data jcudf row data
+ * @param num_rows number of rows in data
+ * @param num_string_columns number of string columns in the table
+ */
+template <typename RowOffsetFunctor>
+__launch_bounds__(STRING_COPY_BLOCK_SIZE) CUDF_KERNEL
+  void copy_strings_from_rows_string_parallel(RowOffsetFunctor row_offsets,
+                                              int32_t** string_row_offsets,
+                                              size_type** string_column_offsets,
+                                              char** string_col_data,
+                                              int8_t const* row_data,
+                                              size_type const num_rows,
+                                              size_type const num_string_columns)
+{
+  constexpr int64_t warp_size         = 32;
+  constexpr int64_t out_datatype_size = sizeof(uint4);
+  constexpr int64_t in_datatype_size  = sizeof(uint);
+
+  auto const global_thread_id = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  auto const global_warp_id   = global_thread_id / warp_size;
+  auto const warp_lane        = global_thread_id % warp_size;
+  auto const nwarps           = static_cast<int64_t>(gridDim.x) * blockDim.x / warp_size;
+
+  for (auto col = blockIdx.y; col < static_cast<uint32_t>(num_string_columns); col += gridDim.y) {
+    auto const str_row_off = string_row_offsets[col];
+    auto const str_col_off = string_column_offsets[col];
+    auto const out_chars   = string_col_data[col];
+
+    auto const alignment_offset =
+      static_cast<int64_t>(reinterpret_cast<std::uintptr_t>(out_chars) % out_datatype_size);
+    uint4* const out_chars_aligned = reinterpret_cast<uint4*>(out_chars - alignment_offset);
+
+    for (auto row = global_warp_id; row < num_rows; row += nwarps) {
+      int64_t const out_start = str_col_off[row];
+      int64_t const out_end   = str_col_off[row + 1];
+      // Null and empty strings carry zero length: nothing to copy
+      if (out_start == out_end) { continue; }
+
+      char const* const in_start = reinterpret_cast<char const*>(row_data) +
+                                   row_offsets(static_cast<size_type>(row), 0) + str_row_off[row];
+
+      // 16B-aligned store range, shrunk by one 4B word on each side so load_uint4's word reads
+      // never leave the string.
+      int64_t const out_start_aligned =
+        (out_start + in_datatype_size + alignment_offset + out_datatype_size - 1) /
+          out_datatype_size * out_datatype_size -
+        alignment_offset;
+      int64_t const out_end_aligned =
+        (out_end - in_datatype_size + alignment_offset) / out_datatype_size * out_datatype_size -
+        alignment_offset;
+
+      for (auto ichar = out_start_aligned + warp_lane * out_datatype_size; ichar < out_end_aligned;
+           ichar += warp_size * out_datatype_size) {
+        *(out_chars_aligned + (ichar + alignment_offset) / out_datatype_size) =
+          load_uint4(in_start + ichar - out_start);
+      }
+
+      if (out_end_aligned <= out_start_aligned) {
+        // No aligned slot fits: copy the whole string bytewise
+        for (auto ichar = out_start + warp_lane; ichar < out_end; ichar += warp_size) {
+          out_chars[ichar] = in_start[ichar - out_start];
+        }
+      } else {
+        // Head [out_start, out_start_aligned) and tail [out_end_aligned, out_end) are each shorter
+        // than one warp-width of bytes.
+        if (out_start + warp_lane < out_start_aligned) {
+          out_chars[out_start + warp_lane] = in_start[warp_lane];
+        }
+        auto const ichar = out_end_aligned + warp_lane;
+        if (ichar < out_end) { out_chars[ichar] = in_start[ichar - out_start]; }
+      }
     }
   }
-
-  block_barrier.arrive_and_wait();
 }
 
 /**
@@ -1252,28 +1576,33 @@ static int calc_fixed_width_kernel_dims(size_type const num_columns,
  * going from start row and containing the next num_rows.  Most of the parameters passed
  * into this function are common between runs and should be calculated once.
  */
-static std::unique_ptr<column> fixed_width_convert_to_rows(
-  size_type const start_row,
-  size_type const num_rows,
-  size_type const num_columns,
-  size_type const size_per_row,
-  rmm::device_uvector<size_type>& column_start,
-  rmm::device_uvector<size_type>& column_size,
-  rmm::device_uvector<int8_t const*>& input_data,
-  rmm::device_uvector<bitmask_type const*>& input_nm,
-  scalar const& zero,
-  scalar const& scalar_size_per_row,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
+static std::unique_ptr<column> fixed_width_convert_to_rows(size_type const start_row,
+                                                           size_type const num_rows,
+                                                           size_type const num_columns,
+                                                           size_type const size_per_row,
+                                                           size_type const* column_start,
+                                                           size_type const* column_size,
+                                                           int8_t const** input_data,
+                                                           bitmask_type const** input_nm,
+                                                           rmm::cuda_stream_view stream,
+                                                           rmm::device_async_resource_ref mr)
 {
   int64_t const total_allocation = size_per_row * num_rows;
   // We made a mistake in the split somehow
   CUDF_EXPECTS(total_allocation < std::numeric_limits<size_type>::max(),
                "Table is too large to fit!");
 
-  // Allocate and set the offsets row for the byte array
-  std::unique_ptr<column> offsets =
-    cudf::sequence(num_rows + 1, zero, scalar_size_per_row, stream, mr);
+  // Every row is size_per_row bytes wide, so tabulating the offsets directly avoids the pair of
+  // device scalars cudf::sequence would need to carry that constant step onto the device.
+  std::unique_ptr<column> offsets = make_numeric_column(
+    data_type(type_id::INT32), num_rows + 1, mask_state::UNALLOCATED, stream, mr);
+  auto* const d_offsets = offsets->mutable_view().begin<size_type>();
+  // Thrust temporaries come from the current device resource, never the caller's output `mr`.
+  thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   d_offsets,
+                   d_offsets + num_rows + 1,
+                   cuda::proclaim_return_type<size_type>(
+                     [size_per_row] __device__(size_type i) { return i * size_per_row; }));
 
   std::unique_ptr<column> data = make_numeric_column(data_type(type_id::INT8),
                                                      static_cast<size_type>(total_allocation),
@@ -1291,10 +1620,10 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
     num_rows,
     num_columns,
     size_per_row,
-    column_start.data(),
-    column_size.data(),
-    input_data.data(),
-    input_nm.data(),
+    column_start,
+    column_size,
+    input_data,
+    input_nm,
     data->mutable_view().data<int8_t>());
 
   return make_lists_column(num_rows,
@@ -1596,11 +1925,7 @@ batch_data build_batches(size_type num_rows,
     last_row_end = row_end;
   }
 
-  return {std::move(batch_row_offsets),
-          make_device_uvector_async(
-            batch_row_boundaries, stream, rmm::mr::get_current_device_resource_ref()),
-          std::move(batch_row_boundaries),
-          std::move(row_batches)};
+  return {std::move(batch_row_offsets), std::move(batch_row_boundaries), std::move(row_batches)};
 }
 
 /**
@@ -1647,7 +1972,7 @@ int compute_tile_counts(device_span<size_type const> const& batch_row_boundaries
  */
 size_type build_tiles(
   device_span<tile_info> tiles,
-  device_uvector<size_type> const& batch_row_boundaries,  // comes from build_batches
+  device_span<size_type const> batch_row_boundaries,  // build_batches (to-rows) or {0, num_rows}
   int column_start,
   int column_end,
   int desired_tile_height,
@@ -1732,6 +2057,9 @@ size_type build_tiles(
  * @param total_number_of_rows total number of rows in the table
  * @param shmem_limit_per_tile shared memory allowed per tile
  * @param f callback function called when building a tile
+ *
+ * The tile height also depends on the current device's SM count, so the count pass and the build
+ * pass of one conversion must run on the same device to agree on the geometry.
  */
 template <typename TileCallback>
 void determine_tiles(std::vector<size_type> const& column_sizes,
@@ -1756,7 +2084,41 @@ void determine_tiles(std::vector<size_type> const& column_sizes,
   auto const optimal_square_len  = static_cast<size_type>(sqrt(shmem_limit_per_tile));
   auto const desired_tile_height = cudf::util::round_up_safe<int>(
     std::min(optimal_square_len / square_bias, total_number_of_rows), cudf::detail::warp_size);
-  auto const tile_height = std::clamp(desired_tile_height, 1, first_row_batch_size);
+
+  // First pass: the total padded row size, accumulated exactly like the column march below so the
+  // single-band test agrees with what the march would build. Keep the two in sync: a probe that
+  // under-estimates the march lets the gate below pass while the march still opens a fresh band,
+  // and that band's row size is never re-checked against the grown tile height.
+  int total_row_size = 0;
+  for (auto const col_size : column_sizes) {
+    total_row_size = cudf::util::round_up_unsafe(total_row_size, col_size) + col_size;
+  }
+  total_row_size = cudf::util::round_up_unsafe(total_row_size, JCUDF_ROW_ALIGNMENT);
+
+  // Schema-adaptive fill-driven height: when the whole row fits a single tile at the square-bias
+  // height the to-rows kernels leave most of their shared-memory budget unused, so grow the tile
+  // downward to fill it and shrink the grid. The from-rows data kernel stages nothing in shared
+  // memory, so there the taller tile is only a grid shrink.
+  // The min-grid guard caps the height at roughly two tiles per SM, and falls back to one warp of
+  // rows when the table is too small to reach that target. Multi-band (wide) schemas keep the
+  // incumbent height.
+  auto adaptive_tile_height = desired_tile_height;
+  if (total_number_of_rows > 0 && total_row_size > 0 &&
+      total_row_size * desired_tile_height <= shmem_limit_per_tile) {
+    constexpr int min_grid_tiles_per_sm = 2;
+    auto const fill_height =
+      cudf::util::round_down_safe<int>(shmem_limit_per_tile / total_row_size, WARP_SIZE);
+    int device_id;
+    CUDF_CUDA_TRY(cudaGetDevice(&device_id));
+    int num_sms;
+    CUDF_CUDA_TRY(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device_id));
+    auto const guard_height =
+      std::max(WARP_SIZE,
+               cudf::util::round_down_safe<int>(
+                 total_number_of_rows / (min_grid_tiles_per_sm * num_sms), WARP_SIZE));
+    adaptive_tile_height = std::min(fill_height, guard_height);
+  }
+  auto const tile_height = std::clamp(adaptive_tile_height, 1, first_row_batch_size);
 
   int row_size = 0;
 
@@ -1801,7 +2163,8 @@ void determine_tiles(std::vector<size_type> const& column_sizes,
  * @param batch_info information about the batches of data
  * @param offset_functor functor that returns the starting offset of each row
  * @param column_info information about incoming columns
- * @param variable_width_offsets optional vector of offsets for variable-with columns
+ * @param variable_width_offsets optional span of offsets for variable-with columns
+ * @param arena staging arena the metadata arrays are uploaded through
  * @param stream stream used
  * @param mr selected memory resource for returned data
  * @return vector of list columns containing byte columns of the JCUDF row data
@@ -1812,7 +2175,8 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   batch_data& batch_info,
   offsetFunctor offset_functor,
   column_info_s const& column_info,
-  std::optional<rmm::device_uvector<cudf::detail::input_offsetalator>> variable_width_offsets,
+  std::optional<device_span<cudf::detail::input_offsetalator>> variable_width_offsets,
+  staging_arena& arena,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -1841,11 +2205,6 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
     return table_view(cols);
   };
 
-  auto dev_col_sizes = make_device_uvector_async(
-    column_info.column_sizes, stream, rmm::mr::get_current_device_resource_ref());
-  auto dev_col_starts = make_device_uvector_async(
-    column_info.column_starts, stream, rmm::mr::get_current_device_resource_ref());
-
   // Get the pointers to the input columnar data ready
   auto const data_begin = cuda::make_transform_iterator(tbl.begin(), [](auto const& c) {
     return is_compound(c.type()) ? nullptr : c.template data<int8_t>();
@@ -1856,11 +2215,6 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   auto const nm_begin =
     cuda::make_transform_iterator(tbl.begin(), [](auto const& c) { return c.null_mask(); });
   std::vector<bitmask_type const*> input_nm(nm_begin, nm_begin + tbl.num_columns());
-
-  auto dev_input_data =
-    make_device_uvector_async(input_data, stream, rmm::mr::get_current_device_resource_ref());
-  auto dev_input_nm =
-    make_device_uvector_async(input_nm, stream, rmm::mr::get_current_device_resource_ref());
 
   // the first batch always exists unless we were sent an empty table
   auto const first_batch_size = batch_info.row_batches[0].row_count;
@@ -1879,20 +2233,60 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
       return static_cast<int8_t*>(buf.data());
     });
 
-  auto dev_output_data = make_device_uvector_async(output_data, stream, mr);
+  // build validity tiles for ALL columns, variable and fixed width.
+  auto validity_tile_infos = detail::build_validity_tile_infos(
+    tbl.num_columns(), num_rows, shmem_limit_per_tile, batch_info.row_batches);
+
+  // build table view for variable-width data only
+  auto const variable_width_table =
+    select_columns(tbl, [](auto col) { return is_compound(col.type()); });
+  std::vector<int8_t const*> variable_width_input_data;
+  if (!fixed_width_only) {
+    CUDF_EXPECTS(!variable_width_table.is_empty(), "No variable-width columns when expected!");
+    CUDF_EXPECTS(variable_width_offsets.has_value(), "No variable width offset data!");
+
+    auto const variable_data_begin = cuda::make_transform_iterator(
+      variable_width_table.begin(),
+      [](auto const& c) { return is_compound(c.type()) ? c.template data<int8_t>() : nullptr; });
+    variable_width_input_data.assign(variable_data_begin,
+                                     variable_data_begin + variable_width_table.num_columns());
+  }
+
+  auto const [dev_batch_row_boundaries,
+              dev_col_sizes,
+              dev_col_starts,
+              dev_input_data,
+              dev_input_nm,
+              dev_output_data,
+              dev_validity_tile_infos,
+              dev_variable_input_data,
+              dev_variable_col_output_offsets] =
+    arena.upload(batch_info.batch_row_boundaries,
+                 column_info.column_sizes,
+                 column_info.column_starts,
+                 input_data,
+                 input_nm,
+                 output_data,
+                 validity_tile_infos,
+                 variable_width_input_data,
+                 column_info.variable_width_column_starts);
+  auto const gpu_batch_row_boundaries =
+    device_span<size_type const>{dev_batch_row_boundaries, batch_info.batch_row_boundaries.size()};
 
   int info_count = 0;
-  detail::determine_tiles(
-    column_info.column_sizes,
-    column_info.column_starts,
-    first_batch_size,
-    num_rows,
-    shmem_limit_per_tile,
-    [&gpu_batch_row_boundaries = batch_info.d_batch_row_boundaries, &info_count, &stream](
-      int const start_col, int const end_col, int const tile_height) {
-      int i = detail::compute_tile_counts(gpu_batch_row_boundaries, tile_height, stream);
-      info_count += i;
-    });
+  int num_bands  = 0;
+  detail::determine_tiles(column_info.column_sizes,
+                          column_info.column_starts,
+                          first_batch_size,
+                          num_rows,
+                          shmem_limit_per_tile,
+                          [gpu_batch_row_boundaries, &info_count, &num_bands, &stream](
+                            int const start_col, int const end_col, int const tile_height) {
+                            ++num_bands;
+                            int i = detail::compute_tile_counts(
+                              gpu_batch_row_boundaries, tile_height, stream);
+                            info_count += i;
+                          });
 
   // allocate space for tiles
   device_uvector<detail::tile_info> gpu_tile_infos(info_count, stream);
@@ -1904,11 +2298,8 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
     first_batch_size,
     num_rows,
     shmem_limit_per_tile,
-    [&gpu_batch_row_boundaries = batch_info.d_batch_row_boundaries,
-     &gpu_tile_infos,
-     num_rows,
-     &tile_offset,
-     stream](int const start_col, int const end_col, int const tile_height) {
+    [gpu_batch_row_boundaries, &gpu_tile_infos, num_rows, &tile_offset, stream](
+      int const start_col, int const end_col, int const tile_height) {
       tile_offset += detail::build_tiles(
         {gpu_tile_infos.data() + tile_offset, gpu_tile_infos.size() - tile_offset},
         gpu_batch_row_boundaries,
@@ -1919,28 +2310,50 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
         stream);
     });
 
-  // build validity tiles for ALL columns, variable and fixed width.
-  auto validity_tile_infos = detail::build_validity_tile_infos(
-    tbl.num_columns(), num_rows, shmem_limit_per_tile, batch_info.row_batches);
-
-  auto dev_validity_tile_infos = make_device_uvector_async(
-    validity_tile_infos, stream, rmm::mr::get_current_device_resource_ref());
-
   auto const validity_offset = column_info.column_starts.back();
 
-  // blast through the entire table and convert it
-  detail::copy_to_rows<BLOCK_SIZE>
-    <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
-      num_rows,
-      tbl.num_columns(),
-      shmem_limit_per_tile,
-      gpu_tile_infos,
-      dev_input_data.data(),
-      dev_col_sizes.data(),
-      dev_col_starts.data(),
-      offset_functor,
-      batch_info.d_batch_row_boundaries.data(),
-      reinterpret_cast<int8_t**>(dev_output_data.data()));
+  // The generated JIT kernels mirror tile_info. Every member is an int, so size alone cannot
+  // catch a field reorder: pin the offsets too.
+  static_assert(sizeof(tile_info) == 5 * sizeof(int) && std::is_standard_layout_v<tile_info>);
+  static_assert(offsetof(tile_info, start_col) == 0 && offsetof(tile_info, start_row) == 4 &&
+                offsetof(tile_info, end_col) == 8 && offsetof(tile_info, end_row) == 12 &&
+                offsetof(tile_info, batch_number) == 16);
+
+  // Single-band all-fixed-width schemas may run a schema-specialized JIT kernel instead of the
+  // generic interpreter kernel; every other case (multi-band, strings present, JIT disabled,
+  // compile still pending or failed) launches the generic kernel below.
+  bool jit_launched = false;
+  if constexpr (std::is_same_v<offsetFunctor, detail::fixed_width_row_offset_functor>) {
+    if (fixed_width_only && num_bands == 1) {
+      jit_launched = detail::try_jit_copy_to_rows(
+        column_info.column_sizes,
+        column_info.column_starts,
+        cudf::util::round_up_unsafe(column_info.size_per_row, JCUDF_ROW_ALIGNMENT),
+        static_cast<int>(gpu_tile_infos.size()),
+        gpu_tile_infos.data(),
+        total_shmem_in_bytes,
+        dev_input_data,
+        dev_output_data,
+        gpu_batch_row_boundaries.data(),
+        stream);
+    }
+  }
+
+  if (!jit_launched) {
+    // blast through the entire table and convert it
+    detail::copy_to_rows<BLOCK_SIZE>
+      <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+        num_rows,
+        tbl.num_columns(),
+        shmem_limit_per_tile,
+        gpu_tile_infos,
+        dev_input_data,
+        dev_col_sizes,
+        dev_col_starts,
+        offset_functor,
+        gpu_batch_row_boundaries.data(),
+        dev_output_data);
+  }
 
   // note that validity gets the entire table and not the fixed-width portion
   detail::copy_validity_to_rows<BLOCK_SIZE>
@@ -1949,31 +2362,13 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
       tbl.num_columns(),
       shmem_limit_per_tile,
       offset_functor,
-      batch_info.d_batch_row_boundaries.data(),
-      dev_output_data.data(),
+      gpu_batch_row_boundaries.data(),
+      dev_output_data,
       validity_offset,
-      dev_validity_tile_infos,
-      dev_input_nm.data());
+      device_span<tile_info const>{dev_validity_tile_infos, validity_tile_infos.size()},
+      dev_input_nm);
 
   if (!fixed_width_only) {
-    // build table view for variable-width data only
-    auto const variable_width_table =
-      select_columns(tbl, [](auto col) { return is_compound(col.type()); });
-
-    CUDF_EXPECTS(!variable_width_table.is_empty(), "No variable-width columns when expected!");
-    CUDF_EXPECTS(variable_width_offsets.has_value(), "No variable width offset data!");
-
-    auto const variable_data_begin = cuda::make_transform_iterator(
-      variable_width_table.begin(),
-      [](auto const& c) { return is_compound(c.type()) ? c.template data<int8_t>() : nullptr; });
-    std::vector<int8_t const*> variable_width_input_data(
-      variable_data_begin, variable_data_begin + variable_width_table.num_columns());
-
-    auto dev_variable_input_data = make_device_uvector_async(
-      variable_width_input_data, stream, rmm::mr::get_current_device_resource_ref());
-    auto dev_variable_col_output_offsets = make_device_uvector_async(
-      column_info.variable_width_column_starts, stream, rmm::mr::get_current_device_resource_ref());
-
     for (uint i = 0; i < batch_info.row_batches.size(); i++) {
       auto const batch_row_offset = batch_info.batch_row_boundaries[i];
       auto const batch_num_rows   = batch_info.row_batches[i].row_count;
@@ -1990,18 +2385,14 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
         <<<string_blocks, NUM_STRING_ROWS_PER_BLOCK_TO_ROWS, 0, stream.value()>>>(
           batch_row_offset + batch_num_rows,
           variable_width_table.num_columns(),
-          dev_variable_input_data.data(),
-          dev_variable_col_output_offsets.data(),
+          dev_variable_input_data,
+          dev_variable_col_output_offsets,
           variable_width_offsets->data(),
           column_info.size_per_row,
           offset_functor,
           batch_row_offset,
           reinterpret_cast<int8_t*>(output_data[i]));
     }
-
-    // Drain the async H2D uploads above before variable_width_input_data goes out of scope:
-    // CUDA 13+ may read the host source only when the stream executes the copy.
-    stream.synchronize();
   }
 
   // split up the output buffer into multiple buffers based on row batch sizes and create list of
@@ -2032,11 +2423,6 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
                                             0,
                                             rmm::device_buffer{0, cudf::get_default_stream(), mr});
                  });
-
-  // Drain the async H2D uploads above before input_data, input_nm, output_data and
-  // validity_tile_infos go out of scope: CUDA 13+ may read the host source only when the stream
-  // executes the copy.
-  stream.synchronize();
 
   return ret;
 }
@@ -2131,6 +2517,10 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
   auto column_info =
     detail::compute_column_information(schema_column_iter, schema_column_iter + num_columns);
   auto const size_per_row = column_info.size_per_row;
+
+  // one arena serves the whole conversion; destroyed after the last consumer is enqueued
+  detail::staging_arena arena(stream);
+
   if (fixed_width_only) {
     // total encoded row size. This includes fixed-width data and validity only. It does not include
     // variable-width data since it isn't copied with the fixed-width and validity kernel.
@@ -2143,9 +2533,9 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
       cudf::util::round_up_unsafe(size_per_row, JCUDF_ROW_ALIGNMENT));
 
     return detail::convert_to_rows(
-      tbl, batch_info, offset_functor, std::move(column_info), std::nullopt, stream, mr);
+      tbl, batch_info, offset_functor, std::move(column_info), std::nullopt, arena, stream, mr);
   } else {
-    auto offset_data = detail::build_string_row_offsets(tbl, size_per_row, stream);
+    auto offset_data = detail::build_string_row_offsets(tbl, size_per_row, arena, stream);
     auto& row_sizes  = std::get<0>(offset_data);
 
     auto row_size_iter = spark_rapids_jni::util::make_counting_transform_iterator(
@@ -2159,7 +2549,8 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
                                    batch_info,
                                    offset_functor,
                                    std::move(column_info),
-                                   std::make_optional(std::move(std::get<1>(offset_data))),
+                                   std::make_optional(std::get<1>(offset_data)),
+                                   arena,
                                    stream,
                                    mr);
   }
@@ -2185,8 +2576,6 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
 
   int32_t const size_per_row =
     detail::compute_fixed_width_layout(schema, column_start, column_size);
-  auto dev_column_start = make_device_uvector_async(column_start, stream, mr);
-  auto dev_column_size  = make_device_uvector_async(column_size, stream, mr);
 
   // Make the number of rows per batch a multiple of 32 so we don't have to worry about splitting
   // validity at a specific row offset.  This might change in the future.
@@ -2203,17 +2592,10 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
     input_data.emplace_back(cv.data<int8_t>());
     input_nm.emplace_back(cv.null_mask());
   }
-  auto dev_input_data = make_device_uvector_async(input_data, stream, mr);
-  auto dev_input_nm   = make_device_uvector_async(input_nm, stream, mr);
 
-  using ScalarType = scalar_type_t<size_type>;
-  auto zero        = make_numeric_scalar(data_type(type_id::INT32), stream.value());
-  zero->set_valid_async(true, stream);
-  static_cast<ScalarType*>(zero.get())->set_value(0, stream);
-
-  auto step = make_numeric_scalar(data_type(type_id::INT32), stream.value());
-  step->set_valid_async(true, stream);
-  static_cast<ScalarType*>(step.get())->set_value(static_cast<size_type>(size_per_row), stream);
+  detail::staging_arena arena(stream);
+  auto const [dev_column_start, dev_column_size, dev_input_data, dev_input_nm] =
+    arena.upload(column_start, column_size, input_data, input_nm);
 
   std::vector<std::unique_ptr<column>> ret;
   for (size_type row_start = 0; row_start < num_rows; row_start += max_rows_per_batch) {
@@ -2227,15 +2609,9 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
                                                          dev_column_size,
                                                          dev_input_data,
                                                          dev_input_nm,
-                                                         *zero,
-                                                         *step,
                                                          stream,
                                                          mr));
   }
-
-  // Drain the async H2D uploads above before column_start, column_size, input_data and input_nm
-  // go out of scope: CUDA 13+ may read the host source only when the stream executes the copy.
-  stream.synchronize();
 
   return ret;
 }
@@ -2246,28 +2622,76 @@ namespace {
 void fixup_null_counts(std::vector<std::unique_ptr<column>>& output_columns,
                        rmm::cuda_stream_view stream)
 {
-  for (auto& col : output_columns) {
-    col->set_null_count(cudf::null_count(col->view().null_mask(), 0, col->size(), stream));
+  if (output_columns.empty()) { return; }
+  // All from-rows output columns share one row count, so one cudf::batch_null_count costs a
+  // single kernel and D2H sync for the whole table.
+  auto const num_rows = output_columns.front()->size();
+  std::vector<bitmask_type const*> masks;
+  masks.reserve(output_columns.size());
+  for (auto const& col : output_columns) {
+    CUDF_EXPECTS(col->size() == num_rows, "Batched null count requires equally sized columns");
+    masks.push_back(col->view().null_mask());
   }
+  auto const null_counts = cudf::batch_null_count(masks, 0, num_rows, stream);
+  for (std::size_t i = 0; i < output_columns.size(); ++i) {
+    output_columns[i]->set_null_count(null_counts[i]);
+  }
+}
+
+// Debug aid (default off): when 1, an all-valid declaration is re-verified through the incumbent
+// path and a violation throws instead of silently corrupting. Read per call so tests can toggle.
+bool validate_all_valid_enabled()
+{
+  char const* const env = std::getenv("ROWCONV_VALIDATE_ALL_VALID");
+  if (env == nullptr) { return false; }
+  // The sibling JIT kill switch accepts the word forms, so this one must too — a user who learns
+  // one convention would otherwise get the other silently wrong.
+  for (auto const* word : {"1", "true", "on", "yes"}) {
+    if (::strcasecmp(env, word) == 0) { return true; }
+  }
+  return false;
+}
+
+// Returns true when the caller declares every column non-nullable; throws on a size mismatch.
+bool is_all_valid_profile(std::vector<bool> const& may_have_nulls, std::size_t schema_size)
+{
+  CUDF_EXPECTS(may_have_nulls.size() == schema_size,
+               "may_have_nulls size must match the schema size");
+  return std::none_of(
+    may_have_nulls.cbegin(), may_have_nulls.cend(), [](bool const b) { return b; });
+}
+
+// Debug-validation epilogue: proves an all-valid declaration against the incumbent result, then
+// drops the all-set masks so the output matches the fast path's non-nullable shape.
+std::unique_ptr<table> strip_verified_all_valid(std::unique_ptr<table>&& verified)
+{
+  auto columns = verified->release();
+  for (auto& col : columns) {
+    CUDF_EXPECTS(col->null_count() == 0,
+                 "all-valid nullability declaration violated: row data contains nulls");
+    col->set_null_mask(rmm::device_buffer{}, 0);
+  }
+  return std::make_unique<table>(std::move(columns));
 }
 
 }  // namespace
 
+namespace {
+
 /**
- * @brief convert from JCUDF row format to cudf columns
+ * @brief Implementation of the general JCUDF-rows-to-columns conversion
  *
- * @param input vector of list columns containing byte columns of the JCUDF row data
- * @param schema incoming schema of the data
- * @param stream stream to use for compute
- * @param mr memory resource for returned data
- * @return cudf table of the data
+ * @param trust_all_valid when true the caller guarantees no row carries a null in any column:
+ * output columns are created without null masks and the whole reverse-validity pipeline (validity
+ * tiles + kernel, valid-count read-back and its synchronize) is skipped. The row bytes are read
+ * exactly as on the incumbent path; their validity bytes are simply never touched.
  */
-std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
-                                         std::vector<data_type> const& schema,
-                                         rmm::cuda_stream_view stream,
-                                         rmm::device_async_resource_ref mr)
+std::unique_ptr<table> convert_from_rows_impl(lists_column_view const& input,
+                                              std::vector<data_type> const& schema,
+                                              bool trust_all_valid,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref mr)
 {
-  SRJ_FUNC_RANGE();
   // verify that the types are what we expect
   column_view child    = input.child();
   auto const list_type = child.type().id();
@@ -2315,13 +2739,14 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
   auto const size_per_row =
     cudf::util::round_up_unsafe(column_info.size_per_row, JCUDF_ROW_ALIGNMENT);
 
-  // Ideally we would check that the offsets are all the same, etc. but for now this is probably
-  // fine
+  // Unchecked precondition: the rows in input must start at multiples of JCUDF_ROW_ALIGNMENT —
+  // for a schema with strings those starts are input.offsets() verbatim. copy_from_rows reads
+  // each element with a naturally-aligned typed load at its row start, so a misaligned start is
+  // undefined behavior, not merely a slow copy. The in-tree producer convert_to_rows rounds each
+  // row size up to that alignment; checking it here would cost a device-wide scan of the offsets.
   CUDF_EXPECTS(size_per_row * num_rows <= child.size(), "The layout of the data appears to be off");
-  auto dev_col_starts = make_device_uvector_async(
-    column_info.column_starts, stream, rmm::mr::get_current_device_resource_ref());
-  auto dev_col_sizes = make_device_uvector_async(
-    column_info.column_sizes, stream, rmm::mr::get_current_device_resource_ref());
+
+  detail::staging_arena arena(stream);
 
   // Allocate the columns we are going to write into
   std::vector<std::unique_ptr<column>> output_columns;
@@ -2350,8 +2775,8 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     };
     if (i.id() == type_id::STRING) {
       auto const int32type = data_type(type_id::INT32);
-      auto offset_col =
-        make_col(int32type, num_rows, true, stream, rmm::mr::get_current_device_resource_ref());
+      auto offset_col      = make_col(
+        int32type, num_rows, !trust_all_valid, stream, rmm::mr::get_current_device_resource_ref());
       string_row_offsets.push_back(offset_col->mutable_view().data<int32_t>());
       string_row_offset_columns.emplace_back(std::move(offset_col));
       auto length_col =
@@ -2361,44 +2786,53 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
       // placeholder
       output_columns.emplace_back(make_empty_column(type_id::STRING));
     } else {
-      output_columns.emplace_back(make_col(i, num_rows, true, stream, mr));
+      output_columns.emplace_back(make_col(i, num_rows, !trust_all_valid, stream, mr));
     }
   }
-
-  auto dev_string_row_offsets = make_device_uvector_async(
-    string_row_offsets, stream, rmm::mr::get_current_device_resource_ref());
-  auto dev_string_lengths =
-    make_device_uvector_async(string_lengths, stream, rmm::mr::get_current_device_resource_ref());
 
   // build the row_batches from the passed in list column
   std::vector<detail::row_batch> row_batches;
   row_batches.push_back(
     {detail::row_batch{child.size(), num_rows, device_uvector<size_type>(0, stream)}});
 
-  auto dev_output_data =
-    make_device_uvector_async(output_data, stream, rmm::mr::get_current_device_resource_ref());
-  auto dev_output_nm =
-    make_device_uvector_async(output_nm, stream, rmm::mr::get_current_device_resource_ref());
-
   // only ever get a single batch when going from rows, so boundaries are 0, num_rows
-  constexpr auto num_batches = 2;
-  device_uvector<size_type> gpu_batch_row_boundaries(num_batches, stream);
+  std::vector<size_type> batch_row_boundaries{0, num_rows};
 
-  thrust::transform(rmm::exec_policy(stream),
-                    cuda::make_counting_iterator(0),
-                    cuda::make_counting_iterator(num_batches),
-                    gpu_batch_row_boundaries.begin(),
-                    cuda::proclaim_return_type<size_type>(
-                      [num_rows] __device__(auto i) { return i == 0 ? 0 : num_rows; }));
+  // validity needs to be calculated based on the actual number of final table columns; the
+  // trusted all-valid path needs no tiles and the empty vector uploads as nullptr below
+  auto validity_tile_infos = trust_all_valid
+                               ? std::vector<detail::tile_info>{}
+                               : detail::build_validity_tile_infos(
+                                   schema.size(), num_rows, shmem_limit_per_tile, row_batches);
+
+  auto const [dev_col_starts,
+              dev_col_sizes,
+              dev_string_row_offsets,
+              dev_string_lengths,
+              dev_output_data,
+              dev_output_nm,
+              dev_batch_row_boundaries,
+              dev_validity_tile_infos] = arena.upload(column_info.column_starts,
+                                                      column_info.column_sizes,
+                                                      string_row_offsets,
+                                                      string_lengths,
+                                                      output_data,
+                                                      output_nm,
+                                                      batch_row_boundaries,
+                                                      validity_tile_infos);
+  auto const gpu_batch_row_boundaries =
+    device_span<size_type const>{dev_batch_row_boundaries, batch_row_boundaries.size()};
 
   int info_count = 0;
+  int num_bands  = 0;
   detail::determine_tiles(column_info.column_sizes,
                           column_info.column_starts,
                           num_rows,
                           num_rows,
                           shmem_limit_per_tile,
-                          [&gpu_batch_row_boundaries, &info_count, &stream](
+                          [gpu_batch_row_boundaries, &info_count, &num_bands, &stream](
                             int const start_col, int const end_col, int const tile_height) {
+                            ++num_bands;
                             info_count += detail::compute_tile_counts(
                               gpu_batch_row_boundaries, tile_height, stream);
                           });
@@ -2413,7 +2847,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     num_rows,
     num_rows,
     shmem_limit_per_tile,
-    [&gpu_batch_row_boundaries, &gpu_tile_infos, num_rows, &tile_offset, stream](
+    [gpu_batch_row_boundaries, &gpu_tile_infos, num_rows, &tile_offset, stream](
       int const start_col, int const end_col, int const tile_height) {
       tile_offset += detail::build_tiles(
         {gpu_tile_infos.data() + tile_offset, gpu_tile_infos.size() - tile_offset},
@@ -2427,114 +2861,239 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
 
   dim3 const blocks(gpu_tile_infos.size());
 
-  // validity needs to be calculated based on the actual number of final table columns
-  auto validity_tile_infos =
-    detail::build_validity_tile_infos(schema.size(), num_rows, shmem_limit_per_tile, row_batches);
-
-  auto dev_validity_tile_infos = make_device_uvector_async(
-    validity_tile_infos, stream, rmm::mr::get_current_device_resource_ref());
-
   dim3 const validity_blocks(validity_tile_infos.size());
 
-  if (dev_string_row_offsets.size() == 0) {
+  // Per-column valid-row counts accumulated by the validity kernel, indexed by original schema
+  // position and zeroed once per conversion on this stream, so null counts can come from one
+  // D2H copy instead of per-column null_count reductions. Empty (unused) on the trusted
+  // all-valid path.
+  device_uvector<size_type> dev_valid_counts(trust_all_valid ? 0 : schema.size(), stream);
+  if (!trust_all_valid) {
+    CUDF_CUDA_TRY(cudaMemsetAsync(
+      dev_valid_counts.data(), 0, dev_valid_counts.size() * sizeof(size_type), stream.value()));
+  }
+
+  if (string_row_offsets.empty()) {
     detail::fixed_width_row_offset_functor offset_functor(size_per_row);
 
-    detail::copy_from_rows<BLOCK_SIZE>
-      <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
-        num_rows,
-        num_columns,
-        shmem_limit_per_tile,
-        offset_functor,
-        gpu_batch_row_boundaries.data(),
-        dev_output_data.data(),
-        dev_col_sizes.data(),
-        dev_col_starts.data(),
-        gpu_tile_infos,
-        child.data<int8_t>());
+    // The generated JIT kernels mirror tile_info. Every member is an int, so size alone cannot
+    // catch a field reorder: pin the offsets too.
+    static_assert(sizeof(detail::tile_info) == 5 * sizeof(int) &&
+                  std::is_standard_layout_v<detail::tile_info>);
+    static_assert(
+      offsetof(detail::tile_info, start_col) == 0 && offsetof(detail::tile_info, start_row) == 4 &&
+      offsetof(detail::tile_info, end_col) == 8 && offsetof(detail::tile_info, end_row) == 12 &&
+      offsetof(detail::tile_info, batch_number) == 16);
 
-    detail::copy_validity_from_rows<BLOCK_SIZE>
-      <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
-        num_rows,
-        num_columns,
-        shmem_limit_per_tile,
-        offset_functor,
-        gpu_batch_row_boundaries.data(),
-        dev_output_nm.data(),
-        column_info.column_starts.back(),
-        dev_validity_tile_infos,
-        child.data<int8_t>());
+    // Single-band schemas may run a schema-specialized JIT gather kernel instead of the generic
+    // interpreter kernel; every other case (multi-band, JIT disabled, compile still pending or
+    // failed) launches the generic kernel below.
+    bool const jit_launched =
+      num_bands == 1 && detail::try_jit_copy_from_rows(column_info.column_sizes,
+                                                       column_info.column_starts,
+                                                       size_per_row,
+                                                       static_cast<int>(gpu_tile_infos.size()),
+                                                       gpu_tile_infos.data(),
+                                                       child.data<int8_t>(),
+                                                       dev_output_data,
+                                                       stream);
+
+    if (!jit_launched) {
+      // copy_from_rows stages nothing in shared memory: launch it with zero dynamic shared
+      // memory and request the maximum-L1 carveout so the cache can serve its strided row
+      // re-reads.
+      CUDF_CUDA_TRY(cudaFuncSetAttribute(
+        detail::copy_from_rows<BLOCK_SIZE, detail::fixed_width_row_offset_functor>,
+        cudaFuncAttributePreferredSharedMemoryCarveout,
+        cudaSharedmemCarveoutMaxL1));
+      detail::copy_from_rows<BLOCK_SIZE>
+        <<<gpu_tile_infos.size(), BLOCK_SIZE, 0, stream.value()>>>(num_rows,
+                                                                   num_columns,
+                                                                   shmem_limit_per_tile,
+                                                                   offset_functor,
+                                                                   gpu_batch_row_boundaries.data(),
+                                                                   dev_output_data,
+                                                                   dev_col_sizes,
+                                                                   dev_col_starts,
+                                                                   gpu_tile_infos,
+                                                                   child.data<int8_t>());
+    }
+
+    if (!trust_all_valid) {
+      detail::copy_validity_from_rows<BLOCK_SIZE>
+        <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+          num_rows,
+          num_columns,
+          shmem_limit_per_tile,
+          offset_functor,
+          gpu_batch_row_boundaries.data(),
+          dev_output_nm,
+          column_info.column_starts.back(),
+          device_span<detail::tile_info const>{dev_validity_tile_infos, validity_tile_infos.size()},
+          child.data<int8_t>(),
+          dev_valid_counts.data());
+    }
 
   } else {
     detail::string_row_offset_functor offset_functor(device_span<size_type const>{input.offsets()});
+    CUDF_CUDA_TRY(
+      cudaFuncSetAttribute(detail::copy_from_rows<BLOCK_SIZE, detail::string_row_offset_functor>,
+                           cudaFuncAttributePreferredSharedMemoryCarveout,
+                           cudaSharedmemCarveoutMaxL1));
     detail::copy_from_rows<BLOCK_SIZE>
-      <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
-        num_rows,
-        num_columns,
-        shmem_limit_per_tile,
-        offset_functor,
-        gpu_batch_row_boundaries.data(),
-        dev_output_data.data(),
-        dev_col_sizes.data(),
-        dev_col_starts.data(),
-        gpu_tile_infos,
-        child.data<int8_t>());
+      <<<gpu_tile_infos.size(), BLOCK_SIZE, 0, stream.value()>>>(num_rows,
+                                                                 num_columns,
+                                                                 shmem_limit_per_tile,
+                                                                 offset_functor,
+                                                                 gpu_batch_row_boundaries.data(),
+                                                                 dev_output_data,
+                                                                 dev_col_sizes,
+                                                                 dev_col_starts,
+                                                                 gpu_tile_infos,
+                                                                 child.data<int8_t>());
 
-    detail::copy_validity_from_rows<BLOCK_SIZE>
-      <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
-        num_rows,
-        num_columns,
-        shmem_limit_per_tile,
-        offset_functor,
-        gpu_batch_row_boundaries.data(),
-        dev_output_nm.data(),
-        column_info.column_starts.back(),
-        dev_validity_tile_infos,
-        child.data<int8_t>());
+    if (!trust_all_valid) {
+      detail::copy_validity_from_rows<BLOCK_SIZE>
+        <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+          num_rows,
+          num_columns,
+          shmem_limit_per_tile,
+          offset_functor,
+          gpu_batch_row_boundaries.data(),
+          dev_output_nm,
+          column_info.column_starts.back(),
+          device_span<detail::tile_info const>{dev_validity_tile_infos, validity_tile_infos.size()},
+          child.data<int8_t>(),
+          dev_valid_counts.data());
+    }
 
+    auto const num_string_columns = static_cast<size_type>(string_lengths.size());
+    auto const temp_mr            = cudf::get_current_device_resource_ref();
+
+    // Allocate all offsets buffers up front so one batched scan can fill every column.
     std::vector<device_uvector<size_type>> string_col_offsets;
     std::vector<rmm::device_uvector<char>> string_data_cols;
     std::vector<size_type*> string_col_offset_ptrs;
     std::vector<char*> string_data_col_ptrs;
-    for (auto& col_string_lengths : string_lengths) {
-      device_uvector<size_type> output_string_offsets(num_rows + 1, stream, mr);
-      auto tmp = cuda::proclaim_return_type<int32_t>(
-        [num_rows, col_string_lengths] __device__(auto const& i) {
-          return i < num_rows ? col_string_lengths[i] : 0;
-        });
-      auto bounded_iter = spark_rapids_jni::util::make_counting_transform_iterator(0, tmp);
-      thrust::exclusive_scan(rmm::exec_policy(stream),
-                             bounded_iter,
-                             bounded_iter + num_rows + 1,
-                             output_string_offsets.begin());
-
-      // allocate destination string column
-      rmm::device_uvector<char> string_data(
-        output_string_offsets.element(num_rows, stream), stream, mr);
-
-      string_col_offset_ptrs.push_back(output_string_offsets.data());
-      string_data_col_ptrs.push_back(string_data.data());
-      string_col_offsets.push_back(std::move(output_string_offsets));
-      string_data_cols.push_back(std::move(string_data));
+    for (size_type i = 0; i < num_string_columns; ++i) {
+      string_col_offsets.emplace_back(num_rows + 1, stream, mr);
+      string_col_offset_ptrs.push_back(string_col_offsets.back().data());
     }
-    auto dev_string_col_offsets = make_device_uvector_async(
-      string_col_offset_ptrs, stream, rmm::mr::get_current_device_resource_ref());
-    auto dev_string_data_cols = make_device_uvector_async(
-      string_data_col_ptrs, stream, rmm::mr::get_current_device_resource_ref());
 
-    dim3 const string_blocks(
-      std::min(std::max(MIN_STRING_BLOCKS, num_rows / NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS),
-               MAX_STRING_BLOCKS));
+    // second arena upload, offsets pointers only: the totals gather below dereferences this
+    // array on device before the chars sizes are known. Earlier conversion work is still queued
+    // on the stream here, so the arena's per-round event guard, not a stream drain, is what keeps
+    // its pinned staging block safe.
+    auto* const dev_string_col_offsets = std::get<0>(arena.upload(string_col_offset_ptrs));
 
-    detail::copy_strings_from_rows<NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS>
-      <<<string_blocks, NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS, 0, stream.value()>>>(
-        offset_functor,
-        dev_string_row_offsets.data(),
-        dev_string_lengths.data(),
-        dev_string_col_offsets.data(),
-        dev_string_data_cols.data(),
-        child.data<int8_t>(),
-        num_rows,
-        static_cast<cudf::size_type>(string_col_offsets.size()));
+    // One exclusive scan-by-key over the K string columns flattened to K*(num_rows+1) elements
+    // replaces K per-column scans that each paid a launch plus a hard sync to read back its
+    // total. Segment = column with init 0 per segment, the exact per-column exclusive_scan
+    // result; past each column's last row the value iterator feeds 0 so the column's total chars
+    // size lands at slot [num_rows]. The flat extent is computed in 64 bits because the only
+    // upstream bound on K*num_rows is a layout check whose own product is 32-bit and can overflow.
+    auto const flat_stride = static_cast<int64_t>(num_rows) + 1;
+    auto const flat_count  = static_cast<int64_t>(num_string_columns) * flat_stride;
+    auto flat_keys         = spark_rapids_jni::util::make_counting_transform_iterator(
+      0, cuda::proclaim_return_type<size_type>([flat_stride] __device__(auto const& i) {
+        return static_cast<size_type>(i / flat_stride);
+      }));
+    auto flat_lengths = spark_rapids_jni::util::make_counting_transform_iterator(
+      0,
+      cuda::proclaim_return_type<int32_t>(
+        [flat_stride, num_rows, lengths = dev_string_lengths] __device__(auto const& i) {
+          auto const row = i % flat_stride;
+          return row < num_rows ? lengths[i / flat_stride][row] : 0;
+        }));
+    {
+      // Scan into one contiguous scratch buffer and peel it into the per-column offsets with K
+      // small stream-ordered D2D copies; scoped to release the scratch before the chars
+      // allocations below.
+      rmm::device_uvector<size_type> flat_offsets(flat_count, stream);
+      thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(stream, temp_mr),
+                                    flat_keys,
+                                    flat_keys + flat_count,
+                                    flat_lengths,
+                                    flat_offsets.begin());
+      for (size_type i = 0; i < num_string_columns; ++i) {
+        CUDF_CUDA_TRY(
+          cudaMemcpyAsync(string_col_offset_ptrs[i],
+                          flat_offsets.data() + static_cast<std::size_t>(i) * flat_stride,
+                          sizeof(size_type) * flat_stride,
+                          cudaMemcpyDeviceToDevice,
+                          stream.value()));
+      }
+    }
+
+    // Gather the K chars totals and read them back with ONE copy and ONE sync instead of K
+    // element() round-trips.
+    rmm::device_uvector<size_type> dev_chars_sizes(num_string_columns, stream);
+    thrust::transform(
+      rmm::exec_policy_nosync(stream, temp_mr),
+      cuda::make_counting_iterator(0),
+      cuda::make_counting_iterator(num_string_columns),
+      dev_chars_sizes.begin(),
+      cuda::proclaim_return_type<size_type>([num_rows, offsets = dev_string_col_offsets] __device__(
+                                              auto const& i) { return offsets[i][num_rows]; }));
+    std::vector<size_type> chars_sizes(num_string_columns);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(chars_sizes.data(),
+                                  dev_chars_sizes.data(),
+                                  sizeof(size_type) * num_string_columns,
+                                  cudaMemcpyDeviceToHost,
+                                  stream.value()));
+    stream.synchronize();
+
+    // Destination chars buffers stay per-column: each one is released into its own strings
+    // column below. The chars total feeds the engine pick, at no extra sync.
+    int64_t total_string_chars = 0;
+    for (size_type i = 0; i < num_string_columns; ++i) {
+      total_string_chars += chars_sizes[i];
+      string_data_cols.emplace_back(chars_sizes[i], stream, mr);
+      string_data_col_ptrs.push_back(string_data_cols.back().data());
+    }
+
+    // third arena upload: the chars pointers only exist after the sized allocations above
+    auto* const dev_string_data_cols = std::get<0>(arena.upload(string_data_col_ptrs));
+
+    // Engine pick reuses cudf's strings-gather thresholds: short strings fill warps better with
+    // dense per-byte stores, long strings amortize aligned 16B vector stores across a warp.
+    // cudf's third branch, a batched memcpy above ~512K strings, is not ported: its crossover was
+    // tuned on gathers with contiguous source chars, and jcudf rows stride the sources by the row
+    // size, so it would have to be re-measured here.
+    if (num_rows > 0) {
+      auto const avg_string_length =
+        total_string_chars / (static_cast<int64_t>(num_rows) * num_string_columns);
+      // dim3.y caps at 65535; the kernels column-stride past it (never expected in practice)
+      auto const grid_y = static_cast<uint32_t>(std::min(num_string_columns, 65535));
+      if (avg_string_length > STRING_COPY_AVG_LEN_SWITCH) {
+        dim3 const string_parallel_grid(
+          std::min(cudf::util::div_rounding_up_safe(num_rows, STRING_COPY_WARPS_PER_BLOCK),
+                   MAX_STRING_COPY_BLOCKS),
+          grid_y);
+        detail::copy_strings_from_rows_string_parallel<<<string_parallel_grid,
+                                                         STRING_COPY_BLOCK_SIZE,
+                                                         0,
+                                                         stream.value()>>>(offset_functor,
+                                                                           dev_string_row_offsets,
+                                                                           dev_string_col_offsets,
+                                                                           dev_string_data_cols,
+                                                                           child.data<int8_t>(),
+                                                                           num_rows,
+                                                                           num_string_columns);
+      } else {
+        dim3 const char_parallel_grid(
+          cudf::util::div_rounding_up_safe(num_rows, STRING_COPY_STRINGS_PER_BLOCK), grid_y);
+        detail::copy_strings_from_rows_char_parallel<STRING_COPY_STRINGS_PER_BLOCK>
+          <<<char_parallel_grid, STRING_COPY_BLOCK_SIZE, 0, stream.value()>>>(
+            offset_functor,
+            dev_string_row_offsets,
+            dev_string_col_offsets,
+            dev_string_data_cols,
+            child.data<int8_t>(),
+            num_rows,
+            num_string_columns);
+      }
+    }
 
     // merge strings back into output_columns
     int string_idx = 0;
@@ -2549,35 +3108,106 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
                               string_data_cols[string_idx].release(),
                               0,
                               std::move(*string_data.null_mask.release()));
-        // Null count set to 0, temporarily. Will be fixed up before return.
+        // Null count 0 is temporary on the incumbent path (overwritten from the kernel's valid
+        // counts before return); on the trusted all-valid path the mask is empty and 0 is final.
         string_idx++;
       }
     }
-
-    // Drain the async H2D uploads above before string_col_offset_ptrs and string_data_col_ptrs
-    // go out of scope: CUDA 13+ may read the host source only when the stream executes the copy.
-    stream.synchronize();
   }
 
-  // Set null counts, because output_columns are modified via mutable-view,
-  // in the kernel above.
-  // TODO(future): Consider setting null count in the kernel itself.
-  fixup_null_counts(output_columns, stream);
-
-  // Explicitly drain async H2D uploads before the host staging vectors go out of scope
-  // (CUDA 13+ may read the host source only at stream-execution time). Not left to the
-  // incidental sync in fixup_null_counts, which vanishes if null counts move into the kernel.
-  stream.synchronize();
+  // The kernels write through mutable views, so null counts must be set before return: one D2H
+  // copy of the kernel-accumulated valid counts, then one synchronize. The all-valid path
+  // allocated no masks, so its counts are already 0 and it skips the read-back entirely.
+  if (!trust_all_valid) {
+    std::vector<size_type> valid_counts(dev_valid_counts.size());
+    CUDF_CUDA_TRY(cudaMemcpyAsync(valid_counts.data(),
+                                  dev_valid_counts.data(),
+                                  dev_valid_counts.size() * sizeof(size_type),
+                                  cudaMemcpyDeviceToHost,
+                                  stream.value()));
+    stream.synchronize();
+    for (std::size_t i = 0; i < output_columns.size(); ++i) {
+      output_columns[i]->set_null_count(num_rows - valid_counts[i]);
+    }
+  }
 
   return std::make_unique<table>(std::move(output_columns));
 }
 
-std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view const& input,
-                                                               std::vector<data_type> const& schema,
-                                                               rmm::cuda_stream_view stream,
-                                                               rmm::device_async_resource_ref mr)
+}  // namespace
+
+/**
+ * @brief convert from JCUDF row format to cudf columns
+ *
+ * @param input vector of list columns containing byte columns of the JCUDF row data
+ * @param schema incoming schema of the data
+ * @param stream stream to use for compute
+ * @param mr memory resource for returned data
+ * @return cudf table of the data
+ */
+std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
+                                         std::vector<data_type> const& schema,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
+  // The trusted all-valid path is opt-in through the `may_have_nulls` overload only. No ambient
+  // switch may select it: a caller that has not observed its data must get the incumbent path,
+  // because the fast path returns wrong values rather than an error when the guarantee is false.
+  return convert_from_rows_impl(input, schema, /*trust_all_valid=*/false, stream, mr);
+}
+
+/**
+ * @brief convert from JCUDF row format to cudf columns, trusting a caller-supplied per-column
+ * nullability declaration
+ *
+ * When every entry of `may_have_nulls` is false the caller guarantees the row data contains no
+ * nulls: output columns come back non-nullable (no null masks) and the reverse-validity pipeline
+ * is skipped entirely. The JCUDF row bytes are consumed unchanged — their validity bytes are just
+ * never read — so a false guarantee silently yields wrong values in the rows that are actually
+ * null. Setting `ROWCONV_VALIDATE_ALL_VALID=1` in the environment re-verifies every all-valid
+ * declaration via the incumbent path and throws on violation (debug aid, default off). Any true
+ * entry selects the incumbent path for the whole call.
+ *
+ * @param input vector of list columns containing byte columns of the JCUDF row data
+ * @param schema incoming schema of the data
+ * @param may_have_nulls one entry per schema column; false = guaranteed to contain no nulls
+ * @param stream stream to use for compute
+ * @param mr memory resource for returned data
+ * @return cudf table of the data
+ */
+std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
+                                         std::vector<data_type> const& schema,
+                                         std::vector<bool> const& may_have_nulls,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr)
+{
+  SRJ_FUNC_RANGE();
+  auto const trust_all_valid = is_all_valid_profile(may_have_nulls, schema.size());
+  if (trust_all_valid && validate_all_valid_enabled()) {
+    return strip_verified_all_valid(
+      convert_from_rows_impl(input, schema, /*trust_all_valid=*/false, stream, mr));
+  }
+  return convert_from_rows_impl(input, schema, trust_all_valid, stream, mr);
+}
+
+namespace {
+
+/**
+ * @brief Implementation of the fixed-width-optimized JCUDF-rows-to-columns conversion
+ *
+ * @param trust_all_valid when true output columns are created without null masks, the fused
+ * kernel receives no mask pointers (skipping its validity phase) and the batched null-count
+ * fix-up with its blocking read-back is skipped; the staging arena's copy event is then the
+ * only remaining host wait.
+ */
+std::unique_ptr<table> convert_from_rows_fixed_width_optimized_impl(
+  lists_column_view const& input,
+  std::vector<data_type> const& schema,
+  bool trust_all_valid,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
   // verify that the types are what we expect
   column_view child    = input.child();
   auto const list_type = child.type().id();
@@ -2601,10 +3231,6 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
   // Ideally we would check that the offsets are all the same, etc. but for now this is probably
   // fine
   CUDF_EXPECTS(size_per_row * num_rows == child.size(), "The layout of the data appears to be off");
-  auto dev_column_start =
-    make_device_uvector_async(column_start, stream, rmm::mr::get_current_device_resource_ref());
-  auto dev_column_size =
-    make_device_uvector_async(column_size, stream, rmm::mr::get_current_device_resource_ref());
 
   // Allocate the columns we are going to write into
   std::vector<std::unique_ptr<column>> output_columns;
@@ -2612,15 +3238,22 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
   std::vector<bitmask_type*> output_nm;
   for (int i = 0; i < static_cast<int>(num_columns); i++) {
     auto column =
-      make_fixed_width_column(schema[i], num_rows, mask_state::UNINITIALIZED, stream, mr);
+      make_fixed_width_column(schema[i],
+                              num_rows,
+                              trust_all_valid ? mask_state::UNALLOCATED : mask_state::UNINITIALIZED,
+                              stream,
+                              mr);
     auto mut = column->mutable_view();
     output_data.emplace_back(mut.data<int8_t>());
-    output_nm.emplace_back(mut.null_mask());
+    if (!trust_all_valid) { output_nm.emplace_back(mut.null_mask()); }
     output_columns.emplace_back(std::move(column));
   }
 
-  auto dev_output_data = make_device_uvector_async(output_data, stream, mr);
-  auto dev_output_nm   = make_device_uvector_async(output_nm, stream, mr);
+  // On the all-valid path output_nm is empty and uploads as nullptr, which disables the
+  // kernel's validity phase.
+  detail::staging_arena arena(stream);
+  auto const [dev_column_start, dev_column_size, dev_output_data, dev_output_nm] =
+    arena.upload(column_start, column_size, output_data, output_nm);
 
   dim3 blocks;
   dim3 threads;
@@ -2631,23 +3264,63 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
     num_rows,
     num_columns,
     size_per_row,
-    dev_column_start.data(),
-    dev_column_size.data(),
-    dev_output_data.data(),
-    dev_output_nm.data(),
+    dev_column_start,
+    dev_column_size,
+    dev_output_data,
+    dev_output_nm,
     child.data<int8_t>());
 
-  // Set null counts, because output_columns are modified via mutable-view,
-  // in the kernel above.
+  // Set null counts, because output_columns are modified via mutable-view, in the kernel above.
+  // The trusted all-valid path allocated no masks, so its counts are already 0 and the batched
+  // count (with its blocking read-back) is skipped.
   // TODO(future): Consider setting null count in the kernel itself.
-  fixup_null_counts(output_columns, stream);
-
-  // Explicitly drain async H2D uploads before the host staging vectors go out of scope
-  // (CUDA 13+ may read the host source only at stream-execution time). Not left to the
-  // incidental sync in fixup_null_counts, which vanishes if null counts move into the kernel.
-  stream.synchronize();
+  if (!trust_all_valid) { fixup_null_counts(output_columns, stream); }
 
   return std::make_unique<table>(std::move(output_columns));
+}
+
+}  // namespace
+
+std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view const& input,
+                                                               std::vector<data_type> const& schema,
+                                                               rmm::cuda_stream_view stream,
+                                                               rmm::device_async_resource_ref mr)
+{
+  SRJ_FUNC_RANGE();
+  // Opt-in only: a wrong guarantee yields wrong values rather than an error.
+  return convert_from_rows_fixed_width_optimized_impl(
+    input, schema, /*trust_all_valid=*/false, stream, mr);
+}
+
+/**
+ * @brief convert from JCUDF row format to cudf columns on the fixed-width-optimized path,
+ * trusting a caller-supplied per-column nullability declaration
+ *
+ * Same declaration contract as the general-path overload above. With an all-valid declaration
+ * this path drops the blocking null-count read-back; the host still waits once on the staging
+ * arena's copy event, which is bounded by the H2D transfer rather than by the kernel.
+ *
+ * @param input vector of list columns containing byte columns of the JCUDF row data
+ * @param schema incoming schema of the data
+ * @param may_have_nulls one entry per schema column; false = guaranteed to contain no nulls
+ * @param stream stream to use for compute
+ * @param mr memory resource for returned data
+ * @return cudf table of the data
+ */
+std::unique_ptr<table> convert_from_rows_fixed_width_optimized(
+  lists_column_view const& input,
+  std::vector<data_type> const& schema,
+  std::vector<bool> const& may_have_nulls,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  SRJ_FUNC_RANGE();
+  auto const trust_all_valid = is_all_valid_profile(may_have_nulls, schema.size());
+  if (trust_all_valid && validate_all_valid_enabled()) {
+    return strip_verified_all_valid(convert_from_rows_fixed_width_optimized_impl(
+      input, schema, /*trust_all_valid=*/false, stream, mr));
+  }
+  return convert_from_rows_fixed_width_optimized_impl(input, schema, trust_all_valid, stream, mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,14 @@
 #include <rmm/resource_ref.hpp>
 
 #include <memory>
+#include <vector>
 
 namespace spark_rapids_jni {
+
+// Stream contract for the conversion entry points below: each enqueues its work on `stream` and
+// may return before that work completes, so callers must keep the inputs alive and synchronize
+// `stream` before reading a result on the host. Some of them synchronize internally today to
+// read null counts back; that is an implementation detail callers must not rely on.
 
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows_fixed_width_optimized(
   cudf::table_view const& tbl,
@@ -48,6 +54,59 @@ std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
 std::unique_ptr<cudf::table> convert_from_rows(
   cudf::lists_column_view const& input,
   std::vector<cudf::data_type> const& schema,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+
+/**
+ * @brief Convert JCUDF rows back to columns on the fixed-width-optimized path, trusting a
+ * caller-supplied per-column nullability declaration
+ *
+ * `may_have_nulls` must carry one entry per schema column. When every entry is false the caller
+ * guarantees the rows contain no nulls: the conversion skips all reverse-validity work (output
+ * null-mask allocation, the validity kernel, null-count computation and its synchronize) and
+ * returns non-nullable columns. A false guarantee silently yields wrong values for the rows that
+ * are actually null; set the environment variable `ROWCONV_VALIDATE_ALL_VALID=1` to re-verify
+ * every all-valid declaration and throw on violation instead (debug aid, default off). Any true
+ * entry selects the incumbent path for the whole call.
+ *
+ * `may_have_nulls` MUST be OBSERVED from the data that produced these rows, never inferred from a
+ * declared schema. Spark's static nullability metadata is not a valid source: it states what a
+ * column MAY contain, and a planner may declare a column non-nullable that carries nulls at
+ * runtime. The supported producers are a null-count on the source columns, or a flag the row
+ * packer sets while writing (see `GpuRowToColumnarExec`'s generated `fillBatch`).
+ *
+ * @param input list column holding the JCUDF row data
+ * @param schema incoming schema of the data
+ * @param may_have_nulls one entry per schema column; false = guaranteed to contain no nulls
+ * @param stream stream to use for compute
+ * @param mr memory resource for returned data
+ * @return the converted table
+ */
+std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
+  cudf::lists_column_view const& input,
+  std::vector<cudf::data_type> const& schema,
+  std::vector<bool> const& may_have_nulls,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+
+/**
+ * @brief Convert JCUDF rows back to columns on the general path, trusting a caller-supplied
+ * per-column nullability declaration
+ *
+ * Same declaration contract as the fixed-width-optimized overload above: `may_have_nulls` must
+ * be OBSERVED from the data, never inferred from a declared schema.
+ *
+ * @param input list column holding the JCUDF row data
+ * @param schema incoming schema of the data
+ * @param may_have_nulls one entry per schema column; false = guaranteed to contain no nulls
+ * @param stream stream to use for compute
+ * @param mr memory resource for returned data
+ * @return the converted table
+ */
+std::unique_ptr<cudf::table> convert_from_rows(
+  cudf::lists_column_view const& input,
+  std::vector<cudf::data_type> const& schema,
+  std::vector<bool> const& may_have_nulls,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 

--- a/src/main/cpp/src/row_conversion_jit.cpp
+++ b/src/main/cpp/src/row_conversion_jit.cpp
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "row_conversion_jit.hpp"
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <dlfcn.h>
+#include <rtcx.hpp>
+#include <strings.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <format>
+#include <future>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace spark_rapids_jni {
+namespace detail {
+
+namespace {
+
+using cudf::size_type;
+
+// The generated kernels mirror the generic kernels' launch shape: 1024 threads = 32 warps.
+constexpr int JIT_BLOCK_SIZE = 1024;
+
+// Beyond this the generated straight-line body stops paying for its compile time; the bench wide
+// case (320 columns) is multi-band and never reaches the JIT anyway.
+constexpr std::size_t JIT_MAX_COLUMNS = 512;
+
+// Compiled kernels are never evicted (unloading a module that may still have launches in flight
+// is the hazard), so cap insertions instead; schemas past the cap use the generic kernel.
+constexpr std::size_t JIT_CACHE_MAX_ENTRIES = 128;
+
+bool jit_enabled()
+{
+  static bool const enabled = [] {
+    char const* env = std::getenv("SPARK_RAPIDS_ROWCONV_JIT");
+    if (env == nullptr) { return true; }
+    // The kill switch has to be usable during an incident, so tolerate the whitespace an env var
+    // picks up on its way through a container spec, accept the common spellings of "no", and say
+    // something when the value is none of them rather than silently staying on.
+    std::string value{env};
+    auto const first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) { return true; }
+    value = value.substr(first, value.find_last_not_of(" \t\r\n") - first + 1);
+    for (auto const* word : {"0", "false", "off", "no", "disable", "disabled"}) {
+      if (::strcasecmp(value.c_str(), word) == 0) { return false; }
+    }
+    std::fprintf(stderr,
+                 "[spark-rapids-jni] SPARK_RAPIDS_ROWCONV_JIT=\"%s\" is not a "
+                 "recognized value; the row-conversion JIT stays enabled\n",
+                 env);
+    return true;
+  }();
+  return enabled;
+}
+
+struct device_env {
+  int ordinal;
+  int compute_capability;  // major * 10 + minor
+  int driver_version;
+  int runtime_version;
+};
+
+std::optional<device_env> query_device_env()
+{
+  device_env env{};
+  int major = 0;
+  int minor = 0;
+  if (cudaGetDevice(&env.ordinal) != cudaSuccess ||
+      cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, env.ordinal) !=
+        cudaSuccess ||
+      cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, env.ordinal) !=
+        cudaSuccess ||
+      cudaDriverGetVersion(&env.driver_version) != cudaSuccess ||
+      cudaRuntimeGetVersion(&env.runtime_version) != cudaSuccess) {
+    return std::nullopt;
+  }
+  env.compute_capability = major * 10 + minor;
+  return env;
+}
+
+// The generated code copies each element with one full-width typed access, so every start must be
+// aligned to the access width (16-byte columns are accessed as two 8-byte halves on the row side).
+bool layout_supported(std::vector<size_type> const& column_sizes,
+                      std::vector<size_type> const& column_starts,
+                      size_type row_stride)
+{
+  auto const num_columns = column_sizes.size();
+  if (num_columns == 0 || num_columns > JIT_MAX_COLUMNS) { return false; }
+  if (column_starts.size() != num_columns + 1) { return false; }
+  for (std::size_t i = 0; i < num_columns; ++i) {
+    auto const size = column_sizes[i];
+    if (size != 1 && size != 2 && size != 4 && size != 8 && size != 16) { return false; }
+    auto const access_width = size < 8 ? size : 8;
+    if (column_starts[i] % access_width != 0) { return false; }
+  }
+  // The generated kernels address rows as `input + row * row_stride` and copy them eight bytes at
+  // a time, so the stride itself has to keep every row 8-byte aligned.
+  if (row_stride % 8 != 0) { return false; }
+  return column_starts[num_columns - 1] + column_sizes[num_columns - 1] <= row_stride;
+}
+
+std::string make_cache_key(char direction,
+                           device_env const& env,
+                           size_type row_stride,
+                           std::vector<size_type> const& column_sizes,
+                           std::vector<size_type> const& column_starts)
+{
+  std::string key;
+  key.reserve(32 + (column_sizes.size() + column_starts.size() + 6) * sizeof(int));
+  key.append("SRJC6v1");
+  key.push_back(direction);
+  auto const append_int = [&key](int v) {
+    key.append(reinterpret_cast<char const*>(&v), sizeof(v));
+  };
+  append_int(env.compute_capability);
+  append_int(env.driver_version);
+  append_int(env.runtime_version);
+  append_int(JIT_BLOCK_SIZE);
+  append_int(row_stride);
+  append_int(static_cast<int>(column_sizes.size()));
+  for (auto const v : column_sizes) {
+    append_int(v);
+  }
+  for (auto const v : column_starts) {
+    append_int(v);
+  }
+  return key;
+}
+
+char const* type_for_width(size_type width)
+{
+  switch (width) {
+    case 1: return "char";
+    case 2: return "short";
+    case 4: return "int";
+    default: return "long long";
+  }
+}
+
+// Shared prologue of the generated source. srj_tile mirrors detail::tile_info (asserted at the
+// call sites); srj_v16 reproduces the generic kernel's single 16-byte decimal128 store.
+constexpr char const* JIT_SOURCE_PROLOGUE =
+  "struct srj_tile { int start_col; int start_row; int end_col; int end_row; int batch_number; "
+  "};\n"
+  "struct alignas(16) srj_v16 { long long lo; long long hi; };\n";
+
+/**
+ * @brief Generate the from-rows gather kernel for one layout
+ *
+ * Mirrors the generic `copy_from_rows` work split — warp w handles columns w, w+32, ... and its
+ * lanes stride the tile's rows — but the column sweep is emitted as straight-line code per warp
+ * with all offsets, widths and the row stride as immediates.
+ */
+std::string make_from_rows_source(std::vector<size_type> const& column_sizes,
+                                  std::vector<size_type> const& column_starts,
+                                  size_type row_stride)
+{
+  auto const num_columns = static_cast<int>(column_sizes.size());
+  std::string src{JIT_SOURCE_PROLOGUE};
+  src += std::format(
+    "extern \"C\" __global__ void __launch_bounds__({}) srj_rowconv_specialized(\n"
+    "  srj_tile const* tiles, char const* __restrict__ input, char* const* output)\n"
+    "{{\n"
+    "  srj_tile const t = tiles[blockIdx.x];\n"
+    "  int const lane   = static_cast<int>(threadIdx.x & 31u);\n"
+    "  int const warp   = static_cast<int>(threadIdx.x >> 5u);\n"
+    "  int const nrows  = t.end_row - t.start_row + 1;\n"
+    "  switch (warp) {{\n",
+    JIT_BLOCK_SIZE);
+  for (int w = 0; w < 32 && w < num_columns; ++w) {
+    src += std::format("    case {}: {{\n", w);
+    for (int c = w; c < num_columns; c += 32) {
+      src += std::format("      char* __restrict__ o{0} = output[{0}];\n", c);
+    }
+    src +=
+      "      for (int rr = lane; rr < nrows; rr += 32) {\n"
+      "        int const row = t.start_row + rr;\n";
+    src += std::format("        char const* __restrict__ rp = input + row * {};\n", row_stride);
+    for (int c = w; c < num_columns; c += 32) {
+      auto const size  = column_sizes[c];
+      auto const start = column_starts[c];
+      if (size == 1) {
+        src += std::format("        o{0}[row] = rp[{1}];\n", c, start);
+      } else if (size == 16) {
+        // Rows are only 8-byte aligned: two 8-byte reads, one 16-byte store.
+        src += std::format(
+          "        {{ long long const* p{0} = reinterpret_cast<long long const*>(rp + {1});\n"
+          "          *reinterpret_cast<srj_v16*>(o{0} + row * 16) = srj_v16{{p{0}[0], p{0}[1]}}; "
+          "}}\n",
+          c,
+          start);
+      } else {
+        src += std::format(
+          "        *reinterpret_cast<{2}*>(o{0} + row * {3}) = *reinterpret_cast<{2} "
+          "const*>(rp + {1});\n",
+          c,
+          start,
+          type_for_width(size),
+          size);
+      }
+    }
+    src += "      }\n    } break;\n";
+  }
+  src += "  }\n}\n";
+  return src;
+}
+
+/**
+ * @brief Generate the to-rows kernel for one layout
+ *
+ * Phase one mirrors the generic `copy_to_rows` element staging (warp w owns columns w, w+32, ...)
+ * into a shared tile with a compile-time padded row width; phase two copies each staged row to
+ * global memory with a warp-cooperative loop whose length is the compile-time un-padded row data
+ * width. Both kernels drain with plain word stores; the generated one additionally drops the
+ * generic kernel's live-column bookkeeping and the block sync that publishes it, keeping only
+ * the stage-to-drain barrier.
+ */
+std::string make_to_rows_source(std::vector<size_type> const& column_sizes,
+                                std::vector<size_type> const& column_starts,
+                                size_type row_stride)
+{
+  auto const num_columns = static_cast<int>(column_sizes.size());
+  // Un-padded data width of a full-row band, and its shared-memory pitch; see
+  // tile_info::get_actual_row_size / get_shared_row_size.
+  auto const actual_row_size = column_starts[num_columns - 1] + column_sizes[num_columns - 1];
+  auto const shared_row_size = (actual_row_size + 7) & ~7;
+  std::string src{JIT_SOURCE_PROLOGUE};
+  src += std::format(
+    "extern \"C\" __global__ void __launch_bounds__({}) srj_rowconv_specialized(\n"
+    "  srj_tile const* tiles, char const* const* input, char* const* output,\n"
+    "  int const* batch_row_boundaries)\n"
+    "{{\n"
+    "  extern __shared__ char smem[];\n"
+    "  srj_tile const t = tiles[blockIdx.x];\n"
+    "  int const lane   = static_cast<int>(threadIdx.x & 31u);\n"
+    "  int const warp   = static_cast<int>(threadIdx.x >> 5u);\n"
+    "  int const nrows  = t.end_row - t.start_row + 1;\n"
+    "  switch (warp) {{\n",
+    JIT_BLOCK_SIZE);
+  for (int w = 0; w < 32 && w < num_columns; ++w) {
+    src += std::format("    case {}: {{\n", w);
+    for (int c = w; c < num_columns; c += 32) {
+      src += std::format("      char const* __restrict__ i{0} = input[{0}];\n", c);
+    }
+    src +=
+      "      for (int rr = lane; rr < nrows; rr += 32) {\n"
+      "        int const row = t.start_row + rr;\n";
+    src += std::format("        char* sp = smem + rr * {};\n", shared_row_size);
+    for (int c = w; c < num_columns; c += 32) {
+      auto const size  = column_sizes[c];
+      auto const start = column_starts[c];
+      if (size == 1) {
+        src += std::format("        sp[{1}] = i{0}[row];\n", c, start);
+      } else if (size == 16) {
+        // The shared row pitch is only 8-byte aligned; stage as two 8-byte halves.
+        src += std::format(
+          "        {{ long long const* p{0} = reinterpret_cast<long long const*>(i{0} + row * "
+          "16);\n"
+          "          *reinterpret_cast<long long*>(sp + {1}) = p{0}[0];\n"
+          "          *reinterpret_cast<long long*>(sp + {2}) = p{0}[1]; }}\n",
+          c,
+          start,
+          start + 8);
+      } else {
+        src += std::format(
+          "        *reinterpret_cast<{2}*>(sp + {1}) = *reinterpret_cast<{2} const*>(i{0} + row "
+          "* {3});\n",
+          c,
+          start,
+          type_for_width(size),
+          size);
+      }
+    }
+    src += "      }\n    } break;\n";
+  }
+  src +=
+    "  }\n"
+    "  __syncthreads();\n"
+    "  char* const obuf      = output[t.batch_number];\n"
+    "  int const batch_start = t.batch_number == 0 ? 0 : batch_row_boundaries[t.batch_number];\n"
+    "  for (int r = warp; r < nrows; r += 32) {\n";
+  src += std::format("    char const* src = smem + r * {};\n", shared_row_size);
+  src +=
+    std::format("    char* dst       = obuf + (t.start_row + r - batch_start) * {};\n", row_stride);
+  src += std::format(
+    "    for (int i = lane * 8; i + 8 <= {0}; i += 256) {{\n"
+    "      *reinterpret_cast<long long*>(dst + i) = *reinterpret_cast<long long const*>(src + "
+    "i);\n"
+    "    }}\n",
+    actual_row_size);
+  if (actual_row_size % 8 != 0) {
+    auto const tail_base = actual_row_size & ~7;
+    src += std::format("    if (lane < {0}) {{ dst[{1} + lane] = src[{1} + lane]; }}\n",
+                       actual_row_size % 8,
+                       tail_base);
+  }
+  src += "  }\n}\n";
+  return src;
+}
+
+struct jit_kernel {
+  rtcx::library library;  // keeps the CUlibrary loaded for the kernel's lifetime
+  CUkernel kernel;
+};
+
+// The preferred-carveout hint mirrors the generic from-rows launch, which requests the maximum L1
+// carveout for its strided row re-reads. libcuda is not on the link line (the static CUDA runtime
+// and librtcx both load it dynamically), so resolve the setter the same way; it is a performance
+// hint only and every failure path simply leaves the default carveout.
+void try_set_max_l1_carveout(CUkernel kernel, int device_ordinal)
+{
+  // Alias the header's own declaration so a driver-side ABI change is a compile error here
+  // rather than a silently mistyped call.
+  using set_attribute_fn                      = decltype(&cuKernelSetAttribute);
+  static set_attribute_fn const set_attribute = [] {
+    void* handle = ::dlopen("libcuda.so.1", RTLD_NOW | RTLD_NOLOAD);
+    if (handle == nullptr) { handle = ::dlopen("libcuda.so.1", RTLD_NOW); }
+    return handle == nullptr
+             ? nullptr
+             : reinterpret_cast<set_attribute_fn>(::dlsym(handle, "cuKernelSetAttribute"));
+  }();
+  if (set_attribute != nullptr) {
+    // 0 == cudaSharedmemCarveoutMaxL1 (carveout values are shared-memory percentages).
+    static_cast<void>(
+      set_attribute(CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT, 0, kernel, device_ordinal));
+  }
+}
+
+jit_kernel compile_specialized_kernel(std::string const& source,
+                                      device_env const& env,
+                                      bool prefer_max_l1)
+{
+  rtcx::initialize();
+  std::vector<std::string> option_strings = {
+    std::format("--gpu-architecture=sm_{}", env.compute_capability), "-std=c++20", "--dopt=on"};
+  // The generated source is header-free; --minimal (NVRTC >= 12.8) skips the builtin header
+  // machinery for a faster cold compile.
+  if (rtcx::nvrtc_version() >= 12'080) { option_strings.emplace_back("--minimal"); }
+  std::vector<char const*> options;
+  options.reserve(option_strings.size());
+  for (auto const& option : option_strings) {
+    options.push_back(option.c_str());
+  }
+
+  auto const params = rtcx::compile_params{.name        = "srj_rowconv_specialized",
+                                           .source      = source.c_str(),
+                                           .options     = options,
+                                           .target_type = rtcx::binary_type::CUBIN};
+  auto cubin        = rtcx::compile(params);
+  auto library      = rtcx::load_library(std::span<std::uint8_t const>{cubin.data(), cubin.size()});
+  auto const kernel = library->get_kernel("srj_rowconv_specialized");
+  if (prefer_max_l1) { try_set_max_l1_carveout(kernel.get(), env.ordinal); }
+  return jit_kernel{std::move(library), kernel.get()};
+}
+
+struct jit_registry {
+  std::mutex mutex;
+  std::unordered_map<std::string, std::shared_future<jit_kernel>> kernels;
+};
+
+jit_registry& registry()
+{
+  // Leaked deliberately: entries hold loaded CUlibrary handles, and unloading them during static
+  // destruction (after the driver may already be torn down) is the hazard this avoids.
+  static auto* const instance = new jit_registry();
+  return *instance;
+}
+
+/**
+ * @brief Get the compiled kernel for a layout, compiling it on this thread if needed
+ *
+ * Block-and-compile first-call policy: a cache miss compiles on the calling thread, so the first
+ * conversion of a layout pays the full compile latency and every conversion after it runs the
+ * specialized kernel. Concurrent first calls for the same layout block on the shared future of
+ * the one compiling thread. A failed compile leaves the exception in the shared future,
+ * permanently routing that layout to the generic kernel.
+ */
+std::optional<jit_kernel> acquire_kernel(std::string const& key,
+                                         std::string (*make_source)(std::vector<size_type> const&,
+                                                                    std::vector<size_type> const&,
+                                                                    size_type),
+                                         std::vector<size_type> const& column_sizes,
+                                         std::vector<size_type> const& column_starts,
+                                         size_type row_stride,
+                                         device_env const& env,
+                                         bool prefer_max_l1)
+{
+  auto& reg = registry();
+  std::shared_future<jit_kernel> fut;
+  bool compile_here = false;
+  std::promise<jit_kernel> promise;
+  {
+    std::lock_guard<std::mutex> const lock{reg.mutex};
+    auto const it = reg.kernels.find(key);
+    if (it != reg.kernels.end()) {
+      fut = it->second;
+    } else {
+      if (reg.kernels.size() >= JIT_CACHE_MAX_ENTRIES) { return std::nullopt; }
+      fut = promise.get_future().share();
+      reg.kernels.emplace(key, fut);
+      compile_here = true;
+    }
+  }
+  if (compile_here) {
+    try {
+      promise.set_value(compile_specialized_kernel(
+        make_source(column_sizes, column_starts, row_stride), env, prefer_max_l1));
+    } catch (std::exception const& e) {
+      std::fprintf(stderr,
+                   "[spark-rapids-jni] row_conversion JIT compile failed; the generic kernel "
+                   "will be used for this schema: %s\n",
+                   e.what());
+      promise.set_exception(std::current_exception());
+    }
+  }
+  try {
+    return fut.get();
+  } catch (...) {
+    return std::nullopt;  // compile failed; the warning was already printed once
+  }
+}
+
+bool launch_specialized_kernel(jit_kernel const& kernel,
+                               int num_tiles,
+                               int shmem_bytes,
+                               rmm::cuda_stream_view stream,
+                               void** params)
+{
+  try {
+    rtcx::kernel_ref{kernel.kernel}.launch({static_cast<std::uint32_t>(num_tiles), 1, 1},
+                                           {JIT_BLOCK_SIZE, 1, 1},
+                                           static_cast<std::uint32_t>(shmem_bytes),
+                                           stream.value(),
+                                           params);
+  } catch (std::exception const& e) {
+    static std::atomic<bool> logged{false};
+    if (!logged.exchange(true)) {
+      std::fprintf(stderr,
+                   "[spark-rapids-jni] row_conversion JIT kernel launch failed; falling back to "
+                   "the generic kernel: %s\n",
+                   e.what());
+    }
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+bool try_jit_copy_from_rows(std::vector<size_type> const& column_sizes,
+                            std::vector<size_type> const& column_starts,
+                            size_type row_stride,
+                            int num_tiles,
+                            void const* dev_tile_infos,
+                            int8_t const* input_data,
+                            int8_t** dev_output_data,
+                            rmm::cuda_stream_view stream)
+{
+  if (!jit_enabled() || num_tiles <= 0 ||
+      !layout_supported(column_sizes, column_starts, row_stride)) {
+    return false;
+  }
+  auto const env = query_device_env();
+  if (!env.has_value()) { return false; }
+  auto const key    = make_cache_key('F', *env, row_stride, column_sizes, column_starts);
+  auto const kernel = acquire_kernel(
+    key, &make_from_rows_source, column_sizes, column_starts, row_stride, *env, true);
+  if (!kernel.has_value()) { return false; }
+  void const* params[] = {&dev_tile_infos, &input_data, &dev_output_data};
+  return launch_specialized_kernel(*kernel, num_tiles, 0, stream, const_cast<void**>(params));
+}
+
+bool try_jit_copy_to_rows(std::vector<size_type> const& column_sizes,
+                          std::vector<size_type> const& column_starts,
+                          cudf::size_type row_stride,
+                          int num_tiles,
+                          void const* dev_tile_infos,
+                          int shmem_bytes,
+                          int8_t const** dev_input_data,
+                          int8_t** dev_output_data,
+                          cudf::size_type const* dev_batch_row_boundaries,
+                          rmm::cuda_stream_view stream)
+{
+  if (!jit_enabled() || num_tiles <= 0 ||
+      !layout_supported(column_sizes, column_starts, row_stride)) {
+    return false;
+  }
+  auto const env = query_device_env();
+  if (!env.has_value()) { return false; }
+  auto const key = make_cache_key('T', *env, row_stride, column_sizes, column_starts);
+  auto const kernel =
+    acquire_kernel(key, &make_to_rows_source, column_sizes, column_starts, row_stride, *env, false);
+  if (!kernel.has_value()) { return false; }
+  void const* params[] = {
+    &dev_tile_infos, &dev_input_data, &dev_output_data, &dev_batch_row_boundaries};
+  return launch_specialized_kernel(
+    *kernel, num_tiles, shmem_bytes, stream, const_cast<void**>(params));
+}
+
+}  // namespace detail
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion_jit.hpp
+++ b/src/main/cpp/src/row_conversion_jit.hpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace spark_rapids_jni {
+namespace detail {
+
+/**
+ * @brief Launch a schema-specialized JIT gather kernel for the from-rows direction if available
+ *
+ * The kernel is compiled at runtime (NVRTC through librtcx, both already statically linked into
+ * this binary) for the exact column layout: every column offset, element width and the row stride
+ * are folded into the instruction stream, removing the per-element layout loads and the width
+ * switch of the generic kernel. Only single-band fixed-width layouts are supported; the caller
+ * must have verified that the tile march produced exactly one column band. Compiled kernels are
+ * memoized in a bounded process-global cache keyed by layout and device environment. The env var
+ * `SPARK_RAPIDS_ROWCONV_JIT=0` is the kill switch.
+ *
+ * The generated kernel addresses rows as `input + row * row_stride` with no batch adjustment, so
+ * the caller must pass a single row batch starting at row 0. Nothing in the signature enforces
+ * this: a multi-batch from-rows caller must launch the generic kernel instead.
+ *
+ * @param column_sizes per-column element widths in bytes
+ * @param column_starts per-column offsets within a row plus the trailing validity offset
+ * @param row_stride padded JCUDF row pitch in bytes
+ * @param num_tiles number of row tiles (grid size); one thread block processes one tile
+ * @param dev_tile_infos device array of `tile_info` (layout asserted at the call site)
+ * @param input_data device pointer to the packed JCUDF row data
+ * @param dev_output_data device array of per-column output base pointers
+ * @param stream CUDA stream for the launch
+ * @return true when the specialized kernel was launched; false when the JIT is disabled, the
+ * layout is unsupported, or compilation failed — the caller must then launch the generic kernel
+ */
+bool try_jit_copy_from_rows(std::vector<cudf::size_type> const& column_sizes,
+                            std::vector<cudf::size_type> const& column_starts,
+                            cudf::size_type row_stride,
+                            int num_tiles,
+                            void const* dev_tile_infos,
+                            int8_t const* input_data,
+                            int8_t** dev_output_data,
+                            rmm::cuda_stream_view stream);
+
+/**
+ * @brief Launch a schema-specialized JIT kernel for the to-rows direction if available
+ *
+ * Same contract as `try_jit_copy_from_rows` for the opposite direction: the generated kernel
+ * stages one tile in shared memory with a fully unrolled column sweep and copies rows out with a
+ * compile-time row width. Validity and variable-width data are handled by the unchanged incumbent
+ * kernels.
+ *
+ * @param column_sizes per-column element widths in bytes
+ * @param column_starts per-column offsets within a row plus the trailing validity offset
+ * @param row_stride padded JCUDF row pitch in bytes
+ * @param num_tiles number of row tiles (grid size); one thread block processes one tile
+ * @param dev_tile_infos device array of `tile_info` (layout asserted at the call site)
+ * @param shmem_bytes dynamic shared-memory size the tiles were shaped against
+ * @param dev_input_data device array of per-column input base pointers
+ * @param dev_output_data device array of per-batch output buffer pointers
+ * @param dev_batch_row_boundaries device array of batch starting row numbers
+ * @param stream CUDA stream for the launch
+ * @return true when the specialized kernel was launched; false otherwise (see above)
+ */
+bool try_jit_copy_to_rows(std::vector<cudf::size_type> const& column_sizes,
+                          std::vector<cudf::size_type> const& column_starts,
+                          cudf::size_type row_stride,
+                          int num_tiles,
+                          void const* dev_tile_infos,
+                          int shmem_bytes,
+                          int8_t const** dev_input_data,
+                          int8_t** dev_output_data,
+                          cudf::size_type const* dev_batch_row_boundaries,
+                          rmm::cuda_stream_view stream);
+
+}  // namespace detail
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/row_conversion.cpp
+++ b/src/main/cpp/tests/row_conversion.cpp
@@ -23,13 +23,19 @@
 #include <cudf/copying.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/error.hpp>
 
 #include <row_conversion.hpp>
 #include <utilities/iterator.cuh>
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
+#include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <memory>
 #include <random>
 
 struct ColumnToRowTests : public cudf::test::BaseFixture {};
@@ -666,17 +672,23 @@ TEST_F(ColumnToRowTests, DISABLED_HugeStringRowThrows)
   EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
 }
 
-// Regression repro for spark-rapids-jni#4588. Disabled by default for the same memory reason as
-// HugeStringRowThrows.
+// Regression repro for spark-rapids-jni#4588. Disabled by default because it needs roughly 7 GB of
+// free GPU memory.
 //
 // The old kernel launch passed batch_num_rows (a per-batch count) as the kernel's `num_rows`
 // while start_row was an absolute index, so all batches whose start lay past the per-batch
 // count silently produced uninitialized output. The fix passes batch_row_offset +
 // batch_num_rows as the absolute end bound; this test exercises the multi-batch path.
+//
+// Sizing: two 20 MiB string columns give an ~40 MiB JCUDF row (string bytes dominate), so
+// floor(INT32_MAX / 40 MiB) = 51 >= 32 rows fit a batch and build_batches never trips the
+// "fewer than 32 rows" throw (the earlier 33 MiB columns left only 31 rows per batch, throwing
+// before the multi-batch path could run). 64 rows * ~40 MiB = ~2.5 GiB > the 2 GiB batch limit,
+// splitting into exactly two 32-row batches.
 TEST_F(ColumnToRowTests, DISABLED_MultiBatchStringDoesNotSkip)
 {
-  constexpr std::size_t per_col_bytes = 33ULL * 1024 * 1024;
-  constexpr int num_rows              = 35;
+  constexpr std::size_t per_col_bytes = 20ULL * 1024 * 1024;
+  constexpr int num_rows              = 64;
 
   std::vector<std::string> data_a, data_b;
   data_a.reserve(num_rows);
@@ -694,7 +706,7 @@ TEST_F(ColumnToRowTests, DISABLED_MultiBatchStringDoesNotSkip)
 
   auto rows = spark_rapids_jni::convert_to_rows(in);
   ASSERT_GE(rows.size(), 2u) << "Expected multiple batches; if a single batch fits the issue "
-                                "cannot be reproduced — increase per_col_bytes or num_rows.";
+                                "cannot be reproduced — increase num_rows.";
 
   // Reconstruct each batch and compare against the matching row slice of the input.
   std::size_t row_start = 0;
@@ -706,6 +718,51 @@ TEST_F(ColumnToRowTests, DISABLED_MultiBatchStringDoesNotSkip)
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in_slice, *result);
     row_start += result->num_rows();
   }
+}
+
+// Fixed-width analogue of MultiBatchStringDoesNotSkip: covers the >2 GiB multi-batch path of the
+// all-fixed-width general conversion. Disabled by default because it needs roughly 8.5 GB of free
+// GPU memory; enable manually with --gtest_also_run_disabled_tests.
+//
+// 300 INT32 columns give a JCUDF row of 300*4 data + ceil(300/8) validity = 1238 bytes, padded to
+// 1240. 2,500,000 rows * 1240 = 3.1 GB of row data, which exceeds the 2 GiB batch limit and must
+// split into exactly two batches: the first holds floor(INT32_MAX / 1240) rows rounded down to a
+// 32-row multiple (1,731,840), the second holds the remaining 768,160 rows (~0.95 GB).
+TEST_F(ColumnToRowTests, DISABLED_MultiBatchFixedWidthRoundTrip)
+{
+  constexpr int num_cols             = 300;
+  constexpr cudf::size_type num_rows = 2'500'000;
+
+  auto data_iter = spark_rapids_jni::util::make_counting_transform_iterator(
+    0, [](auto i) -> int32_t { return static_cast<int32_t>(i * 2654435761u); });
+
+  std::vector<cudf::test::fixed_width_column_wrapper<int32_t>> cols;
+  cols.reserve(num_cols);
+  std::vector<cudf::column_view> views;
+  views.reserve(num_cols);
+  std::vector<cudf::data_type> schema;
+  schema.reserve(num_cols);
+  for (int c = 0; c < num_cols; ++c) {
+    cols.emplace_back(data_iter + c * num_rows, data_iter + c * num_rows + num_rows);
+    views.emplace_back(cols.back());
+    schema.push_back(cudf::data_type{cudf::type_id::INT32});
+  }
+  cudf::table_view in(views);
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 2u) << "Expected exactly two batches; if the split changed, revisit "
+                                "num_cols/num_rows so the row data still exceeds 2 GiB.";
+
+  std::size_t row_start = 0;
+  for (auto& batch : rows) {
+    auto result   = spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*batch), schema);
+    auto in_slice = cudf::slice(in,
+                                {static_cast<cudf::size_type>(row_start),
+                                 static_cast<cudf::size_type>(row_start + result->num_rows())})[0];
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in_slice, *result);
+    row_start += result->num_rows();
+  }
+  EXPECT_EQ(row_start, static_cast<std::size_t>(num_rows));
 }
 
 TEST_F(RowToColumnTests, Single)
@@ -1299,4 +1356,1078 @@ TEST_F(RowToColumnTests, ManyStrings)
     auto in_view = cudf::slice(in, {0, new_cols->num_rows()});
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in_view[0], *new_cols);
   }
+}
+
+// =================================================================================================
+// Test-hardening suite: pins the JCUDF byte format and locks every kernel path so that a kernel
+// change breaking either is caught by this gtest target alone (round trips are symmetric and
+// would miss a format shift that both directions share).
+//
+// JCUDF row layout: [fixed region][validity][string chars][pad to 8 bytes].
+//   - fixed region: columns packed in schema order, each at an offset aligned to its own element
+//     size; a string column occupies an 8-byte slot of two uint32 values (offset, length) with
+//     4-byte alignment, where `offset` is relative to the row start.
+//   - validity: ceil(num_columns/8) bytes directly after the fixed region (byte-aligned); bit c%8
+//     of byte c/8 is 1 when column c is valid.
+//   - string chars: packed unaligned immediately after the validity bytes.
+//   - the row buffer is uninitialized and the kernels never write alignment holes, the tail pad
+//     up to the 8-byte row stride, or validity bits past the last column, so byte-exact compares
+//     must mask those ranges; a null cell's data bytes are masked too, since only its validity
+//     bit is contractual.
+// =================================================================================================
+
+namespace {
+
+// Byte-wise masked compare of a JCUDF row buffer (the INT8 child of a rows column) against a
+// hand-built expected buffer. A zero mask bit marks a byte/bit the kernels leave undefined.
+void expect_masked_bytes_equal(cudf::column_view const& rows_child,
+                               std::vector<uint8_t> const& expected,
+                               std::vector<uint8_t> const& mask)
+{
+  auto const actual = cudf::test::to_host<int8_t>(rows_child).first;
+  ASSERT_EQ(actual.size(), expected.size());
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    if (mask[i] == 0) { continue; }
+    EXPECT_EQ(static_cast<uint8_t>(actual[i]) & mask[i], expected[i] & mask[i]) << "byte " << i;
+  }
+}
+
+std::vector<int32_t> row_offsets_to_host(cudf::column const& rows_column)
+{
+  auto const host =
+    cudf::test::to_host<int32_t>(cudf::lists_column_view(rows_column).offsets()).first;
+  return {host.begin(), host.end()};
+}
+
+// General-path round trip; also checks per-column null counts, which catches a validity kernel
+// writing a plausible-but-wrong mask that the table compare on its own would only see as data.
+void expect_general_round_trip(cudf::table_view const& in,
+                               std::vector<cudf::data_type> const& schema)
+{
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto result = spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*rows[0]), schema);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+  for (cudf::size_type c = 0; c < in.num_columns(); ++c) {
+    EXPECT_EQ(result->get_column(c).null_count(), in.column(c).null_count()) << "column " << c;
+  }
+}
+
+void expect_fixed_width_optimized_round_trip(cudf::table_view const& in,
+                                             std::vector<cudf::data_type> const& schema)
+{
+  auto rows = spark_rapids_jni::convert_to_rows_fixed_width_optimized(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto result = spark_rapids_jni::convert_from_rows_fixed_width_optimized(
+    cudf::lists_column_view(*rows[0]), schema);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+  for (cudf::size_type c = 0; c < in.num_columns(); ++c) {
+    EXPECT_EQ(result->get_column(c).null_count(), in.column(c).null_count()) << "column " << c;
+  }
+}
+
+template <typename ElementT, typename SourceT = ElementT>
+std::unique_ptr<cudf::column> make_typed_column(std::vector<int64_t> const& values,
+                                                std::vector<bool> const& validity,
+                                                bool nullable)
+{
+  if (nullable) {
+    return cudf::test::fixed_width_column_wrapper<ElementT, SourceT>(
+             values.begin(), values.end(), validity.begin())
+      .release();
+  }
+  return cudf::test::fixed_width_column_wrapper<ElementT, SourceT>(values.begin(), values.end())
+    .release();
+}
+
+template <typename RepT>
+std::unique_ptr<cudf::column> make_decimal_column(std::vector<int64_t> const& values,
+                                                  std::vector<bool> const& validity,
+                                                  bool nullable,
+                                                  int32_t scale)
+{
+  if (nullable) {
+    return cudf::test::fixed_point_column_wrapper<RepT>(
+             values.begin(), values.end(), validity.begin(), numeric::scale_type{scale})
+      .release();
+  }
+  return cudf::test::fixed_point_column_wrapper<RepT>(
+           values.begin(), values.end(), numeric::scale_type{scale})
+    .release();
+}
+
+// Deterministic column of `type`: null_fraction 0 allocates no null mask (the absent-mask kernel
+// branch), 1.0 yields an all-null column, anything between draws per-row validity.
+std::unique_ptr<cudf::column> make_random_column(cudf::data_type type,
+                                                 cudf::size_type num_rows,
+                                                 double null_fraction,
+                                                 std::mt19937& engine)
+{
+  std::uniform_int_distribution<int64_t> value_dist(std::numeric_limits<int64_t>::min(),
+                                                    std::numeric_limits<int64_t>::max());
+  std::vector<int64_t> values(num_rows);
+  std::generate(values.begin(), values.end(), [&] { return value_dist(engine); });
+  bool const nullable = null_fraction > 0.0;
+  std::bernoulli_distribution null_dist(null_fraction);
+  std::vector<bool> validity(num_rows);
+  std::generate(validity.begin(), validity.end(), [&] { return !null_dist(engine); });
+
+  using cudf::type_id;
+  switch (type.id()) {
+    case type_id::INT8: return make_typed_column<int8_t>(values, validity, nullable);
+    case type_id::INT16: return make_typed_column<int16_t>(values, validity, nullable);
+    case type_id::INT32: return make_typed_column<int32_t>(values, validity, nullable);
+    case type_id::INT64: return make_typed_column<int64_t>(values, validity, nullable);
+    case type_id::UINT8: return make_typed_column<uint8_t>(values, validity, nullable);
+    case type_id::UINT16: return make_typed_column<uint16_t>(values, validity, nullable);
+    case type_id::UINT32: return make_typed_column<uint32_t>(values, validity, nullable);
+    case type_id::UINT64: return make_typed_column<uint64_t>(values, validity, nullable);
+    case type_id::FLOAT32: return make_typed_column<float>(values, validity, nullable);
+    case type_id::FLOAT64: return make_typed_column<double>(values, validity, nullable);
+    case type_id::BOOL8: return make_typed_column<bool>(values, validity, nullable);
+    case type_id::DECIMAL32:
+      return make_decimal_column<int32_t>(values, validity, nullable, type.scale());
+    case type_id::DECIMAL64:
+      return make_decimal_column<int64_t>(values, validity, nullable, type.scale());
+    case type_id::DECIMAL128:
+      return make_decimal_column<__int128_t>(values, validity, nullable, type.scale());
+    case type_id::TIMESTAMP_DAYS:
+      return make_typed_column<cudf::timestamp_D, cudf::timestamp_D::rep>(
+        values, validity, nullable);
+    case type_id::TIMESTAMP_SECONDS:
+      return make_typed_column<cudf::timestamp_s, cudf::timestamp_s::rep>(
+        values, validity, nullable);
+    case type_id::TIMESTAMP_MILLISECONDS:
+      return make_typed_column<cudf::timestamp_ms, cudf::timestamp_ms::rep>(
+        values, validity, nullable);
+    case type_id::TIMESTAMP_MICROSECONDS:
+      return make_typed_column<cudf::timestamp_us, cudf::timestamp_us::rep>(
+        values, validity, nullable);
+    case type_id::TIMESTAMP_NANOSECONDS:
+      return make_typed_column<cudf::timestamp_ns, cudf::timestamp_ns::rep>(
+        values, validity, nullable);
+    case type_id::DURATION_DAYS:
+      return make_typed_column<cudf::duration_D, cudf::duration_D::rep>(values, validity, nullable);
+    case type_id::DURATION_SECONDS:
+      return make_typed_column<cudf::duration_s, cudf::duration_s::rep>(values, validity, nullable);
+    case type_id::DURATION_MILLISECONDS:
+      return make_typed_column<cudf::duration_ms, cudf::duration_ms::rep>(
+        values, validity, nullable);
+    case type_id::DURATION_MICROSECONDS:
+      return make_typed_column<cudf::duration_us, cudf::duration_us::rep>(
+        values, validity, nullable);
+    case type_id::DURATION_NANOSECONDS:
+      return make_typed_column<cudf::duration_ns, cudf::duration_ns::rep>(
+        values, validity, nullable);
+    case type_id::STRING: {
+      std::uniform_int_distribution<int> len_dist(0, 32);
+      std::uniform_int_distribution<int> char_dist('a', 'z');
+      std::vector<std::string> strings(num_rows);
+      for (auto& s : strings) {
+        s.resize(len_dist(engine));
+        for (auto& ch : s) {
+          ch = static_cast<char>(char_dist(engine));
+        }
+      }
+      if (nullable) {
+        return cudf::test::strings_column_wrapper(strings.begin(), strings.end(), validity.begin())
+          .release();
+      }
+      return cudf::test::strings_column_wrapper(strings.begin(), strings.end()).release();
+    }
+    default: CUDF_FAIL("unsupported type id in row-conversion test data factory");
+  }
+}
+
+struct owning_table {
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  std::vector<cudf::column_view> views;
+  cudf::table_view view() const { return cudf::table_view(views); }
+};
+
+owning_table make_random_table(std::vector<cudf::data_type> const& schema,
+                               cudf::size_type num_rows,
+                               double null_fraction,
+                               std::mt19937& engine)
+{
+  owning_table t;
+  for (auto const& type : schema) {
+    t.columns.push_back(make_random_column(type, num_rows, null_fraction, engine));
+    t.views.push_back(t.columns.back()->view());
+  }
+  return t;
+}
+
+// Every fixed-width type id the row conversion supports (decimal entries carry their scale so the
+// same vector serves as the convert_from_rows schema).
+std::vector<cudf::data_type> const& all_supported_fixed_width_types()
+{
+  static std::vector<cudf::data_type> const types{
+    cudf::data_type{cudf::type_id::INT8},
+    cudf::data_type{cudf::type_id::INT16},
+    cudf::data_type{cudf::type_id::INT32},
+    cudf::data_type{cudf::type_id::INT64},
+    cudf::data_type{cudf::type_id::UINT8},
+    cudf::data_type{cudf::type_id::UINT16},
+    cudf::data_type{cudf::type_id::UINT32},
+    cudf::data_type{cudf::type_id::UINT64},
+    cudf::data_type{cudf::type_id::FLOAT32},
+    cudf::data_type{cudf::type_id::FLOAT64},
+    cudf::data_type{cudf::type_id::BOOL8},
+    cudf::data_type{cudf::type_id::DECIMAL32, -2},
+    cudf::data_type{cudf::type_id::DECIMAL64, -4},
+    cudf::data_type{cudf::type_id::DECIMAL128, -6},
+    cudf::data_type{cudf::type_id::TIMESTAMP_DAYS},
+    cudf::data_type{cudf::type_id::TIMESTAMP_SECONDS},
+    cudf::data_type{cudf::type_id::TIMESTAMP_MILLISECONDS},
+    cudf::data_type{cudf::type_id::TIMESTAMP_MICROSECONDS},
+    cudf::data_type{cudf::type_id::TIMESTAMP_NANOSECONDS},
+    cudf::data_type{cudf::type_id::DURATION_DAYS},
+    cudf::data_type{cudf::type_id::DURATION_SECONDS},
+    cudf::data_type{cudf::type_id::DURATION_MILLISECONDS},
+    cudf::data_type{cudf::type_id::DURATION_MICROSECONDS},
+    cudf::data_type{cudf::type_id::DURATION_NANOSECONDS}};
+  return types;
+}
+
+}  // anonymous namespace
+
+// -- Golden-bytes format pinning ------------------------------------------------------------
+//
+// Schema INT64,INT32,INT16,INT8 packs hole-free at size-aligned offsets:
+//   col0 INT64 @ 0..7, col1 INT32 @ 8..11, col2 INT16 @ 12..13, col3 INT8 @ 14,
+//   validity byte @ 15 (bit c = column c valid), row size 16 = stride (zero tail pad).
+// Bits 4..7 of the validity byte cover no column and are masked as undefined.
+TEST_F(ColumnToRowTests, GoldenBytesFixedWidthLayout)
+{
+  constexpr cudf::size_type num_rows = 5;
+  constexpr std::size_t row_stride   = 16;
+
+  std::array<int64_t, num_rows> const c0{
+    0x0102030405060708LL, -1, 0x1122334455667788LL, 42, -9'000'000'000LL};
+  std::array<int32_t, num_rows> const c1{0x0A0B0C0D, -2, 7, std::numeric_limits<int32_t>::max(), 0};
+  std::array<int16_t, num_rows> const c2{
+    0x0102, -3, 300, std::numeric_limits<int16_t>::min(), 32767};
+  std::array<int8_t, num_rows> const c3{0x7F, -128, 5, -1, 0};
+  // One null per column, each in a different row; row 4 is fully valid.
+  std::array<std::array<bool, num_rows>, 4> const valid{{{true, true, false, true, true},
+                                                         {true, false, true, true, true},
+                                                         {false, true, true, true, true},
+                                                         {true, true, true, false, true}}};
+
+  cudf::test::fixed_width_column_wrapper<int64_t> w0(c0.begin(), c0.end(), valid[0].begin());
+  cudf::test::fixed_width_column_wrapper<int32_t> w1(c1.begin(), c1.end(), valid[1].begin());
+  cudf::test::fixed_width_column_wrapper<int16_t> w2(c2.begin(), c2.end(), valid[2].begin());
+  cudf::test::fixed_width_column_wrapper<int8_t> w3(c3.begin(), c3.end(), valid[3].begin());
+  cudf::table_view in({w0, w1, w2, w3});
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto const lists = cudf::lists_column_view(*rows[0]);
+  ASSERT_EQ(static_cast<std::size_t>(lists.child().size()), row_stride * num_rows);
+
+  auto const offsets = row_offsets_to_host(*rows[0]);
+  ASSERT_EQ(offsets.size(), static_cast<std::size_t>(num_rows) + 1);
+  for (cudf::size_type r = 0; r <= num_rows; ++r) {
+    EXPECT_EQ(offsets[r], static_cast<int32_t>(r * row_stride)) << "row " << r;
+  }
+
+  std::vector<uint8_t> expected(row_stride * num_rows, 0);
+  std::vector<uint8_t> mask(row_stride * num_rows, 0xFF);
+  // Bit c of the validity byte follows valid[c][row]: rows 0..3 each null one column, row 4 none.
+  std::array<uint8_t, num_rows> const validity_bytes{0x0B, 0x0D, 0x0E, 0x07, 0x0F};
+  auto put = [&](cudf::size_type row, std::size_t offset, auto value, bool is_valid) {
+    std::memcpy(expected.data() + row * row_stride + offset, &value, sizeof(value));
+    if (!is_valid) {
+      std::fill_n(mask.begin() + row * row_stride + offset, sizeof(value), uint8_t{0});
+    }
+  };
+  for (cudf::size_type r = 0; r < num_rows; ++r) {
+    put(r, 0, c0[r], valid[0][r]);
+    put(r, 8, c1[r], valid[1][r]);
+    put(r, 12, c2[r], valid[2][r]);
+    put(r, 14, c3[r], valid[3][r]);
+    expected[r * row_stride + 15] = validity_bytes[r];
+    mask[r * row_stride + 15]     = 0x0F;
+  }
+  expect_masked_bytes_equal(lists.child(), expected, mask);
+
+  // The same bytes must reconstruct the source table.
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::INT64},
+                                      cudf::data_type{cudf::type_id::INT32},
+                                      cudf::data_type{cudf::type_id::INT16},
+                                      cudf::data_type{cudf::type_id::INT8}};
+  auto result = spark_rapids_jni::convert_from_rows(lists, schema);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+}
+
+// Schema STRING,INT32,STRING pins the variable-width layout:
+//   (offset,length) pair0 @ 0..7, INT32 @ 8..11, pair1 @ 12..19, validity byte @ 20 (bits 0..2),
+//   chars @ 21..., row size = round_up(21 + chars, 8); the pair offsets are row-relative.
+// Rows (all strings valid; the INT32 is null in row 1):
+//   ("AB", 0x01020304, "xyz")        chars "ABxyz"        pairs (21,2),(23,3)  size 26 -> 32
+//   ("", null, "Q")                  chars "Q"            pairs (21,0),(21,1)  size 22 -> 24
+//   ("hello", 0x7FFFFFFF, "")        chars "hello"        pairs (21,5),(26,0)  size 26 -> 32
+//   ("0123456789", -2, "wp")         chars "0123456789wp" pairs (21,10),(31,2) size 33 -> 40
+// giving the offsets column {0, 32, 56, 88, 128}.
+TEST_F(ColumnToRowTests, GoldenBytesStringLayout)
+{
+  std::vector<std::string> const s0{"AB", "", "hello", "0123456789"};
+  std::vector<int32_t> const ints{0x01020304, -999, std::numeric_limits<int32_t>::max(), -2};
+  std::vector<bool> const int_valid{true, false, true, true};
+  std::vector<std::string> const s1{"xyz", "Q", "", "wp"};
+
+  cudf::test::strings_column_wrapper w0(s0.begin(), s0.end());
+  cudf::test::fixed_width_column_wrapper<int32_t> w1(ints.begin(), ints.end(), int_valid.begin());
+  cudf::test::strings_column_wrapper w2(s1.begin(), s1.end());
+  cudf::table_view in({w0, w1, w2});
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto const lists = cudf::lists_column_view(*rows[0]);
+
+  std::vector<int32_t> const expected_offsets{0, 32, 56, 88, 128};
+  auto const offsets = row_offsets_to_host(*rows[0]);
+  ASSERT_EQ(offsets.size(), expected_offsets.size());
+  for (std::size_t r = 0; r < expected_offsets.size(); ++r) {
+    EXPECT_EQ(offsets[r], expected_offsets[r]) << "row " << r;
+  }
+  ASSERT_EQ(lists.child().size(), expected_offsets.back());
+
+  constexpr std::size_t fixed_and_validity = 21;  // 20 bytes of fixed data + 1 validity byte
+  std::vector<uint8_t> expected(expected_offsets.back(), 0);
+  std::vector<uint8_t> mask(expected_offsets.back(), 0);  // rows have tail pad: opt-in to defined
+  std::array<uint8_t, 4> const validity_bytes{0x07, 0x05, 0x07, 0x07};
+  for (std::size_t r = 0; r < s0.size(); ++r) {
+    std::size_t const base = static_cast<std::size_t>(expected_offsets[r]);
+    auto put_u32           = [&](std::size_t offset, uint32_t value) {
+      std::memcpy(expected.data() + base + offset, &value, sizeof(value));
+      std::fill_n(mask.begin() + base + offset, sizeof(value), uint8_t{0xFF});
+    };
+    auto const len0 = static_cast<uint32_t>(s0[r].size());
+    auto const len1 = static_cast<uint32_t>(s1[r].size());
+    put_u32(0, fixed_and_validity);
+    put_u32(4, len0);
+    put_u32(8, static_cast<uint32_t>(ints[r]));
+    put_u32(12, fixed_and_validity + len0);
+    put_u32(16, len1);
+    if (!int_valid[r]) { std::fill_n(mask.begin() + base + 8, 4, uint8_t{0}); }
+    expected[base + 20] = validity_bytes[r];
+    mask[base + 20]     = 0x07;
+    std::memcpy(expected.data() + base + fixed_and_validity, s0[r].data(), len0);
+    std::memcpy(expected.data() + base + fixed_and_validity + len0, s1[r].data(), len1);
+    std::fill_n(mask.begin() + base + fixed_and_validity, len0 + len1, uint8_t{0xFF});
+  }
+  expect_masked_bytes_equal(lists.child(), expected, mask);
+
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::STRING},
+                                      cudf::data_type{cudf::type_id::INT32},
+                                      cudf::data_type{cudf::type_id::STRING}};
+  auto result = spark_rapids_jni::convert_from_rows(lists, schema);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+}
+
+// DECIMAL128 elements are 16 bytes and dominate alignment. Schema DECIMAL128,INT32,DECIMAL128,
+// INT8 packs as: dec @ 0..15, INT32 @ 16..19, 12-byte alignment hole @ 20..31 (masked), dec @
+// 32..47, INT8 @ 48, validity byte @ 49 (bits 0..3), row size 50 -> stride 56 (pad masked).
+TEST_F(ColumnToRowTests, GoldenBytesDecimal128Layout)
+{
+  constexpr cudf::size_type num_rows = 3;
+  constexpr std::size_t row_stride   = 56;
+
+  auto const wide = (static_cast<__int128_t>(0x0102030405060708LL) << 64) |
+                    static_cast<__int128_t>(0x090A0B0C0D0E0F10LL);
+  std::array<__int128_t, num_rows> const d0{
+    wide, static_cast<__int128_t>(-1), static_cast<__int128_t>(7)};
+  std::array<__int128_t, num_rows> const d1{
+    static_cast<__int128_t>(-3), wide, static_cast<__int128_t>(0)};
+  std::array<int32_t, num_rows> const iv{11, 22, 33};
+  std::array<int8_t, num_rows> const bv{1, -2, 3};
+  std::array<bool, num_rows> const d0_valid{true, false, true};
+  std::array<bool, num_rows> const iv_valid{true, true, false};
+
+  cudf::test::fixed_point_column_wrapper<__int128_t> w0(
+    d0.begin(), d0.end(), d0_valid.begin(), numeric::scale_type{-3});
+  cudf::test::fixed_width_column_wrapper<int32_t> w1(iv.begin(), iv.end(), iv_valid.begin());
+  cudf::test::fixed_point_column_wrapper<__int128_t> w2(
+    d1.begin(), d1.end(), numeric::scale_type{-3});
+  cudf::test::fixed_width_column_wrapper<int8_t> w3(bv.begin(), bv.end());
+  cudf::table_view in({w0, w1, w2, w3});
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto const lists = cudf::lists_column_view(*rows[0]);
+  ASSERT_EQ(static_cast<std::size_t>(lists.child().size()), row_stride * num_rows);
+
+  std::vector<uint8_t> expected(row_stride * num_rows, 0);
+  std::vector<uint8_t> mask(row_stride * num_rows, 0);
+  // Columns 2 and 3 carry no null mask, so their bits are always set.
+  std::array<uint8_t, num_rows> const validity_bytes{0x0F, 0x0E, 0x0D};
+  for (cudf::size_type r = 0; r < num_rows; ++r) {
+    std::size_t const base = r * row_stride;
+    auto put               = [&](std::size_t offset, auto value, bool is_valid) {
+      std::memcpy(expected.data() + base + offset, &value, sizeof(value));
+      std::fill_n(
+        mask.begin() + base + offset, sizeof(value), is_valid ? uint8_t{0xFF} : uint8_t{0});
+    };
+    put(0, d0[r], d0_valid[r]);
+    put(16, iv[r], iv_valid[r]);
+    put(32, d1[r], true);
+    put(48, bv[r], true);
+    expected[base + 49] = validity_bytes[r];
+    mask[base + 49]     = 0x0F;
+  }
+  expect_masked_bytes_equal(lists.child(), expected, mask);
+
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::DECIMAL128, -3},
+                                      cudf::data_type{cudf::type_id::INT32},
+                                      cudf::data_type{cudf::type_id::DECIMAL128, -3},
+                                      cudf::data_type{cudf::type_id::INT8}};
+  auto result = spark_rapids_jni::convert_from_rows(lists, schema);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+}
+
+// -- Path-equivalence invariant -------------------------------------------------------------
+//
+// The general and fixed-width-optimized paths must emit byte-identical rows for any all-fixed
+// table. The 16-column schema (12 INT32 @ 0..47, INT16 @ 48, INT16 @ 50, INT8 @ 52, INT8 @ 53,
+// validity @ 54..55, stride 56) is hole-free with zero tail pad and exactly 16 validity bits, so
+// every output byte is defined and the buffers must match exactly.
+TEST_F(ColumnToRowTests, PathEquivalenceFixedWidthBytes)
+{
+  std::vector<cudf::data_type> schema;
+  for (int c = 0; c < 12; ++c) {
+    schema.push_back(cudf::data_type{cudf::type_id::INT32});
+  }
+  schema.push_back(cudf::data_type{cudf::type_id::INT16});
+  schema.push_back(cudf::data_type{cudf::type_id::INT16});
+  schema.push_back(cudf::data_type{cudf::type_id::INT8});
+  schema.push_back(cudf::data_type{cudf::type_id::INT8});
+
+  for (cudf::size_type num_rows : {1, 100}) {
+    std::mt19937 engine(7013 + num_rows);
+    auto const table = make_random_table(schema, num_rows, 0.3, engine);
+    auto const in    = table.view();
+
+    auto general_rows   = spark_rapids_jni::convert_to_rows(in);
+    auto optimized_rows = spark_rapids_jni::convert_to_rows_fixed_width_optimized(in);
+    ASSERT_EQ(general_rows.size(), 1u);
+    ASSERT_EQ(optimized_rows.size(), 1u);
+
+    auto const general =
+      cudf::test::to_host<int8_t>(cudf::lists_column_view(*general_rows[0]).child()).first;
+    auto const optimized =
+      cudf::test::to_host<int8_t>(cudf::lists_column_view(*optimized_rows[0]).child()).first;
+    ASSERT_EQ(general.size(), static_cast<std::size_t>(56) * num_rows);
+    ASSERT_EQ(general.size(), optimized.size());
+    EXPECT_EQ(0, std::memcmp(general.data(), optimized.data(), general.size()));
+
+    auto const general_offsets   = row_offsets_to_host(*general_rows[0]);
+    auto const optimized_offsets = row_offsets_to_host(*optimized_rows[0]);
+    ASSERT_EQ(general_offsets.size(), optimized_offsets.size());
+    for (std::size_t i = 0; i < general_offsets.size(); ++i) {
+      EXPECT_EQ(general_offsets[i], optimized_offsets[i]) << "offset " << i;
+    }
+
+    // Both from-rows paths must reconstruct the source table.
+    expect_general_round_trip(in, schema);
+    expect_fixed_width_optimized_round_trip(in, schema);
+  }
+}
+
+// -- Tile-boundary shapes -----------------------------------------------------------------------
+//
+// determine_tiles closes a column band once round_up(width, 8) bytes times the 32-row tile height
+// exceeds the ~48 KB shared-memory budget (49136 bytes): 191 INT64 columns (1528 B) still fit one
+// band, 192 (1536 B) and 193 (1544 B) split into two, and 400 (3200 B) need three.
+TEST_F(ColumnToRowTests, TileBandEdgeColumnWidths)
+{
+  constexpr cudf::size_type num_rows = 97;
+  for (int num_cols : {191, 192, 193, 320, 400}) {
+    std::vector<cudf::data_type> const schema(num_cols, cudf::data_type{cudf::type_id::INT64});
+    for (double null_fraction : {0.0, 0.1}) {
+      std::mt19937 engine(3100 + num_cols);
+      auto const table = make_random_table(schema, num_rows, null_fraction, engine);
+      expect_general_round_trip(table.view(), schema);
+    }
+  }
+}
+
+// Row counts around the 32-row tile height and the 64-row edges on a wide mixed schema
+// (256 columns, 32-byte type cycle => 1024-byte fixed region in a single tile band).
+TEST_F(ColumnToRowTests, TileBoundaryRowCounts)
+{
+  std::vector<cudf::data_type> const cycle{cudf::data_type{cudf::type_id::INT64},
+                                           cudf::data_type{cudf::type_id::INT32},
+                                           cudf::data_type{cudf::type_id::INT16},
+                                           cudf::data_type{cudf::type_id::INT8},
+                                           cudf::data_type{cudf::type_id::FLOAT64},
+                                           cudf::data_type{cudf::type_id::FLOAT32},
+                                           cudf::data_type{cudf::type_id::BOOL8},
+                                           cudf::data_type{cudf::type_id::INT16}};
+  std::vector<cudf::data_type> schema;
+  for (int c = 0; c < 256; ++c) {
+    schema.push_back(cycle[c % cycle.size()]);
+  }
+
+  for (cudf::size_type num_rows : {1, 31, 32, 33, 63, 64, 65}) {
+    std::mt19937 engine(9100 + num_rows);
+    auto const table = make_random_table(schema, num_rows, 0.15, engine);
+    expect_general_round_trip(table.view(), schema);
+  }
+}
+
+// -- Fixed-width-optimized path boundaries --------------------------------------------------------
+//
+// The optimized path requires at least 32 rows of shared memory per block, so the padded row size
+// (8N data + ceil(N/8) validity rounded up to 8 for N INT64 columns) is capped at 48*1024/32 =
+// 1536 bytes: N=188 gives 1528, N=189 exactly 1536, and N=190 (1544) must throw in BOTH
+// directions.
+TEST_F(ColumnToRowTests, FixedWidthOptimizedRowSizeBoundaries)
+{
+  constexpr cudf::size_type num_rows = 33;
+  for (int num_cols : {188, 189}) {
+    std::vector<cudf::data_type> const schema(num_cols, cudf::data_type{cudf::type_id::INT64});
+    std::mt19937 engine(5200 + num_cols);
+    auto const table = make_random_table(schema, num_rows, 0.15, engine);
+    expect_fixed_width_optimized_round_trip(table.view(), schema);
+    expect_general_round_trip(table.view(), schema);
+  }
+
+  std::vector<cudf::data_type> const schema(190, cudf::data_type{cudf::type_id::INT64});
+  std::mt19937 engine(5390);
+  auto const table = make_random_table(schema, num_rows, 0.15, engine);
+  EXPECT_THROW(spark_rapids_jni::convert_to_rows_fixed_width_optimized(table.view()),
+               cudf::logic_error);
+
+  // The general path still handles the same table (two tile bands), and its rows are the right
+  // stride for the optimized reader, which must reject them for the same size reason.
+  auto rows = spark_rapids_jni::convert_to_rows(table.view());
+  ASSERT_EQ(rows.size(), 1u);
+  EXPECT_THROW(spark_rapids_jni::convert_from_rows_fixed_width_optimized(
+                 cudf::lists_column_view(*rows[0]), schema),
+               cudf::logic_error);
+  expect_general_round_trip(table.view(), schema);
+}
+
+// Row counts around the optimized kernels' 32-row row-group stride.
+TEST_F(ColumnToRowTests, FixedWidthOptimizedRowCountBoundaries)
+{
+  std::vector<cudf::data_type> const schema{cudf::data_type{cudf::type_id::INT64},
+                                            cudf::data_type{cudf::type_id::INT32},
+                                            cudf::data_type{cudf::type_id::INT16},
+                                            cudf::data_type{cudf::type_id::INT8}};
+  for (cudf::size_type num_rows : {31, 32, 33}) {
+    for (double null_fraction : {0.0, 0.3}) {
+      std::mt19937 engine(5400 + num_rows);
+      auto const table = make_random_table(schema, num_rows, null_fraction, engine);
+      expect_fixed_width_optimized_round_trip(table.view(), schema);
+      expect_general_round_trip(table.view(), schema);
+    }
+  }
+}
+
+// -- Validity boundaries --------------------------------------------------------------------------
+//
+// Column counts {7,8,9} cross the one-validity-byte edge; each null pattern exercises a distinct
+// kernel branch, including the absent-null-mask fast path. The round-trip helper checks
+// per-column null counts after every convert_from_rows.
+TEST_F(RowToColumnTests, ValidityColumnCountBoundaries)
+{
+  constexpr cudf::size_type num_rows = 100;
+  auto data_iter                     = spark_rapids_jni::util::make_counting_transform_iterator(
+    0, [](auto i) -> int32_t { return static_cast<int32_t>(i * 7919 + 13); });
+
+  for (int num_cols : {7, 8, 9}) {
+    // patterns: 0 all-null, 1 none-null with an allocated mask, 2 absent mask, 3 alternating,
+    // 4 sparse ~1%
+    for (int pattern = 0; pattern < 5; ++pattern) {
+      std::vector<cudf::test::fixed_width_column_wrapper<int32_t>> cols;
+      cols.reserve(num_cols);
+      std::vector<cudf::column_view> views;
+      std::vector<cudf::data_type> schema;
+      for (int c = 0; c < num_cols; ++c) {
+        auto const begin = data_iter + c * num_rows;
+        auto const end   = begin + num_rows;
+        switch (pattern) {
+          case 0: {
+            auto v =
+              spark_rapids_jni::util::make_counting_transform_iterator(0, [](auto) { return 0; });
+            cols.emplace_back(begin, end, v);
+            break;
+          }
+          case 1: {
+            auto v =
+              spark_rapids_jni::util::make_counting_transform_iterator(0, [](auto) { return 1; });
+            cols.emplace_back(begin, end, v);
+            break;
+          }
+          case 2: cols.emplace_back(begin, end); break;
+          case 3: {
+            auto v = spark_rapids_jni::util::make_counting_transform_iterator(
+              0, [](auto i) { return i % 2; });
+            cols.emplace_back(begin, end, v);
+            break;
+          }
+          default: {
+            auto v = spark_rapids_jni::util::make_counting_transform_iterator(
+              0, [](auto i) { return i % 97 != 0; });
+            cols.emplace_back(begin, end, v);
+            break;
+          }
+        }
+        views.emplace_back(cols.back());
+        schema.push_back(cudf::data_type{cudf::type_id::INT32});
+      }
+      cudf::table_view in(views);
+      expect_general_round_trip(in, schema);
+    }
+  }
+}
+
+// {215,216,217} sit at the byte-rounded single-column-tile edge (the split threshold is 221),
+// {221,433} force 2- and 3-way column-tile splits at the 216-column stride, and 1500 rows cross
+// the 1472-row tile height — across the set the validity kernels split tiles in both dimensions.
+TEST_F(RowToColumnTests, ValidityWideColumnBoundaries)
+{
+  constexpr cudf::size_type num_rows = 1500;
+  for (int num_cols : {215, 216, 217, 221, 433}) {
+    std::vector<cudf::data_type> const schema(num_cols, cudf::data_type{cudf::type_id::INT8});
+    for (double null_fraction : {0.0, 0.5, 1.0}) {
+      std::mt19937 engine(4200 + num_cols);
+      auto const table = make_random_table(schema, num_rows, null_fraction, engine);
+      expect_general_round_trip(table.view(), schema);
+    }
+  }
+}
+
+// -- String edge cases ----------------------------------------------------------------------------
+
+TEST_F(RowToColumnTests, StringEdgeCases)
+{
+  // String columns in the first and last schema positions; empty strings, an all-empty column,
+  // an all-null column, a null/empty mix, 1-char strings, and ~4 KB strings. The ~4 KB column
+  // pulls the mean string length past the copy-engine switch, so this reaches the string-parallel
+  // from-rows kernel.
+  constexpr cudf::size_type num_rows = 65;
+  std::vector<std::string> first_col(num_rows), one_char(num_rows), big(num_rows),
+    last_col(num_rows), null_empty(num_rows), all_empty(num_rows), all_null(num_rows);
+  std::vector<bool> first_valid(num_rows), null_empty_valid(num_rows);
+  std::vector<bool> const all_null_valid(num_rows, false);
+  std::vector<int32_t> ints(num_rows);
+  std::vector<int64_t> longs(num_rows);
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    first_col[i]        = (i % 7 == 0) ? std::string{} : "row" + std::to_string(i);
+    first_valid[i]      = i % 11 != 0;
+    one_char[i]         = std::string(1, static_cast<char>('a' + i % 26));
+    big[i]              = std::string(4096, static_cast<char>('A' + i % 26));
+    last_col[i]         = "tail_" + std::to_string(i * 31);
+    null_empty_valid[i] = i % 2 == 0;
+    ints[i]             = i * 3 - 1;
+    longs[i]            = static_cast<int64_t>(i) * 1'000'000'007LL;
+  }
+
+  cudf::test::strings_column_wrapper w_first(
+    first_col.begin(), first_col.end(), first_valid.begin());
+  cudf::test::fixed_width_column_wrapper<int32_t> w_int(ints.begin(), ints.end());
+  cudf::test::strings_column_wrapper w_all_empty(all_empty.begin(), all_empty.end());
+  cudf::test::strings_column_wrapper w_null_empty(
+    null_empty.begin(), null_empty.end(), null_empty_valid.begin());
+  cudf::test::fixed_width_column_wrapper<int64_t> w_long(longs.begin(), longs.end());
+  cudf::test::strings_column_wrapper w_one_char(one_char.begin(), one_char.end());
+  cudf::test::strings_column_wrapper w_all_null(
+    all_null.begin(), all_null.end(), all_null_valid.begin());
+  cudf::test::strings_column_wrapper w_big(big.begin(), big.end());
+  cudf::test::strings_column_wrapper w_last(last_col.begin(), last_col.end());
+
+  cudf::table_view in(
+    {w_first, w_int, w_all_empty, w_null_empty, w_long, w_one_char, w_all_null, w_big, w_last});
+  std::vector<cudf::data_type> const schema{cudf::data_type{cudf::type_id::STRING},
+                                            cudf::data_type{cudf::type_id::INT32},
+                                            cudf::data_type{cudf::type_id::STRING},
+                                            cudf::data_type{cudf::type_id::STRING},
+                                            cudf::data_type{cudf::type_id::INT64},
+                                            cudf::data_type{cudf::type_id::STRING},
+                                            cudf::data_type{cudf::type_id::STRING},
+                                            cudf::data_type{cudf::type_id::STRING},
+                                            cudf::data_type{cudf::type_id::STRING}};
+  expect_general_round_trip(in, schema);
+}
+
+// Row counts straddling a from-rows string-copy block boundary (64 = two 32-string blocks).
+TEST_F(RowToColumnTests, StringRowCountBoundaries)
+{
+  std::vector<cudf::data_type> const schema{cudf::data_type{cudf::type_id::STRING},
+                                            cudf::data_type{cudf::type_id::INT32},
+                                            cudf::data_type{cudf::type_id::STRING}};
+  for (cudf::size_type num_rows : {1, 63, 64, 65}) {
+    std::mt19937 engine(6400 + num_rows);
+    auto const table = make_random_table(schema, num_rows, 0.2, engine);
+    expect_general_round_trip(table.view(), schema);
+  }
+}
+
+// Eight string columns interleaved with eight fixed-width columns.
+TEST_F(RowToColumnTests, StringManyColumnsInterleaved)
+{
+  std::vector<cudf::data_type> schema;
+  for (int c = 0; c < 8; ++c) {
+    schema.push_back(cudf::data_type{cudf::type_id::STRING});
+    schema.push_back(cudf::data_type{cudf::type_id::INT32});
+  }
+  constexpr cudf::size_type num_rows = 64;
+  std::mt19937 engine(6800);
+  auto const table = make_random_table(schema, num_rows, 0.25, engine);
+  expect_general_round_trip(table.view(), schema);
+}
+
+// -- Full fixed-width type sweep ------------------------------------------------------------------
+
+// Every supported fixed-width type id as a homogeneous 3-column table, with and without nulls,
+// through BOTH the general and the fixed-width-optimized paths (the optimized kernels hit their
+// wider-than-8-byte fallback branch for DECIMAL128).
+TEST_F(RowToColumnTests, TypeSweepHomogeneous)
+{
+  constexpr cudf::size_type num_rows = 67;
+  for (auto const& type : all_supported_fixed_width_types()) {
+    std::vector<cudf::data_type> const schema(3, type);
+    for (double null_fraction : {0.0, 0.35}) {
+      std::mt19937 engine(1000 + static_cast<int>(type.id()));
+      auto const table = make_random_table(schema, num_rows, null_fraction, engine);
+      expect_general_round_trip(table.view(), schema);
+      expect_fixed_width_optimized_round_trip(table.view(), schema);
+    }
+  }
+}
+
+// All supported fixed-width types together in one mixed schema.
+TEST_F(RowToColumnTests, TypeSweepMixedSchema)
+{
+  auto const& schema                 = all_supported_fixed_width_types();
+  constexpr cudf::size_type num_rows = 129;
+  for (double null_fraction : {0.0, 0.3}) {
+    std::mt19937 engine(2026);
+    auto const table = make_random_table(schema, num_rows, null_fraction, engine);
+    expect_general_round_trip(table.view(), schema);
+    expect_fixed_width_optimized_round_trip(table.view(), schema);
+  }
+}
+
+// Multi-band structural coverage. Replaying the tiler over this 9-type cycle: 320 columns force a
+// 2-band split and 640 force 3, with band 0 ending at 1521 B -- a boundary that is NOT 8-aligned,
+// which is the shape spark-rapids-jni#4590 corrupted. `TileBoundaryWideInt32RoundTrip` cannot reach
+// that shape at all: every column there is INT32, so its band boundaries land on multiples of 8 by
+// construction.
+//
+// These do NOT gate that defect, and mutation testing says no fixed-width round trip can. Restoring
+// the padded row width leaves all of them green, because a band closes at the first column that
+// raises the PADDED row size, which forces the next band to begin at exactly that rounded offset.
+// The over-long write therefore stops where the next band starts, and its stray bytes land in JCUDF
+// alignment padding that a round trip never reads. Keep these as multi-band coverage; they are not
+// a guard on the un-padded write.
+
+namespace {
+
+// A column of the benchmark's `default_cycle` type at `position`, so the schema reproduces the byte
+// offsets the tiler sees. Without nulls the column carries NO null mask, which is the `nulls=none`
+// branch the crash was reported on and a different code path from an all-true mask.
+template <typename T, typename DataIter, typename ValidIter>
+cudf::column make_cycle_column(DataIter data,
+                               cudf::size_type num_rows,
+                               bool with_nulls,
+                               ValidIter valid)
+{
+  // Move out of the owning pointer: dereferencing a raw pointer here would both leak the column
+  // and deep-copy its device buffers into the return value.
+  auto col = with_nulls
+               ? cudf::test::fixed_width_column_wrapper<T>(data, data + num_rows, valid).release()
+               : cudf::test::fixed_width_column_wrapper<T>(data, data + num_rows).release();
+  return std::move(*col);
+}
+
+void multi_band_round_trip(int num_columns, cudf::size_type num_rows, bool with_nulls)
+{
+  std::vector<cudf::column> cols;
+  std::vector<cudf::data_type> schema;
+  cols.reserve(num_columns);
+  schema.reserve(num_columns);
+
+  auto valid =
+    spark_rapids_jni::util::make_counting_transform_iterator(0, [](auto i) { return i % 7 != 0; });
+
+  for (int c = 0; c < num_columns; ++c) {
+    auto data = spark_rapids_jni::util::make_counting_transform_iterator(
+      c * num_rows, [](auto i) -> int64_t { return static_cast<int64_t>(i * 2654435761u); });
+    auto add = [&](auto tag, cudf::type_id id) {
+      cols.push_back(make_cycle_column<decltype(tag)>(data, num_rows, with_nulls, valid));
+      schema.push_back(cudf::data_type{id});
+    };
+    switch (c % 9) {
+      case 0: add(int8_t{}, cudf::type_id::INT8); break;
+      case 1: add(int32_t{}, cudf::type_id::INT32); break;
+      case 2: add(int16_t{}, cudf::type_id::INT16); break;
+      case 3: add(int64_t{}, cudf::type_id::INT64); break;
+      case 4: add(int32_t{}, cudf::type_id::INT32); break;
+      case 5: add(bool{}, cudf::type_id::BOOL8); break;
+      case 6: add(uint16_t{}, cudf::type_id::UINT16); break;
+      case 7: add(uint8_t{}, cudf::type_id::UINT8); break;
+      default: add(uint64_t{}, cudf::type_id::UINT64); break;
+    }
+  }
+
+  std::vector<cudf::column_view> views(cols.begin(), cols.end());
+  cudf::table_view in(views);
+
+  // Repeat, for the same reason TileBoundaryWideInt32RoundTrip does: an overlapping tile write is a
+  // race between adjacent blocks, so a single round trip can pass on a run where the timing happens
+  // not to collide. A misaligned schema without repetition detects nothing reliably.
+  for (int iter = 0; iter < 8; ++iter) {
+    auto rows = spark_rapids_jni::convert_to_rows(in);
+    ASSERT_EQ(rows.size(), 1u);
+    auto result = spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*rows[0]), schema);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+  }
+}
+
+}  // namespace
+
+TEST_F(ColumnToRowTests, MultiBandTileSplitTwoBandsWithNulls)
+{
+  multi_band_round_trip(320, 65, true);
+}
+
+TEST_F(ColumnToRowTests, MultiBandTileSplitThreeBandsWithNulls)
+{
+  multi_band_round_trip(640, 65, true);
+}
+
+// The one band boundary the fixed-width tests above cannot reach: a string or list column occupies
+// 8 bytes but is only 4-byte aligned, while every fixed-width type has alignment == size. That
+// makes it the sole way a band can begin BEFORE the 8-byte rounding of the previous band's end.
+//
+// Replaying the tiler: 381 leading INT32 columns leave band 0 ending at 1524 B, and the string at
+// column 381 starts at 1524 -- four bytes below round_up(1524, 8). The count is exact rather than
+// incidental: 379 and 383 leading columns both close the band 8-aligned.
+//
+// This does NOT gate spark-rapids-jni#4590 either, and mutation testing says nothing here does.
+// Draining the padded width leaves this green too, because `copy_strings_to_rows` launches after
+// `copy_to_rows` on the same stream and rewrites that offset/length pair at exactly the overlapped
+// address. Kept for the coverage: no other test combines a multi-band split with a string on a band
+// edge.
+TEST_F(ColumnToRowTests, StringAtMisalignedBandBoundary)
+{
+  constexpr int leading_int32        = 381;
+  constexpr int trailing_int32       = 20;
+  constexpr cudf::size_type num_rows = 65;
+
+  char const* const test_strings[] = {
+    "", "a", "small", "a considerably longer string value", "medium length"};
+  auto const num_strings = static_cast<int>(std::size(test_strings));
+
+  std::vector<cudf::test::detail::column_wrapper> cols;
+  std::vector<cudf::column_view> views;
+  std::vector<cudf::data_type> schema;
+
+  auto add_int32 = [&](int seed) {
+    auto data = spark_rapids_jni::util::make_counting_transform_iterator(
+      seed * num_rows, [](auto i) -> int32_t { return static_cast<int32_t>(i * 2654435761u); });
+    cols.emplace_back(cudf::test::fixed_width_column_wrapper<int32_t>(data, data + num_rows));
+    views.push_back(cols.back());
+    schema.emplace_back(cudf::data_type{cudf::type_id::INT32});
+  };
+
+  for (int c = 0; c < leading_int32; ++c) {
+    add_int32(c);
+  }
+
+  // Varied lengths so a corrupted offset/length pair changes the decoded value rather than
+  // happening to select an identical string.
+  auto strings = spark_rapids_jni::util::make_counting_transform_iterator(
+    0, [&](auto i) -> char const* { return test_strings[i % num_strings]; });
+  cols.emplace_back(cudf::test::strings_column_wrapper(strings, strings + num_rows));
+  views.push_back(cols.back());
+  schema.emplace_back(cudf::data_type{cudf::type_id::STRING});
+
+  for (int c = 0; c < trailing_int32; ++c) {
+    add_int32(leading_int32 + 1 + c);
+  }
+
+  cudf::table_view in(views);
+
+  // Repeat: an overlapping tile write is a race between adjacent blocks, so one round trip can pass
+  // on a run where the timing happens not to collide.
+  for (int iter = 0; iter < 8; ++iter) {
+    auto rows = spark_rapids_jni::convert_to_rows(in);
+    ASSERT_EQ(rows.size(), 1u);
+    auto result = spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*rows[0]), schema);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+  }
+}
+
+namespace {
+
+// Restores ROWCONV_VALIDATE_ALL_VALID on scope exit, including when a test body throws -- a leaked
+// setting would silently reroute every later test in the binary through the validating path.
+class scoped_validate_all_valid {
+ public:
+  explicit scoped_validate_all_valid(bool enable)
+    : _had(std::getenv("ROWCONV_VALIDATE_ALL_VALID") != nullptr)
+  {
+    if (_had) { _old = std::getenv("ROWCONV_VALIDATE_ALL_VALID"); }
+    setenv("ROWCONV_VALIDATE_ALL_VALID", enable ? "1" : "0", 1);
+  }
+  ~scoped_validate_all_valid()
+  {
+    if (_had) {
+      setenv("ROWCONV_VALIDATE_ALL_VALID", _old.c_str(), 1);
+    } else {
+      unsetenv("ROWCONV_VALIDATE_ALL_VALID");
+    }
+  }
+  scoped_validate_all_valid(scoped_validate_all_valid const&)            = delete;
+  scoped_validate_all_valid& operator=(scoped_validate_all_valid const&) = delete;
+
+ private:
+  bool _had;
+  std::string _old;
+};
+
+// Asserts every column's mask state, which is the ONLY observable that distinguishes the two paths
+// (values are identical by construction on null-free input).
+void expect_nullability(cudf::table_view const& t, bool expected)
+{
+  for (cudf::size_type i = 0; i < t.num_columns(); ++i) {
+    EXPECT_EQ(t.column(i).nullable(), expected) << "column " << i << " nullability";
+    if (!expected) { EXPECT_EQ(t.column(i).null_count(), 0) << "column " << i << " null count"; }
+  }
+}
+
+}  // namespace
+
+// The core contract for the general path: on genuinely null-free input the all-valid overload
+// returns the same VALUES as the incumbent and returns them WITHOUT masks. Both halves are load
+// bearing -- values alone would not show the path engaged, masks alone would not show it stayed
+// correct.
+TEST_F(RowToColumnTests, AllValidGeneralMatchesIncumbent)
+{
+  constexpr int num_rows = 137;  // Not a multiple of 32, so the final validity word is partial.
+
+  auto seq = spark_rapids_jni::util::make_counting_transform_iterator(
+    0, [](auto i) -> int32_t { return static_cast<int32_t>(i * 2654435761u); });
+  cudf::test::fixed_width_column_wrapper<int32_t> c0(seq, seq + num_rows);
+  cudf::test::fixed_width_column_wrapper<int64_t> c1(seq, seq + num_rows);
+  cudf::test::fixed_width_column_wrapper<int8_t> c2(seq, seq + num_rows);
+  cudf::table_view in({c0, c1, c2});
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::INT32},
+                                      cudf::data_type{cudf::type_id::INT64},
+                                      cudf::data_type{cudf::type_id::INT8}};
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto const rows_view = cudf::lists_column_view(*rows[0]);
+
+  auto incumbent = spark_rapids_jni::convert_from_rows(rows_view, schema);
+  auto fast = spark_rapids_jni::convert_from_rows(rows_view, schema, std::vector<bool>(3, false));
+
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *fast);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*incumbent, *fast);
+  expect_nullability(*fast, false);
+  expect_nullability(*incumbent, true);
+}
+
+// Strings take a separate branch: the general path allocates the per-row offset column with
+// `!trust_all_valid`, and the assembled string column takes its mask from a different source than
+// the fixed-width columns do. That branch is the least obviously covered by the two tests above,
+// which is exactly why it gets its own.
+TEST_F(RowToColumnTests, AllValidWithStringsMatchesIncumbent)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> c0({1, 2, 3, 4, 5});
+  cudf::test::strings_column_wrapper c1({"alpha", "", "gamma", "a much longer string value", "d"});
+  cudf::test::fixed_width_column_wrapper<int64_t> c2({10, 20, 30, 40, 50});
+  cudf::table_view in({c0, c1, c2});
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::INT32},
+                                      cudf::data_type{cudf::type_id::STRING},
+                                      cudf::data_type{cudf::type_id::INT64}};
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto const rows_view = cudf::lists_column_view(*rows[0]);
+
+  auto incumbent = spark_rapids_jni::convert_from_rows(rows_view, schema);
+  auto fast = spark_rapids_jni::convert_from_rows(rows_view, schema, std::vector<bool>(3, false));
+
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *fast);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*incumbent, *fast);
+  expect_nullability(*fast, false);
+}
+
+// The fast path is ALL-OR-NOTHING per table: `is_all_valid_profile` is a `none_of`, so one true
+// entry routes the WHOLE call through the incumbent -- the columns declared non-nullable still come
+// back with masks. This is the behaviour that bounds where the optimization applies in production,
+// so it is pinned rather than left to the reader of the predicate.
+TEST_F(RowToColumnTests, AllValidRequiresEveryColumnNonNullable)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> c0({1, 2, 3, 4});
+  cudf::test::fixed_width_column_wrapper<int32_t> c1({5, 6, 7, 8}, {true, false, true, true});
+  cudf::table_view in({c0, c1});
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::INT32},
+                                      cudf::data_type{cudf::type_id::INT32}};
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto const rows_view = cudf::lists_column_view(*rows[0]);
+
+  // Column 0 is genuinely null-free, but column 1 is not: the declaration must disable the fast
+  // path for BOTH, and the null in column 1 must survive.
+  auto result =
+    spark_rapids_jni::convert_from_rows(rows_view, schema, std::vector<bool>{false, true});
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+  expect_nullability(*result, true);
+  EXPECT_EQ(result->get_column(1).null_count(), 1);
+}
+
+// A declaration whose length does not match the schema is caller error, and silently trusting a
+// short vector would read past its end inside `none_of`. Pinned on both entry points because they
+// validate through the same helper and a future refactor could easily drop one.
+TEST_F(RowToColumnTests, AllValidRejectsMismatchedDeclarationSize)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> c0({1, 2, 3});
+  cudf::test::fixed_width_column_wrapper<int32_t> c1({4, 5, 6});
+  cudf::table_view in({c0, c1});
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::INT32},
+                                      cudf::data_type{cudf::type_id::INT32}};
+
+  auto rows     = spark_rapids_jni::convert_to_rows(in);
+  auto rows_opt = spark_rapids_jni::convert_to_rows_fixed_width_optimized(in);
+  ASSERT_EQ(rows.size(), 1u);
+  ASSERT_EQ(rows_opt.size(), 1u);
+
+  for (auto const& bad : {std::vector<bool>{false}, std::vector<bool>{false, false, false}}) {
+    EXPECT_THROW(
+      spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*rows[0]), schema, bad),
+      cudf::logic_error);
+    EXPECT_THROW(spark_rapids_jni::convert_from_rows_fixed_width_optimized(
+                   cudf::lists_column_view(*rows_opt[0]), schema, bad),
+                 cudf::logic_error);
+  }
+}
+
+// A false all-valid declaration corrupts silently by design -- the row bytes are read unchanged and
+// their validity bytes are simply never consulted, so nulls come back as whatever the underlying
+// storage happened to hold. ROWCONV_VALIDATE_ALL_VALID=1 is the debug net for that, and a net that
+// is never tested is not a net. The corrupt output itself is NOT asserted on: the values in a null
+// slot are unspecified, so any expectation about them would be testing an accident.
+TEST_F(RowToColumnTests, AllValidValidatorRejectsFalseDeclaration)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> c0({1, 2, 3, 4}, {true, true, false, true});
+  cudf::table_view in({c0});
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::INT32}};
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto const rows_view = cudf::lists_column_view(*rows[0]);
+
+  scoped_validate_all_valid guard(true);
+  EXPECT_THROW(spark_rapids_jni::convert_from_rows(rows_view, schema, std::vector<bool>{false}),
+               cudf::logic_error);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/RowConversion.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RowConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,26 @@ public class RowConversion {
    * @return the parsed table.
    */
   public static Table convertFromRows(ColumnView vec, DType ... schema) {
+    return convertFromRows(vec, false, schema);
+  }
+
+  /**
+   * Convert a column of list of bytes that is formatted like the output from `convertToRows`
+   * and convert it back to a table.
+   *
+   * NOTE: This method doesn't support nested types
+   *
+   * @param vec the row data to process.
+   * @param allValid true only if the producer OBSERVED that it wrote no nulls into these rows.
+   *                 Never pass a value inferred from a declared schema: the conversion skips all
+   *                 validity work and returns non-nullable columns, so a false claim yields wrong
+   *                 values rather than an error. Set the environment variable
+   *                 ROWCONV_VALIDATE_ALL_VALID=1 to re-verify every such claim and throw on a
+   *                 violation instead (debug aid, default off).
+   * @param schema the types of each column.
+   * @return the parsed table.
+   */
+  public static Table convertFromRows(ColumnView vec, boolean allValid, DType ... schema) {
     int[] types = new int[schema.length];
     int[] scale = new int[schema.length];
     for (int i = 0; i < schema.length; i++) {
@@ -142,7 +162,7 @@ public class RowConversion {
       scale[i] = schema[i].getScale();
 
     }
-    return new Table(convertFromRows(vec.getNativeView(), types, scale));
+    return new Table(convertFromRows(vec.getNativeView(), types, scale, allValid));
   }
 
   /**
@@ -156,6 +176,27 @@ public class RowConversion {
    * @return the parsed table.
    */
   public static Table convertFromRowsFixedWidthOptimized(ColumnView vec, DType ... schema) {
+    return convertFromRowsFixedWidthOptimized(vec, false, schema);
+  }
+
+  /**
+   * Convert a column of list of bytes that is formatted like the output from `convertToRows`
+   * and convert it back to a table.
+   *
+   * NOTE: This method doesn't support nested types
+   *
+   * @param vec the row data to process.
+   * @param allValid true only if the producer OBSERVED that it wrote no nulls into these rows.
+   *                 Never pass a value inferred from a declared schema: the conversion skips all
+   *                 validity work and returns non-nullable columns, so a false claim yields wrong
+   *                 values rather than an error. Set the environment variable
+   *                 ROWCONV_VALIDATE_ALL_VALID=1 to re-verify every such claim and throw on a
+   *                 violation instead (debug aid, default off).
+   * @param schema the types of each column.
+   * @return the parsed table.
+   */
+  public static Table convertFromRowsFixedWidthOptimized(ColumnView vec, boolean allValid,
+      DType ... schema) {
     int[] types = new int[schema.length];
     int[] scale = new int[schema.length];
     for (int i = 0; i < schema.length; i++) {
@@ -163,12 +204,15 @@ public class RowConversion {
       scale[i] = schema[i].getScale();
 
     }
-    return new Table(convertFromRowsFixedWidthOptimized(vec.getNativeView(), types, scale));
+    return new Table(
+        convertFromRowsFixedWidthOptimized(vec.getNativeView(), types, scale, allValid));
   }
 
   private static native long[] convertToRows(long nativeHandle);
   private static native long[] convertToRowsFixedWidthOptimized(long nativeHandle);
 
-  private static native long[] convertFromRows(long nativeColumnView, int[] types, int[] scale);
-  private static native long[] convertFromRowsFixedWidthOptimized(long nativeColumnView, int[] types, int[] scale);
+  private static native long[] convertFromRows(long nativeColumnView, int[] types, int[] scale,
+      boolean allValid);
+  private static native long[] convertFromRowsFixedWidthOptimized(long nativeColumnView,
+      int[] types, int[] scale, boolean allValid);
 }


### PR DESCRIPTION
**Note**: This PR is used for testing only, will be broken down to multiple small PRs for review and merge.

`GpuColumnarToRowExec` and `GpuRowToColumnarExec` run the JCUDF transpose on every Spark transition between the columnar and row representations. This PR improves their performance through optimizing the native JNI APIs with various improvements:
 * JCUDF host buffers are now staged in one pinned arena
 * from-rows output is gathered directly instead of being staged
 * String from-rows splits into char-parallel and string-parallel kernels
 * The from-rows null-count fixup is batched
 * Tile height is filled adaptively for single-band schemas
 * Row offsets are built with `thrust::tabulate`
 * JIT copy kernels
 * A direct drain and an all-valid path are also added to accelerate null processing.

---------

## Benchmark

| cell | base (ms) | split (ms) | speedup |
|---|---:|---:|---:|
| `from_rows_fixed[num_columns=2,num_rows=16777216,path=general]` | 41.695 | 2.924 | 14.262× 🏆 |
| `from_rows_fixed[num_columns=2,num_rows=2097152,path=general]` | 5.601 | 0.618 | 9.065× |
| `to_rows_fixed[num_columns=2,num_rows=32768,path=fixed_opt]` | 0.097 | 0.022 | 4.326× |
| `from_rows_fixed[num_columns=2,num_rows=262144,path=general]` | 0.880 | 0.233 | 3.772× |
| `from_rows_fixed[num_columns=10,num_rows=32768,path=fixed_opt]` | 0.245 | 0.072 | 3.430× |
| `from_rows_fixed[num_columns=10,num_rows=16777216,path=general]` | 56.225 | 17.779 | 3.162× |
| `to_rows_fixed[num_columns=2,num_rows=16777216,path=general]` | 39.332 | 12.697 | 3.098× |
| `to_rows_fixed[num_columns=2,num_rows=2097152,path=general]` | 5.050 | 1.703 | 2.966× |
| `from_rows_fixed[num_columns=212,num_rows=32768,path=fixed_opt]` | 5.815 | 2.043 | 2.847× |
| `from_rows_fixed[num_columns=212,num_rows=32768,path=general]` | 6.151 | 2.171 | 2.833× |
| `from_rows_fixed[num_columns=96,num_rows=32768,path=general]` | 3.165 | 1.121 | 2.823× |
| `from_rows_wide[nulls=0.1,num_columns=320,num_rows=32768]` | 9.390 | 3.327 | 2.822× |
| `from_rows_fixed[num_columns=256,num_rows=32768,path=general]` | 7.588 | 2.695 | 2.816× |
| `from_rows_wide[nulls=0.1,num_columns=212,num_rows=32768]` | 6.126 | 2.182 | 2.807× |
| `from_rows_wide[nulls=none,num_columns=212,num_rows=32768]` | 6.158 | 2.208 | 2.788× |
| `from_rows_fixed[num_columns=256,num_rows=32768,path=fixed_opt]` | 7.132 | 2.570 | 2.775× |
| `from_rows_wide[nulls=none,num_columns=320,num_rows=32768]` | 9.259 | 3.356 | 2.759× |
| `from_rows_fixed[num_columns=10,num_rows=32768,path=general]` | 0.411 | 0.150 | 2.728× |
| `from_rows_fixed[num_columns=128,num_rows=32768,path=fixed_opt]` | 3.627 | 1.342 | 2.702× |
| `from_rows_fixed[num_columns=96,num_rows=32768,path=fixed_opt]` | 2.695 | 0.998 | 2.699× |
| `to_rows_fixed[num_columns=10,num_rows=32768,path=fixed_opt]` | 0.224 | 0.253 | 0.887× |
| `to_rows_fixed[num_columns=10,num_rows=16777216,path=fixed_opt]` | 19.636 | 19.871 | 0.988× |
| `to_rows_fixed[num_columns=96,num_rows=2097152,path=fixed_opt]` | 21.795 | 21.829 | 0.998× |
| `to_rows_fixed[num_columns=212,num_rows=2097152,path=general]` | 48.244 | 48.304 | 0.999× |
| `to_rows_fixed[num_columns=256,num_rows=2097152,path=general]` | 58.604 | 58.609 | 1.000× |
| `to_rows_fixed[num_columns=128,num_rows=16777216,path=fixed_opt]` | 233.894 | 233.862 | 1.000× |
| `to_rows_wide[nulls=0.1,num_columns=212,num_rows=2097152]` | 48.243 | 48.236 | 1.000× |
| `to_rows_fixed[num_columns=128,num_rows=2097152,path=general]` | 29.265 | 29.253 | 1.000× |
| `to_rows_fixed[num_columns=96,num_rows=16777216,path=fixed_opt]` | 176.359 | 176.289 | 1.000× |
| `to_rows_fixed[num_columns=256,num_rows=2097152,path=fixed_opt]` | 57.668 | 57.640 | 1.000× |
| `to_rows_fixed[num_columns=212,num_rows=2097152,path=fixed_opt]` | 47.624 | 47.598 | 1.001× |
| `to_rows_strings[avg_string_len=128,num_rows=2097152,string_cols=8]` | 40.583 | 40.553 | 1.001× |
| `to_rows_fixed[num_columns=128,num_rows=2097152,path=fixed_opt]` | 28.636 | 28.610 | 1.001× |
| `to_rows_wide[nulls=none,num_columns=320,num_rows=2097152]` | 73.343 | 73.252 | 1.001× |
| `to_rows_wide[nulls=0.1,num_columns=320,num_rows=2097152]` | 73.508 | 73.415 | 1.001× |
| `to_rows_wide[nulls=none,num_columns=212,num_rows=2097152]` | 48.455 | 48.369 | 1.002× |
| `to_rows_strings[avg_string_len=128,num_rows=16777216,string_cols=2]` | 98.043 | 97.658 | 1.004× |
| `to_rows_fixed[num_columns=96,num_rows=16777216,path=general]` | 182.125 | 181.289 | 1.005× |
| `from_rows_fixed[num_columns=10,num_rows=16777216,path=fixed_opt]` | 16.182 | 15.527 | 1.042× |
| `from_rows_fixed[num_columns=96,num_rows=16777216,path=fixed_opt]` | 207.350 | 198.605 | 1.044× |
