### PR TITLE
Fix compile errors from `device_scalar` constructor signature change.

### DIFF
--- a/src/main/cpp/src/charset_decode.cu
+++ b/src/main/cpp/src/charset_decode.cu
@@ -223,9 +223,10 @@ decode_result decode_gbk(cudf::column_view const& input,
 
   // Only allocate a device-side flag when the caller actually wants REPORT semantics.
   std::unique_ptr<rmm::device_scalar<int32_t>> flag;
-  int32_t* flag_ptr = nullptr;
+  auto const initial_flag = int32_t{0};
+  int32_t* flag_ptr       = nullptr;
   if (action == error_action::REPORT) {
-    flag     = std::make_unique<rmm::device_scalar<int32_t>>(0, stream, mr);
+    flag     = std::make_unique<rmm::device_scalar<int32_t>>(initial_flag, stream, mr);
     flag_ptr = flag->data();
   }
 

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -1394,11 +1394,12 @@ std::pair<std::unique_ptr<cudf::column>, cudf::size_type> floating_point_to_deci
   auto output = cudf::make_fixed_point_column(
     output_type, input.size(), cudf::mask_state::UNALLOCATED, stream, mr);
 
-  auto const decimal_places = -output_type.scale();
-  auto const default_mr     = rmm::mr::get_current_device_resource_ref();
+  auto const decimal_places         = -output_type.scale();
+  auto const default_mr             = rmm::mr::get_current_device_resource_ref();
+  auto const initial_failure_row_id = cudf::size_type{-1};
 
   rmm::device_uvector<bool> validity(input.size(), stream, default_mr);
-  rmm::device_scalar<cudf::size_type> failure_row_id(-1, stream, default_mr);
+  rmm::device_scalar<cudf::size_type> failure_row_id(initial_failure_row_id, stream, default_mr);
 
   cudf::double_type_dispatcher(input.type(),
                                output_type,

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -81,7 +81,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "c65202f52766e12c73e293b16d6a520a069d4afc",
+      "git_tag" : "6646d15835adba33d70eba714ca4939bb8c8e872",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "26.10"


### PR DESCRIPTION
Fixes #5041.

https://github.com/rapidsai/rmm/pull/2527 changes the signature of `rmm::device_scalar`'s constructor, so as not to take r-value references.

`decimal_utils.cu` and `charset_decode.cu` were mistakenly passing r-values to `rmm::device_scalar`'s constructor.  This is a bug, because there is no guarantee that the r-value would be alive by the time its value is read and copied to device memory.

This commit changes the call sites to use l-value references.

Note that `stream.sync()`s aren't required here, immediately after the device_scalars are constructed.  The source objects remain alive for the copy, and there are stream syncs downstream
(e.g. flag->value(stream)).

