### PR TITLE
Update HLLPP host UDF streams for cuda::stream_ref

### DIFF
--- a/src/main/cpp/src/hyper_log_log_plus_plus.cu
+++ b/src/main/cpp/src/hyper_log_log_plus_plus.cu
@@ -428,11 +428,11 @@ std::unique_ptr<cudf::column> group_hllpp(cudf::column_view const& input,
         cudf::util::div_rounding_up_safe(num_threads_partial_kernel, block_size);
       partial_group_sketches_from_hashs_kernel<block_size, num_hashs_per_thread>
         <<<num_blocks_p1, block_size, 0, stream.get()>>>(*d_hashs,
-                                                           group_labels,
-                                                           precision,
-                                                           sketches_output.begin(),
-                                                           registers_thread_cache.begin(),
-                                                           group_labels_thread_cache.begin());
+                                                         group_labels,
+                                                         precision,
+                                                         sketches_output.begin(),
+                                                         registers_thread_cache.begin(),
+                                                         group_labels_thread_cache.begin());
     }
     // 3. merge the intermidate result
     auto num_merge_threads = num_registers_per_sketch;
@@ -619,14 +619,14 @@ std::unique_ptr<cudf::column> group_merge_hllpp(
     // 1st kernel: partially group
     partial_group_long_sketches_kernel<block_size, num_longs_per_threads>
       <<<num_blocks, block_size, 0, stream.get()>>>(d_inputs,
-                                                      num_sketches,
-                                                      num_threads_per_col_phase1,
-                                                      num_registers_per_sketch,
-                                                      num_groups,
-                                                      group_labels,
-                                                      registers_output_cache.begin(),
-                                                      registers_thread_cache.begin(),
-                                                      group_labels_thread_cache.begin());
+                                                    num_sketches,
+                                                    num_threads_per_col_phase1,
+                                                    num_registers_per_sketch,
+                                                    num_groups,
+                                                    group_labels,
+                                                    registers_output_cache.begin(),
+                                                    registers_thread_cache.begin(),
+                                                    group_labels_thread_cache.begin());
     auto const num_phase2_threads = num_registers_per_sketch;
     auto const num_phase2_blocks = cudf::util::div_rounding_up_safe(num_phase2_threads, block_size);
     // 2nd kernel: vertical merge

--- a/src/main/cpp/src/hyper_log_log_plus_plus.cu
+++ b/src/main/cpp/src/hyper_log_log_plus_plus.cu
@@ -396,7 +396,7 @@ std::unique_ptr<cudf::column> group_hllpp(cudf::column_view const& input,
                                           int64_t const num_groups,
                                           cudf::device_span<cudf::size_type const> group_labels,
                                           int64_t const precision,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   int64_t num_registers_per_sketch   = 1 << precision;
@@ -427,7 +427,7 @@ std::unique_ptr<cudf::column> group_hllpp(cudf::column_view const& input,
       int64_t num_blocks_p1 =
         cudf::util::div_rounding_up_safe(num_threads_partial_kernel, block_size);
       partial_group_sketches_from_hashs_kernel<block_size, num_hashs_per_thread>
-        <<<num_blocks_p1, block_size, 0, stream.value()>>>(*d_hashs,
+        <<<num_blocks_p1, block_size, 0, stream.get()>>>(*d_hashs,
                                                            group_labels,
                                                            precision,
                                                            sketches_output.begin(),
@@ -438,7 +438,7 @@ std::unique_ptr<cudf::column> group_hllpp(cudf::column_view const& input,
     auto num_merge_threads = num_registers_per_sketch;
     auto num_merge_blocks  = cudf::util::div_rounding_up_safe(num_merge_threads, block_size);
     merge_sketches_vertically<block_size>
-      <<<num_merge_blocks, block_size, block_size, stream.value()>>>(
+      <<<num_merge_blocks, block_size, block_size, stream.get()>>>(
         num_threads_partial_kernel,  // num_sketches
         num_registers_per_sketch,
         sketches_output.begin(),
@@ -472,7 +472,7 @@ std::unique_ptr<cudf::column> group_hllpp(cudf::column_view const& input,
   // 5. compact sketches
   auto num_phase3_threads = num_groups * num_long_cols;
   auto num_phase3_blocks  = cudf::util::div_rounding_up_safe(num_phase3_threads, block_size);
-  compact_kernel<block_size><<<num_phase3_blocks, block_size, 0, stream.value()>>>(
+  compact_kernel<block_size><<<num_phase3_blocks, block_size, 0, stream.get()>>>(
     num_groups, num_registers_per_sketch, d_results, sketches_output);
 
   return result;
@@ -589,7 +589,7 @@ std::unique_ptr<cudf::column> group_merge_hllpp(
   int64_t const num_groups,
   cudf::device_span<cudf::size_type const> group_labels,
   int64_t const precision,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   int64_t num_registers_per_sketch        = 1 << precision;
@@ -618,7 +618,7 @@ std::unique_ptr<cudf::column> group_merge_hllpp(
     auto d_inputs   = cudf::detail::make_device_uvector(input_cols, stream, default_mr);
     // 1st kernel: partially group
     partial_group_long_sketches_kernel<block_size, num_longs_per_threads>
-      <<<num_blocks, block_size, 0, stream.value()>>>(d_inputs,
+      <<<num_blocks, block_size, 0, stream.get()>>>(d_inputs,
                                                       num_sketches,
                                                       num_threads_per_col_phase1,
                                                       num_registers_per_sketch,
@@ -631,7 +631,7 @@ std::unique_ptr<cudf::column> group_merge_hllpp(
     auto const num_phase2_blocks = cudf::util::div_rounding_up_safe(num_phase2_threads, block_size);
     // 2nd kernel: vertical merge
     merge_sketches_vertically<block_size>
-      <<<num_phase2_blocks, block_size, block_size, stream.value()>>>(
+      <<<num_phase2_blocks, block_size, block_size, stream.get()>>>(
         num_threads_per_col_phase1,  // num_sketches
         num_registers_per_sketch,
         registers_output_cache.begin(),
@@ -659,7 +659,7 @@ std::unique_ptr<cudf::column> group_merge_hllpp(
   // 3rd kernel: compact
   auto num_phase3_threads = num_groups * num_long_cols;
   auto num_phase3_blocks  = cudf::util::div_rounding_up_safe(num_phase3_threads, block_size);
-  compact_kernel<block_size><<<num_phase3_blocks, block_size, 0, stream.value()>>>(
+  compact_kernel<block_size><<<num_phase3_blocks, block_size, 0, stream.get()>>>(
     num_groups, num_registers_per_sketch, d_sketches_output, registers_output_cache);
 
   return make_structs_column(num_groups, std::move(results), 0, rmm::device_buffer{});
@@ -730,7 +730,7 @@ __launch_bounds__(block_size) CUDF_KERNEL
 
 std::unique_ptr<cudf::scalar> reduce_hllpp(cudf::column_view const& input,
                                            int64_t const precision,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   int64_t num_registers_per_sketch = 1L << precision;
@@ -767,12 +767,12 @@ std::unique_ptr<cudf::scalar> reduce_hllpp(cudf::column_view const& input,
     // use shared memory, max shared memory is 2^12 * 4 = 16M
     auto shared_mem_size = num_registers_per_sketch * sizeof(int32_t);
     reduce_hllpp_kernel<block_size>
-      <<<1, block_size, shared_mem_size, stream.value()>>>(*d_hashs, d_results, precision, nullptr);
+      <<<1, block_size, shared_mem_size, stream.get()>>>(*d_hashs, d_results, precision, nullptr);
   } else {
     // use global memory because shared memory may be not enough
     auto mem_cache = rmm::device_uvector<int32_t>(num_registers_per_sketch, stream, default_mr);
     reduce_hllpp_kernel<block_size>
-      <<<1, block_size, 0, stream.value()>>>(*d_hashs, d_results, precision, mem_cache.data());
+      <<<1, block_size, 0, stream.get()>>>(*d_hashs, d_results, precision, mem_cache.data());
   }
 
   // 3. create struct scalar
@@ -800,7 +800,7 @@ __launch_bounds__(block_size) CUDF_KERNEL
 
 std::unique_ptr<cudf::scalar> reduce_merge_hllpp(cudf::column_view const& input,
                                                  int64_t const precision,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   // create device input
@@ -837,13 +837,13 @@ std::unique_ptr<cudf::scalar> reduce_merge_hllpp(cudf::column_view const& input,
   constexpr int64_t block_size = 256;
   auto num_blocks              = cudf::util::div_rounding_up_safe(num_threads, block_size);
   auto output_cache = rmm::device_uvector<int32_t>(num_registers_per_sketch, stream, default_mr);
-  reduce_merge_hll_kernel_vertically<block_size><<<num_blocks, block_size, 0, stream.value()>>>(
+  reduce_merge_hll_kernel_vertically<block_size><<<num_blocks, block_size, 0, stream.get()>>>(
     d_inputs, input.size(), num_registers_per_sketch, output_cache.begin());
 
   // compact to longs
   auto const num_compact_threads = num_long_cols;
   auto const num_compact_blocks = cudf::util::div_rounding_up_safe(num_compact_threads, block_size);
-  compact_kernel<block_size><<<num_compact_blocks, block_size, 0, stream.value()>>>(
+  compact_kernel<block_size><<<num_compact_blocks, block_size, 0, stream.get()>>>(
     1 /** num_groups **/, num_registers_per_sketch, d_results, output_cache);
 
   // create scalar
@@ -882,7 +882,7 @@ std::unique_ptr<cudf::column> group_hyper_log_log_plus_plus(
   int64_t const num_groups,
   cudf::device_span<cudf::size_type const> group_labels,
   int64_t const precision,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(precision >= 4, "HyperLogLogPlusPlus requires precision bigger than 4.");
@@ -895,7 +895,7 @@ std::unique_ptr<cudf::column> group_merge_hyper_log_log_plus_plus(
   int64_t const num_groups,
   cudf::device_span<cudf::size_type const> group_labels,
   int64_t const precision,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(precision >= 4, "HyperLogLogPlusPlus requires precision bigger than 4.");
@@ -914,7 +914,7 @@ std::unique_ptr<cudf::column> group_merge_hyper_log_log_plus_plus(
 
 std::unique_ptr<cudf::scalar> reduce_hyper_log_log_plus_plus(cudf::column_view const& input,
                                                              int64_t const precision,
-                                                             rmm::cuda_stream_view stream,
+                                                             cuda::stream_ref stream,
                                                              rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(precision >= 4, "HyperLogLogPlusPlus requires precision bigger than 4.");
@@ -925,7 +925,7 @@ std::unique_ptr<cudf::scalar> reduce_hyper_log_log_plus_plus(cudf::column_view c
 std::unique_ptr<cudf::scalar> reduce_merge_hyper_log_log_plus_plus(
   cudf::column_view const& input,
   int64_t const precision,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(precision >= 4, "HyperLogLogPlusPlus requires precision bigger than 4.");
@@ -944,7 +944,7 @@ std::unique_ptr<cudf::scalar> reduce_merge_hyper_log_log_plus_plus(
 
 std::unique_ptr<cudf::column> estimate_from_hll_sketches(cudf::column_view const& input,
                                                          int precision,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(precision >= 4, "HyperLogLogPlusPlus requires precision bigger than 4.");

--- a/src/main/cpp/src/hyper_log_log_plus_plus.hpp
+++ b/src/main/cpp/src/hyper_log_log_plus_plus.hpp
@@ -20,7 +20,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -34,7 +34,7 @@ std::unique_ptr<cudf::column> group_hyper_log_log_plus_plus(
   int64_t const num_groups,
   cudf::device_span<cudf::size_type const> group_labels,
   int64_t const precision,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream          = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -47,7 +47,7 @@ std::unique_ptr<cudf::column> group_merge_hyper_log_log_plus_plus(
   int64_t const num_groups,
   cudf::device_span<cudf::size_type const> group_labels,
   int64_t const precision,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream          = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -58,7 +58,7 @@ std::unique_ptr<cudf::column> group_merge_hyper_log_log_plus_plus(
 std::unique_ptr<cudf::scalar> reduce_hyper_log_log_plus_plus(
   cudf::column_view const& input,
   int64_t const precision,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream          = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -69,7 +69,7 @@ std::unique_ptr<cudf::scalar> reduce_hyper_log_log_plus_plus(
 std::unique_ptr<cudf::scalar> reduce_merge_hyper_log_log_plus_plus(
   cudf::column_view const& input,
   int64_t const precision,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream          = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -81,6 +81,6 @@ std::unique_ptr<cudf::scalar> reduce_merge_hyper_log_log_plus_plus(
 std::unique_ptr<cudf::column> estimate_from_hll_sketches(
   cudf::column_view const& input,
   int precision,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream          = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hyper_log_log_plus_plus.hpp
+++ b/src/main/cpp/src/hyper_log_log_plus_plus.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ std::unique_ptr<cudf::column> group_hyper_log_log_plus_plus(
   int64_t const num_groups,
   cudf::device_span<cudf::size_type const> group_labels,
   int64_t const precision,
-  cuda::stream_ref stream          = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -47,7 +47,7 @@ std::unique_ptr<cudf::column> group_merge_hyper_log_log_plus_plus(
   int64_t const num_groups,
   cudf::device_span<cudf::size_type const> group_labels,
   int64_t const precision,
-  cuda::stream_ref stream          = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -58,7 +58,7 @@ std::unique_ptr<cudf::column> group_merge_hyper_log_log_plus_plus(
 std::unique_ptr<cudf::scalar> reduce_hyper_log_log_plus_plus(
   cudf::column_view const& input,
   int64_t const precision,
-  cuda::stream_ref stream          = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -69,7 +69,7 @@ std::unique_ptr<cudf::scalar> reduce_hyper_log_log_plus_plus(
 std::unique_ptr<cudf::scalar> reduce_merge_hyper_log_log_plus_plus(
   cudf::column_view const& input,
   int64_t const precision,
-  cuda::stream_ref stream          = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -81,6 +81,6 @@ std::unique_ptr<cudf::scalar> reduce_merge_hyper_log_log_plus_plus(
 std::unique_ptr<cudf::column> estimate_from_hll_sketches(
   cudf::column_view const& input,
   int precision,
-  cuda::stream_ref stream          = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hyper_log_log_plus_plus_host_udf.cu
+++ b/src/main/cpp/src/hyper_log_log_plus_plus_host_udf.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/hyper_log_log_plus_plus_host_udf.cu
+++ b/src/main/cpp/src/hyper_log_log_plus_plus_host_udf.cu
@@ -33,7 +33,7 @@ struct hllpp_groupby_udf : cudf::groupby_host_udf {
    * @brief Perform the main groupby computation for HLLPP UDF.
    */
   [[nodiscard]] std::unique_ptr<cudf::column> operator()(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const override
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const override
   {
     auto const group_values = get_grouped_values();
     if (group_values.size() == 0) { return get_empty_output(stream, mr); }
@@ -53,7 +53,7 @@ struct hllpp_groupby_udf : cudf::groupby_host_udf {
    * @brief Create an empty column when the input is empty.
    */
   [[nodiscard]] std::unique_ptr<cudf::column> get_empty_output(
-    rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr) const override
+    cuda::stream_ref stream, rmm::device_async_resource_ref mr) const override
   {
     int num_registers       = 1 << precision;
     int num_long_cols       = num_registers / REGISTERS_PER_LONG + 1;
@@ -96,7 +96,7 @@ struct hllpp_reduct_udf : cudf::reduce_host_udf {
   /**
    * @brief Create an empty scalar when the input is empty.
    */
-  std::unique_ptr<cudf::scalar> get_empty_scalar(rmm::cuda_stream_view stream,
+  std::unique_ptr<cudf::scalar> get_empty_scalar(cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr) const
   {
     int num_registers       = 1 << precision;
@@ -116,7 +116,7 @@ struct hllpp_reduct_udf : cudf::reduce_host_udf {
     cudf::column_view const& input,
     cudf::data_type,                                           /** output_dtype is useless */
     std::optional<std::reference_wrapper<cudf::scalar const>>, /** init is useless */
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::device_async_resource_ref mr) const override
   {
     if (input.size() == 0) { return get_empty_scalar(stream, mr); }


### PR DESCRIPTION
Updates the HLLPP host UDF code for the cuDF host UDF stream API change by using cuda::stream_ref and stream.get() for kernel launches.

Also updates the thirdparty/cudf submodule to 5b6960d072, which includes NVIDIA/cudf#23649, which is where the above signatures changed.