### PR TITLE
Rename RAPIDS Accelerator for Apache Spark to NVIDIA cuDF plugin for Apache Spark

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a bug report to help us improve the RAPIDS Accelerator JNI for Apache Spark
+about: Create a bug report to help us improve the NVIDIA cuDF plugin JNI for Apache Spark
 title: "[BUG]"
 labels: "? - Needs Triage, bug"
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for the RAPIDS Accelerator JNI for Apache Spark
+about: Suggest an idea for the NVIDIA cuDF plugin JNI for Apache Spark
 title: "[FEA]"
 labels: "? - Needs Triage, feature request"
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I wish the RAPIDS Accelerator JNI for Apache Spark would [...]
+A clear and concise description of what the problem is. Ex. I wish the NVIDIA cuDF plugin JNI for Apache Spark would [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/submit-question.md
+++ b/.github/ISSUE_TEMPLATE/submit-question.md
@@ -1,6 +1,6 @@
 ---
 name: Submit question
-about: Ask a general question about RAPIDS Accelerator JNI for Apache Spark
+about: Ask a general question about NVIDIA cuDF plugin JNI for Apache Spark
 title: "[QST]"
 labels: "? - Needs Triage, question"
 assignees: ''

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 
-Thank you for contributing to RAPIDS Accelerator for Apache Spark!
+Thank you for contributing to NVIDIA cuDF plugin for Apache Spark!
 
 Here are some guidelines to help the review process go smoothly.
 

--- a/.github/workflows/action-helper/python/submodule-sync
+++ b/.github/workflows/action-helper/python/submodule-sync
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ def main():
                 'base': pr.base,
                 'body': "submodule-sync to create a PR keeping thirdparty/cudf up-to-date.\n"
                         f"HEAD commit SHA: {args.sha}, "
-                        f"cudf commit SHA: https://github.com/rapidsai/cudf/commit/{args.cudf_sha}\n\n"
+                        f"cudf commit SHA: https://github.com/nvidia/cudf/commit/{args.cudf_sha}\n\n"
                         "This PR will be auto-merged if test passed. "
                         "If failed, it will remain open until test pass or manually fix.",
                 'maintainer_can_modify': True
@@ -65,7 +65,7 @@ def main():
                 sys.exit(0)
 
         pr.comment(number, content=f"HEAD commit SHA: {args.sha}, "
-                                   f"CUDF commit SHA: https://github.com/rapidsai/cudf/commit/{args.cudf_sha}\n"
+                                   f"CUDF commit SHA: https://github.com/nvidia/cudf/commit/{args.cudf_sha}\n"
                                    f"Test passed: **{args.passed}**")
 
         if args.passed:

--- a/.github/workflows/action-helper/python/submodule-sync
+++ b/.github/workflows/action-helper/python/submodule-sync
@@ -66,6 +66,7 @@ def main():
 
         pr.comment(number, content=f"HEAD commit SHA: {args.sha}, "
                                    f"CUDF commit SHA: https://github.com/NVIDIA/cudf/commit/{args.cudf_sha}\n"
+                                   f"CUDF commit SHA: https://github.com/nvidia/cudf/commit/{args.cudf_sha}\n"
                                    f"Test passed: **{args.passed}**")
 
         if args.passed:

--- a/.github/workflows/sync-clang-format-version.yml
+++ b/.github/workflows/sync-clang-format-version.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A workflow to sync the clang-format version between spark-rapids-jni and cudf
+# A workflow to sync the clang-format version between cudf-spark-jni and cudf
 name: sync clang-format version with cudf
 
 on:
@@ -60,8 +60,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
           NEW_VER: ${{ steps.update_clang_format_version.outputs.new_ver }}
-          GIT_AUTHOR_NAME: "spark-rapids automation"
-          GIT_COMMITTER_NAME: "spark-rapids automation"
+          GIT_AUTHOR_NAME: "cudf-spark automation"
+          GIT_COMMITTER_NAME: "cudf-spark automation"
           GIT_AUTHOR_EMAIL: "70000568+nvauto@users.noreply.github.com"
           GIT_COMMITTER_EMAIL: "70000568+nvauto@users.noreply.github.com"
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "thirdparty/cudf"]
 	path = thirdparty/cudf
-	url = https://github.com/rapidsai/cudf.git
+	url = https://github.com/nvidia/cudf.git
 	branch = main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           cudf_ver=$(grep -A1 "repo: $clang_format_pattern" "thirdparty/cudf/.pre-commit-config.yaml" | grep "rev:" | tail -1 | sed "s/.*rev: *//");
           if [ -z "$our_ver" ] || [ -z "$cudf_ver" ] || [ "$our_ver" != "$cudf_ver" ]; then
             echo "ERROR: clang-format version mismatch or failed to extract version!";
-            echo "  cudf-spark-jni: ${our_ver:-(empty)}";
+            echo "  spark-rapids-jni: ${our_ver:-(empty)}";
             echo "  cudf:             ${cudf_ver:-(empty)}";
             echo "Please update .pre-commit-config.yaml to use the same rev as cudf";
             exit 1;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           cudf_ver=$(grep -A1 "repo: $clang_format_pattern" "thirdparty/cudf/.pre-commit-config.yaml" | grep "rev:" | tail -1 | sed "s/.*rev: *//");
           if [ -z "$our_ver" ] || [ -z "$cudf_ver" ] || [ "$our_ver" != "$cudf_ver" ]; then
             echo "ERROR: clang-format version mismatch or failed to extract version!";
-            echo "  spark-rapids-jni: ${our_ver:-(empty)}";
+            echo "  cudf-spark-jni: ${our_ver:-(empty)}";
             echo "  cudf:             ${cudf_ver:-(empty)}";
             echo "Please update .pre-commit-config.yaml to use the same rev as cudf";
             exit 1;

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Define the code of conduct followed and enforced by the RAPIDS Accelerator for Apache Spark project
+Define the code of conduct followed and enforced by the NVIDIA cuDF plugin for Apache Spark project
 
 ### Intended audience
 
@@ -42,12 +42,12 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at  [spark-rapids-conduct@nvidia.com](mailto:spark-rapids-conduct@nvidia.com)  All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at  [cudf-spark-conduct@nvidia.com](mailto:cudf-spark-conduct@nvidia.com)  All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
 
 ## Attribution
 
-This Code of Conduct was taken from the [NVIDIA RAPIDS](https://docs.rapids.ai/resources/conduct/) project, which was adapted from the  [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct was taken from the [NVIDIA cuDF](https://docs.rapids.ai/resources/conduct/) project, which was adapted from the  [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,6 +48,6 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct was taken from the [NVIDIA cuDF](https://docs.rapids.ai/resources/conduct/) project, which was adapted from the  [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct was taken from the [NVIDIA RAPIDS](https://docs.rapids.ai/resources/conduct/) project, which was adapted from the  [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
-# Contributing to RAPIDS Accelerator JNI for Apache Spark
+# Contributing to the NVIDIA cuDF plugin JNI for Apache Spark
 
-Contributions to RAPIDS Accelerator JNI for Apache Spark fall into the following three categories.
+Contributions to the NVIDIA cuDF plugin JNI for Apache Spark fall into the following three categories.
 
 1. To report a bug, request a new feature, or report a problem with
-    documentation, please file an [issue](https://github.com/NVIDIA/spark-rapids-jni/issues/new/choose)
+    documentation, please file an [issue](https://github.com/NVIDIA/cudf-spark-jni/issues/new/choose)
     describing in detail the problem or new feature. The project team evaluates
     and triages issues, and schedules them for a release. If you believe the
     issue needs priority attention, please comment on the issue to notify the
     team.
 2. To propose and implement a new Feature, please file a new feature request
-    [issue](https://github.com/NVIDIA/spark-rapids-jni/issues/new/choose). Describe the
+    [issue](https://github.com/NVIDIA/cudf-spark-jni/issues/new/choose). Describe the
     intended feature and discuss the design and implementation with the team and
     community. Once the team agrees that the plan looks good, go ahead and
     implement it using the [code contributions](#code-contributions) guide below.
@@ -42,17 +42,17 @@ git submodule update --init --recursive
 ## Building From Source
 
 [Maven](https://maven.apache.org) is used for most aspects of the build. For example, the
-Maven `package` goal can be used to build the RAPIDS Accelerator JNI jar. After a successful
-build the RAPIDS Accelerator JNI jar will be in the `spark-rapids-jni/target/` directory.
+Maven `package` goal can be used to build the cuDF plugin JNI jar. After a successful
+build the cuDF plugin JNI jar will be in the `cudf-spark-jni/target/` directory.
 Be sure to select the jar with the CUDA classifier.
 
-When building spark-rapids-jni, the pom.xml in the submodule thirdparty/cudf is completely
+When building cudf-spark-jni, the pom.xml in the submodule thirdparty/cudf is completely
 bypassed. For a detailed explanation please read
-[this](https://github.com/NVIDIA/spark-rapids-jni/issues/1084#issuecomment-1513471739).
+[this](https://github.com/NVIDIA/cudf-spark-jni/issues/1084#issuecomment-1513471739).
 
 ### Building in the Docker Container
 
-The `build/build-in-docker` script will build the spark-rapids-jni artifact within a Docker
+The `build/build-in-docker` script will build the cudf-spark-jni artifact within a Docker
 container using devtoolset to produce native code that can run on all supported Linux
 distributions. The repo directory is bind-mounted into the container and the container runs
 as the current user, so the artifacts are produced as if they were built or installed outside
@@ -61,21 +61,20 @@ the Docker container.
 The script passes all of its arguments onto the Maven command run inside the Docker container,
 so it should be invoked as one would invoke Maven, e.g.: `build/build-in-docker clean package`
 
-#### Using spark-rapids-jni Docker Container with other Repos
+#### Using the cudf-spark-jni Docker Container with other Repos
 
-Spark RAPIDS project spans multiple repos. Some issues are discovered in
-spark-rapids-jni but they need to be made easily reproducible in the cudf repo
-
+The cuDF plugin project spans multiple repos. Some issues are discovered in
+cudf-spark-jni but they need to be made easily reproducible in the cudf repo. 
 To this end export WORKDIR with the path pointing to a different repo
 
 ```
-export WORKDIR=~/gits/rapidsai/cudf
-~/gits/NVIDIA/spark-rapids-jni/build/run-in-docker head README.md
+export WORKDIR=~/gits/nvidia/cudf
+~/gits/NVIDIA/cudf-spark-jni/build/run-in-docker head README.md
 ```
 
-### cudf Submodule and Build
+### cuDF Submodule and Build
 
-[RAPIDS cuDF](https://github.com/rapidsai/cudf) is being used as a submodule in this project.
+[NVIDIA cuDF](https://github.com/nvidia/cudf) is being used as a submodule in this project.
 
 Currently libcudf is only configured once and the build relies on cmake to re-configure as needed.
 This is because libcudf currently is rebuilding almost entirely when it is configured with the same
@@ -102,33 +101,33 @@ to control aspects of the build:
 | `submodule.check.skip`               | Whether to skip checking git submodules | false   |
 
 
-### Local testing of cross-repo contributions cudf, spark-rapids-jni, and spark-rapids
+### Local testing of cross-repo contributions cudf, cudf-spark-jni, and cudf-spark
 
 When we work on a feature or a bug fix across repositories, it is beneficial to be able to
 run manual and integration tests end to end on the full stack from Apache Spark
-with spark-rapids plugin upfront before merging the PRs.
+with cuDF plugin upfront before merging the PRs.
 
 So we are dealing with a subset of the following:
 
 Local PR branches for
-- rapidsai/cuDF, branch pr1
-- NVIDIA/spark-rapids-jni, branch pr2
-- NVIDIA/spark-rapids, branch pr3
+- NVIDIA/cuDF, branch pr1
+- NVIDIA/cudf-spark-jni, branch pr2
+- NVIDIA/cudf-spark, branch pr3
 
 Our end goal is to build the rapids-4-spark dist jar in the pr3 branch under local repo path
-~/repos/NVIDIA/spark-rapids that includes changes from the pr2 branch in
-~/repos/NVIDIA/spark-rapids-jni and the pr1 branch in rapidsai/cuDF that we will test
+~/repos/NVIDIA/cudf-spark that includes changes from the pr2 branch in
+~/repos/NVIDIA/cudf-spark-jni and the pr1 branch in NVIDIA/cudf that we will test
 with Spark. There are two options for working on pr1.
 
-#### Option 1: Working on cuDF PR inside the the submodule in spark-rapids-jni
+#### Option 1: Working on cuDF PR inside the the submodule in cudf-spark-jni
 To avoid retargeting the submodule to the local cuDF repo as below, we might find it easier
-to make changes locally under ~/repos/NVIDIA/spark-rapids-jni/thirdparty/cudf directly.
+to make changes locally under ~/repos/NVIDIA/cudf-spark-jni/thirdparty/cudf directly.
 
 In order to push pr1 to create a pull request, we need to add a remote to the submodule for the cuDF
 fork in our account
 
 ```bash
-$ cd ~/repos/NVIDIA/spark-rapids-jni/thirdparty/cudf
+$ cd ~/repos/NVIDIA/cudf-spark-jni/thirdparty/cudf
 $ git remote add <user> git@github.com:<user>/cudf.git
 # make and commit changes
 $ git push <user>
@@ -136,27 +135,27 @@ $ git push <user>
 
 #### Option 2: Working on cuDF PR in a conventional local cuDF fork
 Once we are done with our changes to the pr1 branch in
-~/repos/rapidsai/cuDF, we git commit changes locally.
+~/repos/nvidia/cudf, we git commit changes locally.
 
-Then we cd to ~/repos/NVIDIA/spark-rapids-jni and point the cudf submodule temporarily to the pr1
+Then we cd to ~/repos/NVIDIA/cudf-spark-jni and point the cudf submodule temporarily to the pr1
 branch
 
 ```bash
-$ git submodule set-url thirdparty/cudf ~/repos/rapidsai/cudf
+$ git submodule set-url thirdparty/cudf ~/repos/nvidia/cudf
 $ git submodule set-branch --branch pr1 thirdparty/cudf
 ```
 
-Sync pr1 into our pr2 branch in ~/repos/NVIDIA/spark-rapids-jni
+Sync pr1 into our pr2 branch in ~/repos/NVIDIA/cudf-spark-jni
 ```bash
 $ git submodule sync --recursive
 $ git submodule update --init --recursive --remote
 ```
 
-#### Building final spark-rapids artifact with pr1, pr2, and pr3 changes
+#### Building final cuDF plugin artifact with pr1, pr2, and pr3 changes
 Regardless what option we have used to make cuDF changes, we proceed with building
-spark-rapids-jni. The spark-rapids repo will consume spark-rapids-jni with pr1 and pr2 changes
+cudf-spark-jni. The cudf-spark repo will consume cudf-spark-jni with pr1 and pr2 changes
 from the local Maven cache after we run `mvn install` via `build/build-in-docker`
-in ~/repos/NVIDIA/spark-rapids-jni.
+in ~/repos/NVIDIA/cudf-spark-jni.
 
 Make sure to stage thirdparty/cudf with `git add` to satifsfy build's submodule check.
 ```bash
@@ -164,8 +163,8 @@ $ git add thirdparty/cudf
 $ ./build/build-in-docker install ...
 ```
 
-Now cd to ~/repos/NVIDIA/spark-rapids and build with one of the options from
-[spark-rapids instructions](https://github.com/NVIDIA/spark-rapids/blob/main/CONTRIBUTING.md#building-from-source).
+Now cd to ~/repos/NVIDIA/cudf-spark and build with one of the options from
+[cuDF plugin instructions](https://github.com/NVIDIA/cudf-spark/blob/main/CONTRIBUTING.md#building-from-source).
 
 ```bash
 $ ./build/buildall
@@ -176,7 +175,7 @@ the final rapids-4-spark artifact includes the locally built dependencies as opp
 CI-built snapshot dependencies from the remote Maven repo. This may happen even if Maven
 is invoked with `--offline` or `--no-snapshot-updates` option due to IDE-Maven
 interactions in the background. To confirm that the artifact is correct we can either enable
-[INFO logging in Spark](https://github.com/NVIDIA/spark-rapids/blob/4c77f0db58d229b2e6cb75c196934fcc0ae3a485/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala#L73-L83)
+[INFO logging in Spark](https://github.com/NVIDIA/cudf-spark/blob/4c77f0db58d229b2e6cb75c196934fcc0ae3a485/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala#L73-L83)
 or directly inspect the resulting jar for build info:
 ```bash
 $ unzip -c dist/target/rapids-4-spark_2.12-22.08.0-SNAPSHOT-cuda12.jar *version-info.properties
@@ -187,7 +186,7 @@ user=
 revision=62657ad6a296ea3547417504652e3b8836b020fb
 branch=testCUDF_pr1
 date=2022-07-19T21:48:15Z
-url=https://github.com/rapidsai/cudf.git
+url=https://github.com/nvidia/cudf.git
 
   inflating: spark-rapids-jni-version-info.properties
 version=22.08.0-SNAPSHOT
@@ -195,7 +194,7 @@ user=
 revision=70adcc86a513ad6665968021c669fbca7515a188
 branch=pr/user1/381
 date=2022-07-19T21:48:15Z
-url=git@github.com:NVIDIA/spark-rapids-jni.git
+url=git@github.com:NVIDIA/cudf-spark-jni.git
 
   inflating: rapids4spark-version-info.properties
 version=22.08.0-SNAPSHOT
@@ -204,15 +203,15 @@ user=user1
 revision=6453047ef479b5ec79384c5150c50af2f50f563e
 branch=aqeFinalPlanOnGPUDoc
 date=2022-07-19T21:51:52Z
-url=https://github.com/NVIDIA/spark-rapids
+url=https://github.com/NVIDIA/cudf-spark
 ```
 and verify that the branch names and the revisions in the console output
 correspond the local repos.
 
-When we are ready to move on, prior to switching to another spark-rapids-jni branch
-or submiting a PR to NVIDIA/spark-rapids-jni, we should undo the cudf submodule modifications.
+When we are ready to move on, prior to switching to another cudf-spark-jni branch
+or submiting a PR to NVIDIA/cudf-spark-jni, we should undo the cudf submodule modifications.
 ```
-$ cd ~/repos/NVIDIA/spark-rapids-jni
+$ cd ~/repos/NVIDIA/cudf-spark-jni
 $ git restore .gitmodules
 $ git restore --staged thirdparty/cudf
 ```
@@ -226,7 +225,7 @@ Ubuntu distro WSL2 instance to be able to run `build/build-in-docker` above.
 > .\build\win\create-wsl2.ps1
 ```
 
-Clone spark-rapids-jni inside or outside (convenient but slower filesystem) the distro,
+Clone cudf-spark-jni inside or outside (convenient but slower filesystem) the distro,
 and build inside WSL2, e.g.
 ```PowerShell
 > wsl -d Ubuntu ./build/build-in-docker clean install -DGPU_ACRCHS=NATIVE -Dtest="*,!CuFileTest"
@@ -244,7 +243,7 @@ arguments to get into an interactive shell inside the container.
 
 #### Testing with Compute Sanitizer
 [Compute Sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) is a
-functional correctness checking suite included in the CUDA toolkit. The RAPIDS Accelerator JNI
+functional correctness checking suite included in the CUDA toolkit. The cuDF plugin JNI
 supports leveraging the Compute Sanitizer in memcheck mode in the unit tests to help catch any kernels
 that may be doing something incorrectly. To run the unit tests with the Compute Sanitizer, append the
 `-DUSE_SANITIZER=ON` to the build command. e.g.
@@ -276,7 +275,7 @@ class NormalCaseTest {
 ```
 
 ### Debugging
-You can add debug symbols selectively to C++ files in spark-rapids-jni by modifying the appropriate
+You can add debug symbols selectively to C++ files in cudf-spark-jni by modifying the appropriate
 `CMakeLists.txt` files. You will need to add a specific flag depending on what kind of code you are
 debugging. For CUDA code, you need to add the `-G` flag to add device debug symbols:
 
@@ -305,8 +304,8 @@ bash-4.2$ cuda-gdb target/jni/cmake-build/gtests/ROW_CONVERSION
 You can also use the [NVIDIA Nsight VSCode Code Integration](https://docs.nvidia.com/nsight-visual-studio-code-edition/latest/cuda-debugger/index.html)
 as well to debug within Visual Studio Code.
 
-To debug libcudf code, please see [Debugging cuDF](https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md#debugging-cudf)
-in the cuDF [CONTRIBUTING](https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md) guide.
+To debug libcudf code, please see [Debugging cuDF](https://github.com/nvidia/cudf/blob/main/CONTRIBUTING.md#debugging-cudf)
+in the cuDF [CONTRIBUTING](https://github.com/nvidia/cudf/blob/main/CONTRIBUTING.md) guide.
 
 ### Benchmarks
 Benchmarks exist for c++ benchmarks using NVBench and are in the `src/main/cpp/benchmarks` directory.
@@ -321,15 +320,15 @@ script can be run without any arguments to get into an interactive shell inside 
 
 ### Your first issue
 
-1. Read the [Developer Overview](https://github.com/NVIDIA/spark-rapids/blob/main/docs/dev/README.md)
-    to understand how the RAPIDS Accelerator plugin works.
+1. Read the [Developer Overview](https://github.com/NVIDIA/cudf-spark/blob/main/docs/dev/README.md)
+    to understand how the cuDF plugin works.
 2. Find an issue to work on. The best way is to look for the
-    [good first issue](https://github.com/NVIDIA/spark-rapids-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-    or [help wanted](https://github.com/NVIDIA/spark-rapids-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+    [good first issue](https://github.com/NVIDIA/cudf-spark-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+    or [help wanted](https://github.com/NVIDIA/cudf-spark-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
     labels.
 3. Comment on the issue stating that you are going to work on it.
 4. Code! Make sure to add or update unit tests if needed!
-5. When done, [create your pull request](https://github.com/NVIDIA/spark-rapids-jni/compare).
+5. When done, [create your pull request](https://github.com/NVIDIA/cudf-spark-jni/compare).
 6. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/).
     Fix if needed.
 7. Wait for other developers to review your code and update code as needed.
@@ -349,7 +348,7 @@ This Java code in this project (`src/main/java`) follows the
 #### C++
 
 The C++ code in this project (`src/main/cpp`) follows the
-[coding style from `rapidsai/cudf` repository](https://github.com/rapidsai/cudf/blob/main/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md#code-and-documentation-style-and-formatting).
+[coding style from `nvidia/cudf` repository](https://github.com/nvidia/cudf/blob/main/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md#code-and-documentation-style-and-formatting).
 
 We also provide a precommit-hook to format code using cudf's C++ `clang-format` style.
 To use precommit-hook, install it on your system such as using `conda` or `pip`:
@@ -434,4 +433,4 @@ By making a contribution to this project, I certify that:
 ```
 
 ## Attribution
-Portions adopted from https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/main/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md
+Portions adopted from https://github.com/nvidia/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/main/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ so it should be invoked as one would invoke Maven, e.g.: `build/build-in-docker 
 #### Using the cudf-spark-jni Docker Container with other Repos
 
 The cuDF plugin project spans multiple repos. Some issues are discovered in
-cudf-spark-jni but they need to be made easily reproducible in the cudf repo. 
+cudf-spark-jni but they need to be made easily reproducible in the cudf repo.
 To this end export WORKDIR with the path pointing to a different repo
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
-# Contributing to RAPIDS Accelerator JNI for Apache Spark
+# Contributing to the NVIDIA cuDF plugin JNI for Apache Spark
 
-Contributions to RAPIDS Accelerator JNI for Apache Spark fall into the following three categories.
+Contributions to the NVIDIA cuDF plugin JNI for Apache Spark fall into the following three categories.
 
 1. To report a bug, request a new feature, or report a problem with
-    documentation, please file an [issue](https://github.com/NVIDIA/spark-rapids-jni/issues/new/choose)
+    documentation, please file an [issue](https://github.com/NVIDIA/cudf-spark-jni/issues/new/choose)
     describing in detail the problem or new feature. The project team evaluates
     and triages issues, and schedules them for a release. If you believe the
     issue needs priority attention, please comment on the issue to notify the
     team.
 2. To propose and implement a new Feature, please file a new feature request
-    [issue](https://github.com/NVIDIA/spark-rapids-jni/issues/new/choose). Describe the
+    [issue](https://github.com/NVIDIA/cudf-spark-jni/issues/new/choose). Describe the
     intended feature and discuss the design and implementation with the team and
     community. Once the team agrees that the plan looks good, go ahead and
     implement it using the [code contributions](#code-contributions) guide below.
@@ -42,17 +42,17 @@ git submodule update --init --recursive
 ## Building From Source
 
 [Maven](https://maven.apache.org) is used for most aspects of the build. For example, the
-Maven `package` goal can be used to build the RAPIDS Accelerator JNI jar. After a successful
-build the RAPIDS Accelerator JNI jar will be in the `spark-rapids-jni/target/` directory.
+Maven `package` goal can be used to build the cuDF plugin JNI jar. After a successful
+build the cuDF plugin JNI jar will be in the `cudf-spark-jni/target/` directory.
 Be sure to select the jar with the CUDA classifier.
 
-When building spark-rapids-jni, the pom.xml in the submodule thirdparty/cudf is completely
+When building cudf-spark-jni, the pom.xml in the submodule thirdparty/cudf is completely
 bypassed. For a detailed explanation please read
-[this](https://github.com/NVIDIA/spark-rapids-jni/issues/1084#issuecomment-1513471739).
+[this](https://github.com/NVIDIA/cudf-spark-jni/issues/1084#issuecomment-1513471739).
 
 ### Building in the Docker Container
 
-The `build/build-in-docker` script will build the spark-rapids-jni artifact within a Docker
+The `build/build-in-docker` script will build the cudf-spark-jni artifact within a Docker
 container using devtoolset to produce native code that can run on all supported Linux
 distributions. The repo directory is bind-mounted into the container and the container runs
 as the current user, so the artifacts are produced as if they were built or installed outside
@@ -61,16 +61,15 @@ the Docker container.
 The script passes all of its arguments onto the Maven command run inside the Docker container,
 so it should be invoked as one would invoke Maven, e.g.: `build/build-in-docker clean package`
 
-#### Using spark-rapids-jni Docker Container with other Repos
+#### Using the cudf-spark-jni Docker Container with other Repos
 
-Spark RAPIDS project spans multiple repos. Some issues are discovered in
-spark-rapids-jni but they need to be made easily reproducible in the cudf repo
-
+The cuDF plugin project spans multiple repos. Some issues are discovered in
+cudf-spark-jni but they need to be made easily reproducible in the cudf repo. 
 To this end export WORKDIR with the path pointing to a different repo
 
 ```
-export WORKDIR=~/gits/rapidsai/cudf
-~/gits/NVIDIA/spark-rapids-jni/build/run-in-docker head README.md
+export WORKDIR=~/gits/nvidia/cudf
+~/gits/NVIDIA/cudf-spark-jni/build/run-in-docker head README.md
 ```
 
 `run-in-docker` defaults `CCACHE_BASEDIR` to `WORKDIR`, allowing equivalent Release builds
@@ -80,7 +79,7 @@ disabling ccache's `hash_dir` instead can embed an incorrect working directory i
 
 ### cudf Submodule and Build
 
-[RAPIDS cuDF](https://github.com/rapidsai/cudf) is being used as a submodule in this project.
+[NVIDIA cuDF](https://github.com/nvidia/cudf) is being used as a submodule in this project.
 
 Currently libcudf is only configured once and the build relies on cmake to re-configure as needed.
 This is because libcudf currently is rebuilding almost entirely when it is configured with the same
@@ -107,33 +106,33 @@ to control aspects of the build:
 | `submodule.check.skip`               | Whether to skip checking git submodules | false   |
 
 
-### Local testing of cross-repo contributions cudf, spark-rapids-jni, and spark-rapids
+### Local testing of cross-repo contributions cudf, cudf-spark-jni, and cudf-spark
 
 When we work on a feature or a bug fix across repositories, it is beneficial to be able to
 run manual and integration tests end to end on the full stack from Apache Spark
-with spark-rapids plugin upfront before merging the PRs.
+with cuDF plugin upfront before merging the PRs.
 
 So we are dealing with a subset of the following:
 
 Local PR branches for
-- rapidsai/cuDF, branch pr1
-- NVIDIA/spark-rapids-jni, branch pr2
-- NVIDIA/spark-rapids, branch pr3
+- NVIDIA/cuDF, branch pr1
+- NVIDIA/cudf-spark-jni, branch pr2
+- NVIDIA/cudf-spark, branch pr3
 
 Our end goal is to build the rapids-4-spark dist jar in the pr3 branch under local repo path
-~/repos/NVIDIA/spark-rapids that includes changes from the pr2 branch in
-~/repos/NVIDIA/spark-rapids-jni and the pr1 branch in rapidsai/cuDF that we will test
+~/repos/NVIDIA/cudf-spark that includes changes from the pr2 branch in
+~/repos/NVIDIA/cudf-spark-jni and the pr1 branch in NVIDIA/cudf that we will test
 with Spark. There are two options for working on pr1.
 
-#### Option 1: Working on cuDF PR inside the the submodule in spark-rapids-jni
+#### Option 1: Working on cuDF PR inside the the submodule in cudf-spark-jni
 To avoid retargeting the submodule to the local cuDF repo as below, we might find it easier
-to make changes locally under ~/repos/NVIDIA/spark-rapids-jni/thirdparty/cudf directly.
+to make changes locally under ~/repos/NVIDIA/cudf-spark-jni/thirdparty/cudf directly.
 
 In order to push pr1 to create a pull request, we need to add a remote to the submodule for the cuDF
 fork in our account
 
 ```bash
-$ cd ~/repos/NVIDIA/spark-rapids-jni/thirdparty/cudf
+$ cd ~/repos/NVIDIA/cudf-spark-jni/thirdparty/cudf
 $ git remote add <user> git@github.com:<user>/cudf.git
 # make and commit changes
 $ git push <user>
@@ -141,27 +140,27 @@ $ git push <user>
 
 #### Option 2: Working on cuDF PR in a conventional local cuDF fork
 Once we are done with our changes to the pr1 branch in
-~/repos/rapidsai/cuDF, we git commit changes locally.
+~/repos/nvidia/cudf, we git commit changes locally.
 
-Then we cd to ~/repos/NVIDIA/spark-rapids-jni and point the cudf submodule temporarily to the pr1
+Then we cd to ~/repos/NVIDIA/cudf-spark-jni and point the cudf submodule temporarily to the pr1
 branch
 
 ```bash
-$ git submodule set-url thirdparty/cudf ~/repos/rapidsai/cudf
+$ git submodule set-url thirdparty/cudf ~/repos/nvidia/cudf
 $ git submodule set-branch --branch pr1 thirdparty/cudf
 ```
 
-Sync pr1 into our pr2 branch in ~/repos/NVIDIA/spark-rapids-jni
+Sync pr1 into our pr2 branch in ~/repos/NVIDIA/cudf-spark-jni
 ```bash
 $ git submodule sync --recursive
 $ git submodule update --init --recursive --remote
 ```
 
-#### Building final spark-rapids artifact with pr1, pr2, and pr3 changes
+#### Building final cuDF plugin artifact with pr1, pr2, and pr3 changes
 Regardless what option we have used to make cuDF changes, we proceed with building
-spark-rapids-jni. The spark-rapids repo will consume spark-rapids-jni with pr1 and pr2 changes
+cudf-spark-jni. The cudf-spark repo will consume cudf-spark-jni with pr1 and pr2 changes
 from the local Maven cache after we run `mvn install` via `build/build-in-docker`
-in ~/repos/NVIDIA/spark-rapids-jni.
+in ~/repos/NVIDIA/cudf-spark-jni.
 
 Make sure to stage thirdparty/cudf with `git add` to satifsfy build's submodule check.
 ```bash
@@ -169,8 +168,8 @@ $ git add thirdparty/cudf
 $ ./build/build-in-docker install ...
 ```
 
-Now cd to ~/repos/NVIDIA/spark-rapids and build with one of the options from
-[spark-rapids instructions](https://github.com/NVIDIA/spark-rapids/blob/main/CONTRIBUTING.md#building-from-source).
+Now cd to ~/repos/NVIDIA/cudf-spark and build with one of the options from
+[cuDF plugin instructions](https://github.com/NVIDIA/cudf-spark/blob/main/CONTRIBUTING.md#building-from-source).
 
 ```bash
 $ ./build/buildall
@@ -181,7 +180,7 @@ the final rapids-4-spark artifact includes the locally built dependencies as opp
 CI-built snapshot dependencies from the remote Maven repo. This may happen even if Maven
 is invoked with `--offline` or `--no-snapshot-updates` option due to IDE-Maven
 interactions in the background. To confirm that the artifact is correct we can either enable
-[INFO logging in Spark](https://github.com/NVIDIA/spark-rapids/blob/4c77f0db58d229b2e6cb75c196934fcc0ae3a485/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala#L73-L83)
+[INFO logging in Spark](https://github.com/NVIDIA/cudf-spark/blob/4c77f0db58d229b2e6cb75c196934fcc0ae3a485/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala#L73-L83)
 or directly inspect the resulting jar for build info:
 ```bash
 $ unzip -c dist/target/rapids-4-spark_2.12-22.08.0-SNAPSHOT-cuda12.jar *version-info.properties
@@ -192,7 +191,7 @@ user=
 revision=62657ad6a296ea3547417504652e3b8836b020fb
 branch=testCUDF_pr1
 date=2022-07-19T21:48:15Z
-url=https://github.com/rapidsai/cudf.git
+url=https://github.com/nvidia/cudf.git
 
   inflating: spark-rapids-jni-version-info.properties
 version=22.08.0-SNAPSHOT
@@ -200,7 +199,7 @@ user=
 revision=70adcc86a513ad6665968021c669fbca7515a188
 branch=pr/user1/381
 date=2022-07-19T21:48:15Z
-url=git@github.com:NVIDIA/spark-rapids-jni.git
+url=git@github.com:NVIDIA/cudf-spark-jni.git
 
   inflating: rapids4spark-version-info.properties
 version=22.08.0-SNAPSHOT
@@ -209,15 +208,15 @@ user=user1
 revision=6453047ef479b5ec79384c5150c50af2f50f563e
 branch=aqeFinalPlanOnGPUDoc
 date=2022-07-19T21:51:52Z
-url=https://github.com/NVIDIA/spark-rapids
+url=https://github.com/NVIDIA/cudf-spark
 ```
 and verify that the branch names and the revisions in the console output
 correspond the local repos.
 
-When we are ready to move on, prior to switching to another spark-rapids-jni branch
-or submiting a PR to NVIDIA/spark-rapids-jni, we should undo the cudf submodule modifications.
+When we are ready to move on, prior to switching to another cudf-spark-jni branch
+or submiting a PR to NVIDIA/cudf-spark-jni, we should undo the cudf submodule modifications.
 ```
-$ cd ~/repos/NVIDIA/spark-rapids-jni
+$ cd ~/repos/NVIDIA/cudf-spark-jni
 $ git restore .gitmodules
 $ git restore --staged thirdparty/cudf
 ```
@@ -231,7 +230,7 @@ Ubuntu distro WSL2 instance to be able to run `build/build-in-docker` above.
 > .\build\win\create-wsl2.ps1
 ```
 
-Clone spark-rapids-jni inside or outside (convenient but slower filesystem) the distro,
+Clone cudf-spark-jni inside or outside (convenient but slower filesystem) the distro,
 and build inside WSL2, e.g.
 ```PowerShell
 > wsl -d Ubuntu ./build/build-in-docker clean install -DGPU_ACRCHS=NATIVE -Dtest="*,!CuFileTest"
@@ -249,7 +248,7 @@ arguments to get into an interactive shell inside the container.
 
 #### Testing with Compute Sanitizer
 [Compute Sanitizer](https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html) is a
-functional correctness checking suite included in the CUDA toolkit. The RAPIDS Accelerator JNI
+functional correctness checking suite included in the CUDA toolkit. The cuDF plugin JNI
 supports leveraging the Compute Sanitizer in memcheck mode in the unit tests to help catch any kernels
 that may be doing something incorrectly. To run the unit tests with the Compute Sanitizer, append the
 `-DUSE_SANITIZER=ON` to the build command. e.g.
@@ -281,7 +280,7 @@ class NormalCaseTest {
 ```
 
 ### Debugging
-You can add debug symbols selectively to C++ files in spark-rapids-jni by modifying the appropriate
+You can add debug symbols selectively to C++ files in cudf-spark-jni by modifying the appropriate
 `CMakeLists.txt` files. You will need to add a specific flag depending on what kind of code you are
 debugging. For CUDA code, you need to add the `-G` flag to add device debug symbols:
 
@@ -310,8 +309,8 @@ bash-4.2$ cuda-gdb target/jni/cmake-build/gtests/ROW_CONVERSION
 You can also use the [NVIDIA Nsight VSCode Code Integration](https://docs.nvidia.com/nsight-visual-studio-code-edition/latest/cuda-debugger/index.html)
 as well to debug within Visual Studio Code.
 
-To debug libcudf code, please see [Debugging cuDF](https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md#debugging-cudf)
-in the cuDF [CONTRIBUTING](https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md) guide.
+To debug libcudf code, please see [Debugging cuDF](https://github.com/nvidia/cudf/blob/main/CONTRIBUTING.md#debugging-cudf)
+in the cuDF [CONTRIBUTING](https://github.com/nvidia/cudf/blob/main/CONTRIBUTING.md) guide.
 
 ### Benchmarks
 Benchmarks exist for c++ benchmarks using NVBench and are in the `src/main/cpp/benchmarks` directory.
@@ -326,15 +325,15 @@ script can be run without any arguments to get into an interactive shell inside 
 
 ### Your first issue
 
-1. Read the [Developer Overview](https://github.com/NVIDIA/spark-rapids/blob/main/docs/dev/README.md)
-    to understand how the RAPIDS Accelerator plugin works.
+1. Read the [Developer Overview](https://github.com/NVIDIA/cudf-spark/blob/main/docs/dev/README.md)
+    to understand how the cuDF plugin works.
 2. Find an issue to work on. The best way is to look for the
-    [good first issue](https://github.com/NVIDIA/spark-rapids-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-    or [help wanted](https://github.com/NVIDIA/spark-rapids-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+    [good first issue](https://github.com/NVIDIA/cudf-spark-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+    or [help wanted](https://github.com/NVIDIA/cudf-spark-jni/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
     labels.
 3. Comment on the issue stating that you are going to work on it.
 4. Code! Make sure to add or update unit tests if needed!
-5. When done, [create your pull request](https://github.com/NVIDIA/spark-rapids-jni/compare).
+5. When done, [create your pull request](https://github.com/NVIDIA/cudf-spark-jni/compare).
 6. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/).
     Fix if needed.
 7. Wait for other developers to review your code and update code as needed.
@@ -354,7 +353,7 @@ This Java code in this project (`src/main/java`) follows the
 #### C++
 
 The C++ code in this project (`src/main/cpp`) follows the
-[coding style from `rapidsai/cudf` repository](https://github.com/rapidsai/cudf/blob/main/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md#code-and-documentation-style-and-formatting).
+[coding style from `nvidia/cudf` repository](https://github.com/nvidia/cudf/blob/main/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md#code-and-documentation-style-and-formatting).
 
 We also provide a precommit-hook to format code using cudf's C++ `clang-format` style.
 To use precommit-hook, install it on your system such as using `conda` or `pip`:
@@ -439,4 +438,4 @@ By making a contribution to this project, I certify that:
 ```
 
 ## Attribution
-Portions adopted from https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/main/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md
+Portions adopted from https://github.com/nvidia/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/main/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-RAPIDS Accelerator JNI For Apache Spark
-Copyright (c) 2022-2024, NVIDIA CORPORATION
+NVIDIA cuDF plugin JNI for Apache Spark
+Copyright (c) 2022-2026, NVIDIA CORPORATION
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains native support code for the
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/cudf-spark-jni)
 
 Note: The NVIDIA cuDF plugin for Apache Spark was formerly known as the RAPIDS Accelerator for
-Apache Spark.  The RAPIDS name will be sunset over time.  Github links from `spark-rapids` will
-redirect to `cudf-spark`.  Artifact names will remain the same for now.
+Apache Spark.  The RAPIDS name will be sunset over time.  GitHub links from `spark-rapids-jni` will
+redirect to `cudf-spark-jni`.  Artifact names will remain the same for now.
 
 ## Building From Source
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-# RAPIDS Accelerator JNI For Apache Spark
+# NVIDIA cuDF plugin JNI for Apache Spark
 
 This repository contains native support code for the
-[RAPIDS Accelerator for Apache Spark](https://github.com/NVIDIA/spark-rapids).
+[NVIDIA cuDF plugin for Apache Spark](https://github.com/NVIDIA/cudf-spark).
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/spark-rapids-jni)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/cudf-spark-jni)
+
+Note: The NVIDIA cuDF plugin for Apache Spark was formerly known as the RAPIDS Accelerator for
+Apache Spark.  The RAPIDS name will be sunset over time.  Github links from `spark-rapids` will
+redirect to `cudf-spark`.  Artifact names will remain the same for now.
 
 ## Building From Source
 

--- a/build/Dockerfile.devel
+++ b/build/Dockerfile.devel
@@ -15,7 +15,7 @@
 #
 
 ###
-# Build the image for spark-rapids-jni local development environment.
+# Build the image for cudf-spark-jni local development environment.
 
 # Inherit from the CICD docker image
 ARG JNI_DOCKER_CICD_IMAGE

--- a/build/apply-patches
+++ b/build/apply-patches
@@ -32,7 +32,7 @@ PATCH_DIR=$(realpath "$PATCH_DIR")
 CUDF_DIR=${CUDF_DIR:-$(realpath "$BASE_DIR/thirdparty/cudf/")}
 
 # Apply pattches to CUDF is problematic in a number of ways. But ultimately it comes down to
-# making sure that a user can do development work in spark-rapids-jni without the patches
+# making sure that a user can do development work in cudf-spark-jni without the patches
 # getting in the way
 # The operations I really want to support no matter what state CUDF is in are
 # 1) Build the repo from scratch

--- a/build/build-in-docker
+++ b/build/build-in-docker
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Build the spark-rapids-jni artifact in a Docker container with devtoolset
+# Build the cudf-spark-jni artifact in a Docker container with devtoolset
 
 set -e
 

--- a/build/buildcpp.sh
+++ b/build/buildcpp.sh
@@ -16,7 +16,7 @@
 #
 
 #
-# Script to build native code in cudf and spark-rapids-jni
+# Script to build native code in cudf and cudf-spark-jni
 #
 
 set -e
@@ -163,7 +163,7 @@ cmake --build "$LIBCUDFJNI_BUILD_PATH" "-j$CPP_PARALLEL_LEVEL"
 #
 mkdir -p "$SPARK_JNI_BUILD_PATH"
 cd "$SPARK_JNI_BUILD_PATH"
-echo "Configuring spark-rapids-jni native libs"
+echo "Configuring cudf-spark-jni native libs"
 CUDF_ROOT="$CUDF_PATH" \
   CUDF_INSTALL_DIR="$LIBCUDF_INSTALL_PATH" \
   CUDFJNI_BUILD_DIR="$LIBCUDFJNI_BUILD_PATH" \
@@ -183,5 +183,5 @@ CUDF_ROOT="$CUDF_PATH" \
 
 create_compile_commands_symlink "$SPARK_JNI_BUILD_PATH" "$PROJECT_BASE_DIR/src/main/cpp"
 
-echo "Building spark-rapids-jni native libs"
+echo "Building cudf-spark-jni native libs"
 cmake --build "$SPARK_JNI_BUILD_PATH" "-j$CPP_PARALLEL_LEVEL"

--- a/build/unapply-patches
+++ b/build/unapply-patches
@@ -37,7 +37,7 @@ if [ -d "$PATCH_DIR" ] ; then
 fi
 
 # Apply pattches to CUDF is problematic in a number of ways. But ultimately it comes down to
-# making sure that a user can do development work in spark-rapids-jni without the patches
+# making sure that a user can do development work in cudf-spark-jni without the patches
 # getting in the way
 # The operations I really want to support no matter what state CUDF is in are
 # 1) Build the repo from scratch

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 ###
-# Build the image for spark-rapids-jni CICD environment.
+# Build the image for cudf-spark-jni CICD environment.
 #
 # Arguments: CUDA_VERSION=[12.X.Y], OS_RELEASE=[8, 9], TARGETPLATFORM=[linux/amd64, linux/arm64]
 #

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -17,7 +17,7 @@
 
 /**
  *
- * Jenkinsfile for building spark-rapids-jni on blossom
+ * Jenkinsfile for building cudf-spark-jni on blossom
  *
  */
 import hudson.model.Result

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -48,7 +48,7 @@ fi
 if [ "${CUDA_VER}" == "cuda13" ]; then
   BUILD_FAULTINJ="OFF"
   BUILD_PROFILER="OFF"
-  # Disable sanitizer https://github.com/NVIDIA/spark-rapids-jni/issues/4127
+  # Disable sanitizer https://github.com/NVIDIA/cudf-spark-jni/issues/4127
   USE_SANITIZER="OFF"
 fi
 

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -28,8 +28,8 @@ REPO=${REPO:-"cudf-spark-jni"}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 REPO_LOC="github.com/${OWNER}/${REPO}.git"
 
-GIT_AUTHOR_NAME="spark-rapids automation"
-GIT_COMMITTER_NAME="spark-rapids automation"
+GIT_AUTHOR_NAME="cudf-spark automation"
+GIT_COMMITTER_NAME="cudf-spark automation"
 GIT_AUTHOR_EMAIL="70000568+nvauto@users.noreply.github.com"
 GIT_COMMITTER_EMAIL="70000568+nvauto@users.noreply.github.com"
 git submodule update --init --recursive

--- a/docs/memory_management.md
+++ b/docs/memory_management.md
@@ -1,12 +1,12 @@
 ## Memory Management Overview
 
 Effective memory management is crucial for processing queries successfully with limited memory resources.
-The Spark-RAPIDS plugin leverages the [RAPIDS Memory Manager (RMM)](https://github.com/rapidsai/rmm) to handle and recover from out-of-memory (OOM) errors during query processing. This document describes the mechanisms and the state management implemented in [SparkResourceAdaptorJni.cpp](../src/main/cpp/src/SparkResourceAdaptorJni.cpp). The plugin tracks every memory allocation and deallocation request to handle various OOM situations. It chooses the appropriate recovery mechanism, such as spilling, rollback-and-retry, or split-and-retry, based on the situation. If recovery is not possible, the plugin fails gracefully.
+The NVIDIA cuDF plugin for Apache Spark leverages the [RAPIDS Memory Manager (RMM)](https://github.com/rapidsai/rmm) to handle and recover from out-of-memory (OOM) errors during query processing. This document describes the mechanisms and the state management implemented in [SparkResourceAdaptorJni.cpp](../src/main/cpp/src/SparkResourceAdaptorJni.cpp). The plugin tracks every memory allocation and deallocation request to handle various OOM situations. It chooses the appropriate recovery mechanism, such as spilling, rollback-and-retry, or split-and-retry, based on the situation. If recovery is not possible, the plugin fails gracefully.
 
 
 ### Handling Out-of-Memory Errors
 
-The Spark-RAPIDS plugin manages both device memory and host memory (optional). It tracks all memory allocations to detect OOM errors. While an allocation request succeeds, the plugin does not interfere with the running threads. However, when the allocation request fails due to insufficient memory, the plugin pauses the requesting thread and allows it to retry later when more memory becomes available. The plugin employs several strategies to free up memory:
+The cuDF plugin manages both device memory and host memory (optional). It tracks all memory allocations to detect OOM errors. While an allocation request succeeds, the plugin does not interfere with the running threads. However, when the allocation request fails due to insufficient memory, the plugin pauses the requesting thread and allows it to retry later when more memory becomes available. The plugin employs several strategies to free up memory:
 
 - Spilling: Data marked as spillable is moved out of memory.
 - Rollback: If no thread can make progress even after spilling, the plugin starts rolling back threads to the point where their inputs are spillable, allowing other thread to proceed.
@@ -16,7 +16,7 @@ If no further splitting is possible, the plugin gracefully cancels the query and
 
 ### State Machine for OOM Handler
 
-To handle various OOM situations, the Spark-RAPIDS plugin keeps track of the state of individual threads. Note that one Spark task can use multiple threads during execution.
+To handle various OOM situations, the cuDF plugin keeps track of the state of individual threads. Note that one Spark task can use multiple threads during execution.
 
 A thread can have one of these states at a time:
 
@@ -37,7 +37,7 @@ The thread state can change based on the diagram below. Note that the thread sta
 
 ### Thread Priority
 
-The Spark-RAPIDS plugin uses thread priority to break ties between threads.
+The cuDF plugin uses thread priority to break ties between threads.
 Note that the thread priority is currently decoupled from query priority. Each task thread is assigned a priority based on their `task_id` and `thread_id`. 
 Shuffle threads have the highest priority to avoid priority inversion as the task threads may depend on the shuffle indirectly.
 
@@ -58,7 +58,7 @@ The selected thread transitions its state to `THREAD_SPLIT_THROW` and throws an 
 From the view of the OOM state machine, each task has one or more "dedicated threads", along with zero or more "pool threads" (background threads). When checking whether a task is blocked, OOM state machine is lenient on dedicated threads (only require any one of the dedicated threads to be blocked), but stringent on pool threads (all pool threads must be blocked). Being treated leniently is not always a good thing, it increases the chance of being mistakenly identified as a blocked task, thus causing unnecessary deadlock resolution. So we don't want a thread to be treated as a dedicated thread unless it is really necessary. There are two ways of avoiding a thread being treated as a dedicated thread:
 
 1. Avoid calling TaskContext.setTaskContext() in the current thread, this will prevent OOM state machine connecting the current thread to the task as a dedicated thread. 
-2. Proactively register thread itself as a pool thread instead of a dedicated thread. An example can be found [here](https://github.com/NVIDIA/spark-rapids/blob/c39f6a6004b0cf684ca526172e87b2bd4481eb3a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala#L2056) for registering threads. (Don't forget to unregister the thread when it is done.)
+2. Proactively register thread itself as a pool thread instead of a dedicated thread. An example can be found [here](https://github.com/NVIDIA/cudf-spark/blob/c39f6a6004b0cf684ca526172e87b2bd4481eb3a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala#L2056) for registering threads. (Don't forget to unregister the thread when it is done.)
 
 In most cases, we recommend the second approach, because typically the main task and the background thread will form a producer-consumer relationship. The main task thread, which plays as a consumer, will typically wait for the background thread to produce data. If we choose approach 1 then while consumer is waiting, its Java thread state will be `WAITING`, and even if the producer is actively working (so the whole task should NOT be considered as blocked), the OOM state machine will mistakenly consider it as a blocked task because it cannot find any "pool thread" connected with this task. So "has at least one dedicated thread blocked on memory allocation, and all of the pool threads working on that task are also blocked" stands. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,11 @@
   <artifactId>spark-rapids-jni</artifactId>
   <version>26.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>RAPIDS Accelerator JNI for Apache Spark</name>
+  <name>cuDF plugin JNI for Apache Spark</name>
   <description>
-    Native code and CUDA kernels specific to the RAPIDS Accelerator for Apache Spark
+    Native code and CUDA kernels specific to the NVIDIA cuDF plugin for Apache Spark
   </description>
-  <url>http://github.com/NVIDIA/spark-rapids-jni</url>
+  <url>http://github.com/NVIDIA/cudf-spark-jni</url>
 
   <licenses>
     <license>
@@ -38,10 +38,10 @@
     </license>
   </licenses>
   <scm>
-    <connection>scm:git:https://github.com/NVIDIA/spark-rapids-jni.git</connection>
-    <developerConnection>scm:git:git@github.com:NVIDIA/spark-rapids-jni.git</developerConnection>
+    <connection>scm:git:https://github.com/NVIDIA/cudf-spark-jni.git</connection>
+    <developerConnection>scm:git:git@github.com:NVIDIA/cudf-spark-jni.git</developerConnection>
     <tag>HEAD</tag>
-    <url>https://github.com/NVIDIA/spark-rapids-jni</url>
+    <url>https://github.com/NVIDIA/cudf-spark-jni</url>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <artifactId>spark-rapids-jni</artifactId>
   <version>26.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>cuDF plugin JNI for Apache Spark</name>
+  <name>NVIDIA cuDF plugin JNI for Apache Spark</name>
   <description>
     Native code and CUDA kernels specific to the NVIDIA cuDF plugin for Apache Spark
   </description>

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -155,10 +155,10 @@ else()
 endif()
 
 # cuCollections
-# As of rapidsai/cudf PR #22277 (commit 5a375a3417ef70c55564bd0c4c6255a2da5dca49), libcudf
+# As of nvidia/cudf PR #22277 (commit 5a375a3417ef70c55564bd0c4c6255a2da5dca49), libcudf
 # wraps its `cuco::cuco` link with `$<BUILD_LOCAL_INTERFACE:...>`, so the cuco headers are no
 # longer transitively exposed to downstream consumers via `find_package(cudf)`. Several
-# spark-rapids-jni sources (e.g. the hash kernels) include cudf detail headers that pull in
+# cudf-spark-jni sources (e.g. the hash kernels) include cudf detail headers that pull in
 # `<cuco/hash_functions.cuh>`, so we need to fetch cuco ourselves.
 include(${rapids-cmake-dir}/cpm/cuco.cmake)
 rapids_cpm_cuco()

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -50,7 +50,7 @@ project(
 
 # We use no C++20 modules; disable module scanning so CMake emits no ninja dyndep phase. Otherwise
 # its dyndep refresh trips ninja's RefreshDyndepDependents assertion on incremental rebuilds after
-# a structural source change. Mirrors libcudf (rapidsai/cudf#19192).
+# a structural source change. Mirrors libcudf (nvidia/cudf#19192).
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 # ##################################################################################################

--- a/src/main/cpp/faultinj/README.md
+++ b/src/main/cpp/faultinj/README.md
@@ -22,7 +22,7 @@ The tool is a dynamically linked library `libcufaultinj.so` that is loaded by
 the CUDA process via CUDA Driver API `cuInit` if it is provided
 via the `CUDA_INJECTION64_PATH` environment variable.
 
-As an example it can be used to test RAPIDS Accelerator for Apache Spark.
+As an example it can be used to test the NVIDIA cuDF plugin for Apache Spark.
 Consult documentation to find how to set these variables correctly in the
 context of the framework under test.
 

--- a/src/main/cpp/profiler/README.md
+++ b/src/main/cpp/profiler/README.md
@@ -1,6 +1,7 @@
-# Spark Rapids Profile Converter Tool
+# NVIDIA cuDF plugin for Apache Spark Profile Converter Tool
 
-This directory contains the Spark Rapids Profile Converter, a tool for converting NVTX profiling data from the Spark Rapids JNI library.
+This directory contains the NVIDIA cuDF plugin for Apache Spark Profile Converter, a tool for
+converting NVTX profiling data from the cuDF plugin JNI library. 
 
 ## Building the Tool
 

--- a/src/main/cpp/profiler/README.md
+++ b/src/main/cpp/profiler/README.md
@@ -1,7 +1,7 @@
 # NVIDIA cuDF plugin for Apache Spark Profile Converter Tool
 
 This directory contains the NVIDIA cuDF plugin for Apache Spark Profile Converter, a tool for
-converting NVTX profiling data from the cuDF plugin JNI library. 
+converting NVTX profiling data from the cuDF plugin JNI library.
 
 ## Building the Tool
 

--- a/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
+++ b/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
@@ -114,7 +114,7 @@ void print_usage()
 {
   std::cout << "spark_rapids_profile_converter [OPTION]... profilebin" << std::endl;
   std::cout << R"(
-Converts the spark-rapids profile in profile.bin into other forms.
+Converts the cuDF plugin profile in profile.bin into other forms.
 
   -h, --help                show this usage message
   -j, --json                convert to JSON, default output is stdout
@@ -366,7 +366,7 @@ void verify_profile_header(std::ifstream& in)
   auto header = validate_fb<spark_rapids_jni::profiler::ProfileHeader>(*fb_ptr, "profile header");
   auto magic  = header->magic();
   if (magic == nullptr) {
-    throw std::runtime_error("does not appear to be a spark-rapids profile");
+    throw std::runtime_error("does not appear to be a cuDF plugin profile");
   }
   if (magic->str() != "spark-rapids profile") {
     std::ostringstream oss;

--- a/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
+++ b/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
@@ -365,9 +365,7 @@ void verify_profile_header(std::ifstream& in)
   auto fb_ptr = read_flatbuffer(in);
   auto header = validate_fb<spark_rapids_jni::profiler::ProfileHeader>(*fb_ptr, "profile header");
   auto magic  = header->magic();
-  if (magic == nullptr) {
-    throw std::runtime_error("does not appear to be a cuDF plugin profile");
-  }
+  if (magic == nullptr) { throw std::runtime_error("does not appear to be a cuDF plugin profile"); }
   if (magic->str() != "spark-rapids profile") {
     std::ostringstream oss;
     oss << "bad profile magic, expected 'spark-rapids profile' found '" << magic->str() << "'";

--- a/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
+++ b/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* A tool that converts a spark-rapids profile binary into other forms. */
+/* A tool that converts a cuDF plugin profile binary into other forms. */
 
 #if 0
 #include <stdexcept>

--- a/src/main/cpp/src/NVMLJni.cpp
+++ b/src/main/cpp/src/NVMLJni.cpp
@@ -21,7 +21,7 @@
 #include <bit>
 #include <cstdint>
 
-// NVML JNI implementation with comprehensive GPU metrics for Spark Rapids
+// NVML JNI implementation with comprehensive GPU metrics for the NVIDIA cuDF plugin for Apache Spark
 
 #define NVML_CLASS_PATH "com/nvidia/spark/rapids/jni/nvml/"
 

--- a/src/main/cpp/src/NVMLJni.cpp
+++ b/src/main/cpp/src/NVMLJni.cpp
@@ -21,7 +21,8 @@
 #include <bit>
 #include <cstdint>
 
-// NVML JNI implementation with comprehensive GPU metrics for the NVIDIA cuDF plugin for Apache Spark
+// NVML JNI implementation with comprehensive GPU metrics for the NVIDIA cuDF plugin for Apache
+// Spark
 
 #define NVML_CLASS_PATH "com/nvidia/spark/rapids/jni/nvml/"
 

--- a/src/main/cpp/src/bloom_filter.cu
+++ b/src/main/cpp/src/bloom_filter.cu
@@ -198,7 +198,7 @@ unpack_bloom_filter(cudf::device_span<uint8_t const> bloom_filter, rmm::cuda_str
     std::min(bloom_filter.size(), static_cast<size_t>(bloom_filter_header_v2_size_bytes));
 
   // TODO (future): Consider using pinned host memory for cudaMemcpyAsync.
-  // Refer to https://github.com/NVIDIA/spark-rapids-jni/issues/4407.
+  // Refer to https://github.com/NVIDIA/cudf-spark-jni/issues/4407.
   CUDF_CUDA_TRY(
     cudaMemcpyAsync(raw_ints, bloom_filter.data(), read_size, cudaMemcpyDefault, stream));
   stream.synchronize();

--- a/src/main/cpp/src/cast_string_to_datetime.cu
+++ b/src/main/cpp/src/cast_string_to_datetime.cu
@@ -555,7 +555,7 @@ __device__ result_type parse_timestamp_string(bool is_spark_320,
   }
 
   // Spark400+ and DB14.3+: do not support pattern: spaces + Thh:mm:ss
-  // Refer to https://github.com/NVIDIA/spark-rapids-jni/issues/3401
+  // Refer to https://github.com/NVIDIA/cudf-spark-jni/issues/3401
   // Refer to https://issues.apache.org/jira/browse/SPARK-52351
   // Check if Spark is Spark400+ or DB14.3+ and has left spaces
   bool match_issue_52351 = is_spark_400_or_later_or_db_14_3_or_later && pos > 0;

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -192,7 +192,7 @@ __device__ __inline__ double assemble_ieee754_double(uint64_t mantissa, int unbi
  * @brief Correctly-rounded conversion of `digits * 10^q` to a double for the
  *        case where `digits` exceeds the safe-cast range of double (2^53) and
  *        the existing `static_cast<double>(digits) * exp10(q)` path therefore
- *        loses up to 1 ULP. See NVIDIA/spark-rapids#10773.
+ *        loses up to 1 ULP. See NVIDIA/cudf-spark#10773.
  *
  *        Caller precondition: `digits > 2^53 AND |q| <= 19`. The caller (the
  *        high-precision-path gate inside `string_to_float::operator()`) guards
@@ -393,7 +393,7 @@ class string_to_float {
       // Two output paths:
       //  - High-precision helper for the `digits > 2^53 AND |q| <= 19` window
       //    (T == double only), where the default `static_cast<double>(digits)
-      //    * exp10(exp_ten)` path loses up to 1 ULP (NVIDIA/spark-rapids#10773).
+      //    * exp10(exp_ten)` path loses up to 1 ULP (NVIDIA/cudf-spark#10773).
       //  - Default path for everything else: float outputs, or doubles outside
       //    the helper window (small digits or large |q|).
       bool const helper_eligible = cuda::std::is_same_v<T, double> && (digits > (1ULL << 53)) &&

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -185,7 +185,7 @@ std::tuple<rmm::device_buffer, char, std::unique_ptr<cudf::column>> unify_json_s
 
   // Append the delimiter to the end of the concatenated buffer.
   // This is to fix a bug when the last string is invalid
-  // (https://github.com/rapidsai/cudf/issues/16999).
+  // (https://github.com/nvidia/cudf/issues/16999).
   // The bug was fixed in libcudf's JSON reader by the same way like this.
   auto unified_buff = rmm::device_buffer(concatenated_buff->size() + 1, stream, default_mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(unified_buff.data(),

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -543,7 +543,7 @@ std::unique_ptr<cudf::column> cast_strings_to_floats(cudf::column_view const& in
     output_type, cudf::strings_column_view{input}, /*ansi_mode*/ false, stream, mr);
 }
 
-// TODO there is a bug here around 0 https://github.com/NVIDIA/spark-rapids/issues/10898
+// TODO there is a bug here around 0 https://github.com/NVIDIA/cudf-spark/issues/10898
 std::unique_ptr<cudf::column> cast_strings_to_decimals(cudf::column_view const& input,
                                                        cudf::data_type output_type,
                                                        int precision,
@@ -798,7 +798,7 @@ std::unique_ptr<cudf::column> convert_data_type(InputType&& input,
 
   if (d_type == cudf::type_id::STRING) {
     if (cudf::is_chrono(schema.type)) {
-      // Date/time is not processed here - it should be handled separately in spark-rapids.
+      // Date/time is not processed here - it should be handled separately in cudf-spark.
       if constexpr (input_is_column_ptr) {
         return std::move(input);
       } else {

--- a/src/main/cpp/src/parse_timestamp_with_format.cu
+++ b/src/main/cpp/src/parse_timestamp_with_format.cu
@@ -161,7 +161,7 @@ struct format_token {
 //   - "Packed" runs (a digit field abutting another digit field without a literal between them,
 //     e.g. yyyyMMdd) get exact width — otherwise the boundary is ambiguous.
 //   - Otherwise CORRECTED uses exact width and LEGACY uses [1, 2].
-//   - CORRECTED `yyyy/MM/dd` keeps the existing spark-rapids compatibility contract and accepts
+//   - CORRECTED `yyyy/MM/dd` keeps the existing cudf-spark compatibility contract and accepts
 //     1-2 digit month/day fields. This intentionally DEVIATES from Spark CPU, whose STRICT
 //     DateTimeFormatter rejects single-digit fields ("2024/5/6" is null on CPU); the GPU
 //     over-accepts. Pinned by parseTimestampWithFormat_correctedSlashDateDeviation.

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -534,7 +534,7 @@ __device__ static int32_t get_transition_index(int64_t time_ms, tz_side_info con
  * borrow decision in the same frame as Apache. It can therefore both add a missing borrow and undo
  * one that cuDF applied before the sign changed.
  *
- * For example, the Asia/Shanghai reproducer from rapidsai/cudf#21993 has:
+ * For example, the Asia/Shanghai reproducer from nvidia/cudf#21993 has:
  *
  * @code{.pseudo}
  *   decoded_us     =  21'087'883'873  // cuDF used the UTC 2015 epoch; no borrow

--- a/src/main/cpp/tests/hash.cpp
+++ b/src/main/cpp/tests/hash.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/tests/hash.cpp
+++ b/src/main/cpp/tests/hash.cpp
@@ -202,7 +202,7 @@ TEST_F(SparkMurmurHash3Test, MultiValueWithSeeds)
 {
   // The hash values were determined by running the following Scala code in Apache Spark.
   // Note that Spark >= 3.2 normalizes the float/double value of -0. to +0. and both values hash
-  // to the same result. This is normalized in the calling code (Spark RAPIDS plugin) for Spark
+  // to the same result. This is normalized in the calling code (cuDF plugin) for Spark
   // >= 3.2. However, the reference values for -0. below must be obtained with Spark < 3.2 and
   // libcudf will continue to implement the Spark < 3.2 behavior until Spark >= 3.2 is required and
   // the workaround in the calling code is removed. This also affects the combined hash values.
@@ -617,7 +617,7 @@ TEST_F(SparkXXHash64Test, MultiValueWithSeeds)
 {
   // The hash values were determined by running the following Scala code in Apache Spark.
   // Note that Spark >= 3.2 normalizes the float/double value of -0. to +0. and both values hash
-  // to the same result. This is normalized in the calling code (Spark RAPIDS plugin) for Spark
+  // to the same result. This is normalized in the calling code (cuDF plugin) for Spark
   // >= 3.2. However, the reference values for -0. below must be obtained with Spark < 3.2 and
   // libcudf will continue to implement the Spark < 3.2 behavior until Spark >= 3.2 is required and
   // the workaround in the calling code is removed. This also affects the combined hash values.

--- a/src/main/cpp/tests/row_conversion.cpp
+++ b/src/main/cpp/tests/row_conversion.cpp
@@ -440,7 +440,7 @@ TEST_F(ColumnToRowTests, Biggest)
   }
 }
 
-// Regression test for https://github.com/NVIDIA/spark-rapids/issues/10062.
+// Regression test for https://github.com/NVIDIA/cudf-spark/issues/10062.
 //
 // AcceleratedColumnarToRowIterator packs columns by size descending, so a
 // pivot-shaped schema of N INT64 columns plus one INT32 places the INT32
@@ -498,7 +498,7 @@ TEST_F(ColumnToRowTests, PivotLikeLayout)
   }
 }
 
-// Regression test for spark-rapids-jni#4586: the default branch of the type-size switch in
+// Regression test for cudf-spark-jni#4586: the default branch of the type-size switch in
 // copy_to_rows wrote to the same byte col_size times rather than advancing the offset, so any
 // fixed-width column wider than 8 bytes (DECIMAL128 in practice) was silently corrupted.
 TEST_F(ColumnToRowTests, Decimal128RoundTrip)
@@ -523,7 +523,7 @@ TEST_F(ColumnToRowTests, Decimal128RoundTrip)
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
 }
 
-// Regression test for spark-rapids-jni#4590: when a tile boundary falls at a byte offset that
+// Regression test for cudf-spark-jni#4590: when a tile boundary falls at a byte offset that
 // is not 8-aligned, the old code wrote `round_up_8(actual_size)` bytes from the shared tile to
 // global memory. The trailing padding bytes overlapped with the next tile's destination range,
 // causing a non-deterministic race between adjacent CUDA blocks. With the fix, the write length
@@ -565,7 +565,7 @@ TEST_F(ColumnToRowTests, TileBoundaryWideInt32RoundTrip)
   }
 }
 
-// Regression test for spark-rapids-jni#4586: nested types (LIST, STRUCT, MAP) and other
+// Regression test for cudf-spark-jni#4586: nested types (LIST, STRUCT, MAP) and other
 // unsupported data types must be rejected at the entry point with a clear exception, rather
 // than producing silently corrupted output (which happened when LIST/STRUCT columns reached
 // the variable-width path that assumes STRING).
@@ -585,7 +585,7 @@ TEST_F(ColumnToRowTests, RejectStructColumn)
   EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
 }
 
-// Regression test for spark-rapids-jni#4586: column_view::data<int8_t>() returns
+// Regression test for cudf-spark-jni#4586: column_view::data<int8_t>() returns
 // `head + offset_in_elements` interpreted as bytes, so a sliced column produced a misaligned
 // input pointer and could either crash or silently corrupt data. With the entry-point guard
 // the caller now gets a clear exception.
@@ -645,7 +645,7 @@ TEST_F(RowToColumnTests, RejectSlicedRowList)
                cudf::logic_error);
 }
 
-// Regression repro for spark-rapids-jni#4587. Disabled by default because it requires ~2.5 GB
+// Regression repro for cudf-spark-jni#4587. Disabled by default because it requires ~2.5 GB
 // of free GPU memory to build the input; enable manually with --gtest_also_run_disabled_tests.
 //
 // With fewer than 32 rows whose cumulative encoded size exceeds 2 GiB, the old
@@ -666,7 +666,7 @@ TEST_F(ColumnToRowTests, DISABLED_HugeStringRowThrows)
   EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
 }
 
-// Regression repro for spark-rapids-jni#4588. Disabled by default for the same memory reason as
+// Regression repro for cudf-spark-jni#4588. Disabled by default for the same memory reason as
 // HugeStringRowThrows.
 //
 // The old kernel launch passed batch_num_rows (a per-batch count) as the kernel's `num_rows`

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -217,7 +217,7 @@ public class CastStringsTest {
     }
   }
 
-  // Regression test for https://github.com/NVIDIA/spark-rapids/issues/10773.
+  // Regression test for https://github.com/NVIDIA/cudf-spark/issues/10773.
   // Inputs whose decimal mantissa exceeds 2^53 used to lose 1 ULP because the
   // kernel cast the uint64 digits to double *before* applying the exp10 factor.
   // After the correctly-rounded fallback was added, the GPU result must match
@@ -238,7 +238,7 @@ public class CastStringsTest {
     // case where the mantissa rounding rolls into the exponent. These take
     // the new correctly-rounded fallback path and MUST match Double.parseDouble
     // bit-for-bit. A 1-ULP regression here means the helper is broken and
-    // NVIDIA/spark-rapids#10773 has regressed.
+    // NVIDIA/cudf-spark#10773 has regressed.
     String[] helperInputs = new String[] {
         // --- happy path: helper, q <= 0 ---
         "1.7976931348623157",        // the literal that broke RapidsJsonSuite
@@ -1478,7 +1478,7 @@ public class CastStringsTest {
 
   /**
    * Spark400+ and DB14.3+: do not support pattern: spaces + Thh:mm:ss
-   * Refer to https://github.com/NVIDIA/spark-rapids-jni/issues/3401
+   * Refer to https://github.com/NVIDIA/cudf-spark-jni/issues/3401
    */
   @Test
   void castStringToTimestampForSpark400PlusDB14_3Plus() {
@@ -1824,7 +1824,7 @@ public class CastStringsTest {
 
   @Test
   void parseTimestampWithFormat_correctedSlashDateDeviation() {
-    // CORRECTED yyyy/MM/dd accepts 1-2 digit month/day to preserve the pre-existing spark-rapids
+    // CORRECTED yyyy/MM/dd accepts 1-2 digit month/day to preserve the pre-existing cudf-spark
     // compatibility contract. This DEVIATES from Spark CPU, whose STRICT DateTimeFormatter rejects
     // single-digit fields ("2024/5/6" is null on CPU). This test pins the deviation so a future
     // refactor of compile_format's corrected_variable_width_slash_date cannot silently change it.

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -217,7 +217,7 @@ public class CastStringsTest {
     }
   }
 
-  // Regression test for https://github.com/NVIDIA/spark-rapids/issues/10773.
+  // Regression test for https://github.com/NVIDIA/cudf-spark/issues/10773.
   // Inputs whose decimal mantissa exceeds 2^53 used to lose 1 ULP because the
   // kernel cast the uint64 digits to double *before* applying the exp10 factor.
   // After the correctly-rounded fallback was added, the GPU result must match
@@ -238,7 +238,7 @@ public class CastStringsTest {
     // case where the mantissa rounding rolls into the exponent. These take
     // the new correctly-rounded fallback path and MUST match Double.parseDouble
     // bit-for-bit. A 1-ULP regression here means the helper is broken and
-    // NVIDIA/spark-rapids#10773 has regressed.
+    // NVIDIA/cudf-spark#10773 has regressed.
     String[] helperInputs = new String[] {
         // --- happy path: helper, q <= 0 ---
         "1.7976931348623157",        // the literal that broke RapidsJsonSuite
@@ -1478,7 +1478,7 @@ public class CastStringsTest {
 
   /**
    * Spark400+ and DB14.3+: do not support pattern: spaces + Thh:mm:ss
-   * Refer to https://github.com/NVIDIA/spark-rapids-jni/issues/3401
+   * Refer to https://github.com/NVIDIA/cudf-spark-jni/issues/3401
    */
   @Test
   void castStringToTimestampForSpark400PlusDB14_3Plus() {
@@ -1805,7 +1805,7 @@ public class CastStringsTest {
 
   @Test
   void parseTimestampWithFormat_correctedSlashDateDeviation() {
-    // CORRECTED yyyy/MM/dd accepts 1-2 digit month/day to preserve the pre-existing spark-rapids
+    // CORRECTED yyyy/MM/dd accepts 1-2 digit month/day to preserve the pre-existing cudf-spark
     // compatibility contract. This DEVIATES from Spark CPU, whose STRICT DateTimeFormatter rejects
     // single-digit fields ("2024/5/6" is null on CPU). This test pins the deviation so a future
     // refactor of compile_format's corrected_variable_width_slash_date cannot silently change it.

--- a/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
@@ -91,7 +91,7 @@ public class HashTest {
   @Test
   void testSpark32BitMurmur3HashTimestamps() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.timestampMicroSecondsFromBoxedLongs(
         0L, null, 100L, -100L, 0x123456789abcdefL, null, -0x123456789abcdefL);
          ColumnVector result = Hash.murmurHash32(42, new ColumnVector[]{v});
@@ -103,7 +103,7 @@ public class HashTest {
   @Test
   void testSpark32BitMurmur3HashDecimal64() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.decimalFromLongs(-7,
         0L, 100L, -100L, 0x123456789abcdefL, -0x123456789abcdefL);
          ColumnVector result = Hash.murmurHash32(42, new ColumnVector[]{v});
@@ -115,7 +115,7 @@ public class HashTest {
   @Test
   void testSpark32BitMurmur3HashDecimal32() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.decimalFromInts(-3,
         0, 100, -100, 0x12345678, -0x12345678);
          ColumnVector result = Hash.murmurHash32(42, new ColumnVector[]{v});
@@ -127,7 +127,7 @@ public class HashTest {
   @Test
   void testSpark32BitMurmur3HashDates() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.timestampDaysFromBoxedInts(
         0, null, 100, -100, 0x12345678, null, -0x12345678);
          ColumnVector result = Hash.murmurHash32(42, new ColumnVector[]{v});
@@ -310,7 +310,7 @@ public class HashTest {
   @Test
   void testXXHash64Timestamps() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.timestampMicroSecondsFromBoxedLongs(
         0L, null, 100L, -100L, 0x123456789abcdefL, null, -0x123456789abcdefL);
          ColumnVector result = Hash.xxhash64(new ColumnVector[]{v});
@@ -322,7 +322,7 @@ public class HashTest {
   @Test
   void testXXHash64Decimal64() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.decimalFromLongs(-7,
         0L, 100L, -100L, 0x123456789abcdefL, -0x123456789abcdefL);
          ColumnVector result = Hash.xxhash64(new ColumnVector[]{v});
@@ -334,7 +334,7 @@ public class HashTest {
   @Test
   void testXXHash64Decimal32() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.decimalFromInts(-3,
         0, 100, -100, 0x12345678, -0x12345678);
          ColumnVector result = Hash.xxhash64(new ColumnVector[]{v});
@@ -346,7 +346,7 @@ public class HashTest {
   @Test
   void testXXHash64Dates() {
     // The hash values were derived from Apache Spark in a manner similar to the one documented at
-    // https://github.com/rapidsai/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
+    // https://github.com/nvidia/cudf/blob/aa7ca46dcd9e/cpp/tests/hashing/hash_test.cpp#L281-L307
     try (ColumnVector v = ColumnVector.timestampDaysFromBoxedInts(
         0, null, 100, -100, 0x12345678, null, -0x12345678);
          ColumnVector result = Hash.xxhash64(new ColumnVector[]{v});

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -299,7 +299,7 @@ public class ParseURITest {
     String[] testData = {
       "https://nvidia.com/https&#://nvidia.com",
       "https://http://www.nvidia.com",
-      // commented out until https://github.com/NVIDIA/spark-rapids/issues/10036 is fixed
+      // commented out until https://github.com/NVIDIA/cudf-spark/issues/10036 is fixed
       //"http://www.nvidia.com/object.php?object=ะก-Ð%9Fะฑ-ะฟ-ะกÑ%82Ñ%80ะตะปÑ%8Cะฝะฐ-Ñ%83ะป-Ð%97ะฐะฒะพะดÑ%81ะบะฐÑ%8F.htm",
       "http://www.nvidia.com/object.php?object=ะก-Ðะฑ-ะฟ-ะกÑÑะตะปÑ%20ะฝะฐ-Ñะป-ÐะฐะฒะพะดÑะบะฐÑ.htm",
       "filesystemmagicthing://bob.yaml",
@@ -359,7 +359,7 @@ public class ParseURITest {
       String[] queries = {
         "a",
         "h",
-        // commented out until https://github.com/NVIDIA/spark-rapids/issues/10036 is fixed
+        // commented out until https://github.com/NVIDIA/cudf-spark/issues/10036 is fixed
         //"object",
         "object",
         "a",

--- a/src/test/java/com/nvidia/spark/rapids/jni/iceberg/IcebergTruncateTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/iceberg/IcebergTruncateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/nvidia/spark/rapids/jni/iceberg/IcebergTruncateTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/iceberg/IcebergTruncateTest.java
@@ -49,7 +49,7 @@ public class IcebergTruncateTest {
   @BeforeAll
   static void setup() {
     // Use a fixed seed because Iceberg truncate can not handle overflows well
-    // Refer to https://github.com/NVIDIA/spark-rapids-jni/issues/4016
+    // Refer to https://github.com/NVIDIA/cudf-spark-jni/issues/4016
     seed = 0L;
     System.out.println("IcebergTruncateTest seed: " + seed);
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoGpuSerializerTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoGpuSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -401,7 +401,7 @@ public class KudoGpuSerializerTest {
     }
   }
 
-  // FIXME: Commented out to unblock CI.  See https://github.com/NVIDIA/spark-rapids-jni/issues/3291.
+  // FIXME: Commented out to unblock CI.  See https://github.com/NVIDIA/cudf-spark-jni/issues/3291.
   @Test
   public void testEmptyStructRoundTrip() throws Exception {
     try (Table table = KudoSerializerTest.buildEmptyStructTable()) {


### PR DESCRIPTION
Rename RAPIDS Accelerator for Apache Spark to NVIDIA cuDF plugin for Apache Spark.  

Update first reference to the product to NVIDIA cuDF plugin for Apache Spark, and subsequent references to the cuDF plugin.  It is ok to include JNI in the name for this repository, so NVIDIA cuDF plugin JNI for Apache Spark.  

Update github references for [cudf](https://github.com/nvidia/cudf), [cudf-spark](https://github.com/nvidia/cudf-spark), [cudf-spark-jni](https://github.com/nvidia/cudf-spark-jni)
