### PR TITLE
Fix compile error in `murmur_hash`, `map_zip_with_utils`

### DIFF
--- a/src/main/cpp/src/hash/murmur_hash.cu
+++ b/src/main/cpp/src/hash/murmur_hash.cu
@@ -207,9 +207,10 @@ std::unique_ptr<cudf::column> murmur_hash3_32(cudf::table_view const& input,
   // Lists of structs are not supported
   check_hash_compatibility(input);
 
-  bool const nullable   = has_nested_nulls(input);
-  auto const row_hasher = cudf::detail::row::hash::row_hasher(input, stream);
-  auto output_view      = output->mutable_view();
+  bool const nullable = has_nested_nulls(input);
+  auto const row_hasher =
+    cudf::detail::row::hash::row_hasher(input, stream, cudf::get_current_device_resource_ref());
+  auto output_view = output->mutable_view();
 
   // Compute the hash value for each row
   thrust::tabulate(

--- a/src/main/cpp/src/map_zip_with_utils.cu
+++ b/src/main/cpp/src/map_zip_with_utils.cu
@@ -270,8 +270,8 @@ std::unique_ptr<column> indices_of(
   auto const keys_tview   = cudf::table_view{{all_keys}};
   auto const values_tview = cudf::table_view{{all_values}};
   auto const has_nulls    = has_nested_nulls(values_tview) || has_nested_nulls(keys_tview);
-  auto const comparator =
-    cudf::detail::row::equality::two_table_comparator(values_tview, keys_tview, stream);
+  auto const comparator   = cudf::detail::row::equality::two_table_comparator(
+    values_tview, keys_tview, stream, cudf::get_current_device_resource_ref());
   auto const d_comp    = comparator.equal_to<false>(cudf::nullate::DYNAMIC{has_nulls});
   using lhs_index_type = cudf::detail::row::lhs_index_type;
   using rhs_index_type = cudf::detail::row::rhs_index_type;


### PR DESCRIPTION
Fixes #5019.

NVIDIA/cudf/pull/23665 seems to have changed the `row_hasher` interface that `murmur_hash` depends on.  Compilation fails as follows:

```
[INFO]      [exec] /mnt/nvme0n1p2/more-workspace/dev/cudf-spark-jni/hllpp-break/src/main/cpp/src/hash/murmur_hash.cu(211): error: no instance of constructor "cudf::detail::row::hash::row_hasher::row_hasher" matches the argument list
[INFO]      [exec]             argument types are: (const cudf::table_view, rmm::_RMM_26_10::cuda_stream_view)
[INFO]      [exec]     auto const row_hasher = cudf::detail::row::hash::row_hasher(input, stream);
[INFO]      [exec]                             ^
[INFO]      [exec] /mnt/nvme0n1p2/more-workspace/dev/cudf-spark-jni/hllpp-break/target/libcudf-install/include/cudf/detail/row_operator/hashing.cuh(235): note #3322-D: number of parameters of function "cudf::detail::row::hash::row_hasher::row_hasher(const cudf::detail::row::hash::row_hasher &)" does not match the call
[INFO]      [exec]   class row_hasher {
[INFO]      [exec]         ^
[INFO]      [exec] /mnt/nvme0n1p2/more-workspace/dev/cudf-spark-jni/hllpp-break/target/libcudf-install/include/cudf/detail/row_operator/hashing.cuh(235): note #3322-D: number of parameters of function "cudf::detail::row::hash::row_hasher::row_hasher(cudf::detail::row::hash::row_hasher &&)" does not match the call
[INFO]      [exec]   class row_hasher {
...
```

This commit fixes `murmur_hash.cu` and `map_zip_with_utils.cu`, to pass a temp-mr to the underlying (changed) cuDF functions.
