### PR TITLE
Add SonarQube to JNI premerge

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -300,10 +300,9 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                 ])
 
                             if (sonarBuild.result == 'UNSTABLE') {
-                                unstable("SonarQube Quality Gate failed: ${sonarBuild.absoluteUrl}")
+                                unstable('SonarQube Quality Gate failed')
                             } else if (sonarBuild.result != 'SUCCESS') {
-                                error("SonarQube pipeline was ${sonarBuild.result}: " +
-                                    "${sonarBuild.absoluteUrl}")
+                                error("SonarQube pipeline was ${sonarBuild.result}")
                             }
                         }
                     }

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -278,6 +278,36 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         }
                     }
                 }
+
+                stage ('sonarqube') {
+                    steps {
+                        script {
+                            def prNumber = githubHelper.getIssue().number
+
+                            def sonarBuild = build(
+                                job: 'sonar-scan',
+                                wait: true,
+                                propagate: false,
+                                parameters: [
+                                    string(name: 'REPO_URL', value: githubHelper.getCloneUrl()),
+                                    string(name: 'REF', value: githubHelper.getMergedSHA()),
+                                    string(name: 'BRANCH_NAME', value: "PR-${prNumber}"),
+                                    string(name: 'REFSPEC', value:
+                                        "+refs/pull/${prNumber}/merge:" +
+                                        "refs/remotes/origin/pr/${prNumber}"),
+                                    booleanParam(name: 'CHECK_QUALITY_GATE', value: true),
+                                    booleanParam(name: 'MUTE_SLACK', value: true),
+                                ])
+
+                            if (sonarBuild.result == 'UNSTABLE') {
+                                unstable("SonarQube Quality Gate failed: ${sonarBuild.absoluteUrl}")
+                            } else if (sonarBuild.result != 'SUCCESS') {
+                                error("SonarQube pipeline was ${sonarBuild.result}: " +
+                                    "${sonarBuild.absoluteUrl}")
+                            }
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Add sonarqube scan to premerge.

If sonar job returns UNSATBLE (Quality Gate failed, high/block issue exists) or FAILED (pipeline issue), blossom-ci fails.