### PR TITLE
[submodule-sync] bot-submodule-sync-main to main [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -81,7 +81,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "9bef8393ea1f80f7b2799a01f9035c30e3a2e6eb",
+      "git_tag" : "02bec8dacb7ad3fe3a7ec3ee837b8d37a0ac0333",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "26.10"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: bb695ebb157ab050edc11182d5ed5fa12647d759, cudf commit SHA: https://github.com/NVIDIA/cudf/commit/45d262a6473c7ce5949b81a3ebb5f01fc8a8497f

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.