### PR TITLE
Update cuDF submodule repository URL to NVIDIA/cudf

### DIFF
--- a/.github/workflows/action-helper/python/submodule-sync
+++ b/.github/workflows/action-helper/python/submodule-sync
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/action-helper/python/submodule-sync
+++ b/.github/workflows/action-helper/python/submodule-sync
@@ -55,7 +55,7 @@ def main():
                 'base': pr.base,
                 'body': "submodule-sync to create a PR keeping thirdparty/cudf up-to-date.\n"
                         f"HEAD commit SHA: {args.sha}, "
-                        f"cudf commit SHA: https://github.com/rapidsai/cudf/commit/{args.cudf_sha}\n\n"
+                        f"cudf commit SHA: https://github.com/NVIDIA/cudf/commit/{args.cudf_sha}\n\n"
                         "This PR will be auto-merged if test passed. "
                         "If failed, it will remain open until test pass or manually fix.",
                 'maintainer_can_modify': True
@@ -65,7 +65,7 @@ def main():
                 sys.exit(0)
 
         pr.comment(number, content=f"HEAD commit SHA: {args.sha}, "
-                                   f"CUDF commit SHA: https://github.com/rapidsai/cudf/commit/{args.cudf_sha}\n"
+                                   f"CUDF commit SHA: https://github.com/NVIDIA/cudf/commit/{args.cudf_sha}\n"
                                    f"Test passed: **{args.passed}**")
 
         if args.passed:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "thirdparty/cudf"]
 	path = thirdparty/cudf
-	url = https://github.com/rapidsai/cudf.git
+	url = https://github.com/NVIDIA/cudf.git
 	branch = main


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/cudf-spark-jni/issues/4814

cuDF GitHub Repo has been renamed from rapidsai/cudf to NVIDIA/cudf : https://github.com/NVIDIA/cudf.git

Update cudf-spark-JNI GitHub Repo to: 

- update the cuDF submodule URL from rapidsai/cudf to the canonical NVIDIA/cudf repository
- update submodule-sync generated commit links to use NVIDIA/cudf
- keep the pinned cuDF commit and main tracking branch unchanged

Nothing in thirdparty/cudf-pins needs updating because the change alters only the cuDF repository
 location—not any pinned revisions or dependencies.

These pins should be regenerated when the thirdparty/cudf SHA or its dependency manifests change. 
The synchronization workflow handles that in work.d/spark-rapids-jni/ci/ submodule-sync.sh:52.
 A repository rename alone does not change their contents.