### PR TITLE
Use cuDF to count the total deleted row count for cuDF based Delta reader for deletion vectors

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -217,6 +217,7 @@ add_library(
   src/CharsetDecodeJni.cpp
   src/DateTimeUtilsJni.cpp
   src/DecimalUtilsJni.cpp
+  src/DeletionVectorUtilsJni.cpp
   src/DeviceAttrJni.cpp
   src/GpuTimeZoneDBJni.cpp
   src/HistogramJni.cpp

--- a/src/main/cpp/src/DeletionVectorUtilsJni.cpp
+++ b/src/main/cpp/src/DeletionVectorUtilsJni.cpp
@@ -26,8 +26,7 @@
 
 extern "C" {
 
-JNIEXPORT jlong JNICALL
-Java_com_nvidia_spark_rapids_jni_DeletionVectorUtils_computeNumDeletedRows(
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DeletionVectorUtils_computeNumDeletedRows(
   JNIEnv* env,
   jclass,
   jlong serialized_bitmap_address,

--- a/src/main/cpp/src/DeletionVectorUtilsJni.cpp
+++ b/src/main/cpp/src/DeletionVectorUtilsJni.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "jni_utils.hpp"
+
+#include <cudf/io/experimental/deletion_vectors.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL
+Java_com_nvidia_spark_rapids_jni_DeletionVectorUtils_computeNumDeletedRows(
+  JNIEnv* env,
+  jclass,
+  jlong serialized_bitmap_address,
+  jlong serialized_bitmap_length,
+  jint total_num_rows,
+  jlongArray row_group_offsets,
+  jintArray row_group_num_rows,
+  jboolean is_retention,
+  jint max_chunk_rows)
+{
+  JNI_NULL_CHECK(env, serialized_bitmap_address, "serialized bitmap address is null", 0);
+
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    cudf::jni::native_jlongArray n_row_group_offsets(env, row_group_offsets);
+    cudf::jni::native_jintArray n_row_group_num_rows(env, row_group_num_rows);
+
+    auto offsets = std::vector<std::size_t>{};
+    offsets.reserve(n_row_group_offsets.size());
+    std::transform(n_row_group_offsets.begin(),
+                   n_row_group_offsets.end(),
+                   std::back_inserter(offsets),
+                   [](jlong offset) { return static_cast<std::size_t>(offset); });
+
+    auto const bitmap = cudf::host_span<cuda::std::byte const>{
+      reinterpret_cast<cuda::std::byte const*>(serialized_bitmap_address),
+      static_cast<std::size_t>(serialized_bitmap_length)};
+    auto const info = cudf::io::parquet::experimental::deletion_vector_info{
+      .serialized_roaring_bitmaps = {bitmap},
+      .deletion_vector_row_counts = {total_num_rows},
+      .row_group_offsets          = std::move(offsets),
+      .row_group_num_rows         = n_row_group_num_rows.to_vector(),
+      .are_retention_vectors      = static_cast<bool>(is_retention)};
+
+    return static_cast<jlong>(cudf::io::parquet::experimental::compute_num_deleted_rows(
+      info, static_cast<cudf::size_type>(max_chunk_rows)));
+  }
+  JNI_CATCH(env, 0);
+}
+
+}  // extern "C"

--- a/src/main/java/com/nvidia/spark/rapids/jni/DeletionVectorUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DeletionVectorUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.DeletionVector;
+import ai.rapids.cudf.NativeDepsLoader;
+
+/**
+ * JNI utilities for processing deletion vectors.
+ */
+public final class DeletionVectorUtils {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  private DeletionVectorUtils() {}
+
+  /**
+   * Computes the number of rows deleted by a serialized deletion vector on the GPU.
+   *
+   * @param deletionVectorInfo deletion vector and row-group metadata
+   * @param maxChunkRows maximum number of row indexes to process at once
+   * @return number of deleted rows in the specified row groups
+   */
+  public static long computeNumDeletedRows(
+      DeletionVector.DeletionVectorInfo deletionVectorInfo, int maxChunkRows) {
+    if (deletionVectorInfo == null) {
+      throw new NullPointerException("deletionVectorInfo");
+    }
+    if (maxChunkRows <= 0) {
+      throw new IllegalArgumentException("maxChunkRows must be positive");
+    }
+    return computeNumDeletedRows(
+        deletionVectorInfo.serializedBitmap.getAddress(),
+        deletionVectorInfo.serializedBitmap.getLength(),
+        deletionVectorInfo.totalNumRows,
+        deletionVectorInfo.rowGroupOffsets,
+        deletionVectorInfo.rowGroupNumRows,
+        deletionVectorInfo.isRetention,
+        maxChunkRows);
+  }
+
+  private static native long computeNumDeletedRows(
+      long serializedBitmapAddress,
+      long serializedBitmapLength,
+      int totalNumRows,
+      long[] rowGroupOffsets,
+      int[] rowGroupNumRows,
+      boolean isRetention,
+      int maxChunkRows);
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/DeletionVectorUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DeletionVectorUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.DeletionVector;
+import ai.rapids.cudf.HostMemoryBuffer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DeletionVectorUtilsTest {
+  @Test
+  void testEmptyDeletionVector() {
+    try (HostMemoryBuffer serializedBitmap = HostMemoryBuffer.allocate(8)) {
+      serializedBitmap.setLong(0, 0);
+      DeletionVector.DeletionVectorInfo info = new DeletionVector.DeletionVectorInfo(
+          serializedBitmap, false, new long[] {1000}, new int[] {100});
+      DeletionVector.DeletionVectorInfo retentionInfo = new DeletionVector.DeletionVectorInfo(
+          serializedBitmap, true, new long[] {1000}, new int[] {100});
+
+      assertEquals(0, DeletionVectorUtils.computeNumDeletedRows(info, 25));
+      assertEquals(100, DeletionVectorUtils.computeNumDeletedRows(retentionInfo, 25));
+    }
+  }
+
+  @Test
+  void testInvalidChunkSize() {
+    try (HostMemoryBuffer serializedBitmap = HostMemoryBuffer.allocate(8)) {
+      serializedBitmap.setLong(0, 0);
+      DeletionVector.DeletionVectorInfo info = new DeletionVector.DeletionVectorInfo(
+          serializedBitmap, false, new long[] {0}, new int[] {1});
+
+      assertThrows(IllegalArgumentException.class,
+          () -> DeletionVectorUtils.computeNumDeletedRows(info, 0));
+    }
+  }
+}


### PR DESCRIPTION
Fixes [#14628](https://github.com/NVIDIA/cudf-spark/issues/14628)

## Summary

Expose the new libcudf deletion vector row count API through `DeletionVectorUtils.computeNumDeletedRows`.

This allows cudf-spark to count deleted rows on the GPU instead of traversing the deletion vector bitmap in host code.

## Testing

- JNI Maven build and tests passed on CUDA 12.9 with architecture 86.
- Validated end-to-end with DBR 17.3, Spark 4.0.0, and Scala 2.13.
- Targeted Delta deletion-vector integration tests: 48 passed; remaining selected cases were skipped by existing runtime guards.

## Performance

100 million rows, 5 million deleted rows, 2 warmups, and 10 measured runs. The JNI and cudf-spark changes were tested together.

| Reader/query | Baseline median | PR median | Speedup |
|---|---:|---:|---:|
| PERFILE `count(*)` | 1.095745 s | 1.041387 s | 1.05× |
| PERFILE partition aggregate | 0.496434 s | 0.445686 s | 1.11× |
| COALESCING `count(*)` | 0.909243 s | 0.835445 s | 1.09× |
| COALESCING partition aggregate | 0.459016 s | 0.385882 s | 1.19× |
| MULTITHREADED `count(*)` | 0.841082 s | 0.783515 s | 1.07× |
| MULTITHREADED partition aggregate | 0.401422 s | 0.373242 s | 1.08× |
