### PR TITLE
Update SHA wrappers for cuda::stream_ref

### DIFF
--- a/src/main/cpp/src/hash/hash.hpp
+++ b/src/main/cpp/src/hash/hash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -85,7 +87,7 @@ std::unique_ptr<cudf::column> hive_hash(
  */
 std::unique_ptr<cudf::column> sha224_nulls_preserved(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -100,7 +102,7 @@ std::unique_ptr<cudf::column> sha224_nulls_preserved(
  */
 std::unique_ptr<cudf::column> sha256_nulls_preserved(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -115,7 +117,7 @@ std::unique_ptr<cudf::column> sha256_nulls_preserved(
  */
 std::unique_ptr<cudf::column> sha384_nulls_preserved(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -130,7 +132,7 @@ std::unique_ptr<cudf::column> sha384_nulls_preserved(
  */
 std::unique_ptr<cudf::column> sha512_nulls_preserved(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash/sha.cpp
+++ b/src/main/cpp/src/hash/sha.cpp
@@ -19,19 +19,20 @@
 #include <cudf/hashing.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <hash/hash.hpp>
 
 namespace {
 using HashFunction = std::unique_ptr<cudf::column> (*)(cudf::table_view const&,
-                                                       rmm::cuda_stream_view,
+                                                       cuda::stream_ref,
                                                        rmm::device_async_resource_ref);
 
 std::unique_ptr<cudf::column> sha_impl(HashFunction hash_function,
                                        cudf::column_view const& input,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}); }
@@ -55,28 +56,28 @@ std::unique_ptr<cudf::column> sha_impl(HashFunction hash_function,
 namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> sha224_nulls_preserved(cudf::column_view const& input,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   return sha_impl(cudf::hashing::sha224, input, stream, mr);
 }
 
 std::unique_ptr<cudf::column> sha256_nulls_preserved(cudf::column_view const& input,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   return sha_impl(cudf::hashing::sha256, input, stream, mr);
 }
 
 std::unique_ptr<cudf::column> sha384_nulls_preserved(cudf::column_view const& input,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   return sha_impl(cudf::hashing::sha384, input, stream, mr);
 }
 
 std::unique_ptr<cudf::column> sha512_nulls_preserved(cudf::column_view const& input,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   return sha_impl(cudf::hashing::sha512, input, stream, mr);


### PR DESCRIPTION
Update the SHA null-preserving wrappers to accept cuda::stream_ref so they match the cudf hashing APIs after NVIDIA/cudf#23691. This fixes the Spark RAPIDS JNI build failure seen in the cudf stream_ref migration where the local SHA function pointer typedef still expected rmm::cuda_stream_view. Testing not run locally.