### PR TITLE
Migrate native streams to cuda::stream_ref

### DIFF
--- a/src/main/cpp/benchmarks/bloom_filter.cu
+++ b/src/main/cpp/benchmarks/bloom_filter.cu
@@ -40,12 +40,12 @@ void bloom_filter_put_impl(nvbench::state& state, int version)
   auto const input = spark_rapids_jni::xxhash64(*src);
 
   auto const stream = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
              [&](nvbench::launch&, auto& timer) {
                timer.start();
                spark_rapids_jni::bloom_filter_put(*bloom_filter, *input);
-               stream.synchronize();
+               stream.sync();
                timer.stop();
              });
 

--- a/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
+++ b/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
@@ -30,7 +30,7 @@ static void long_to_binary_string(nvbench::state& state)
   auto const input_table = create_random_table({cudf::type_id::INT64}, row_count{num_rows});
   auto const long_col    = input_table->get_column(0);
   auto const stream      = cudf::get_default_stream();
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     spark_rapids_jni::long_to_binary_string(long_col, stream);
   });

--- a/src/main/cpp/benchmarks/from_json.cu
+++ b/src/main/cpp/benchmarks/from_json.cu
@@ -361,7 +361,7 @@ void BM_from_json_to_raw_map(nvbench::state& state)
 
   auto const json_strings = generate_input(size_bytes, make_all_string_column_types(num_keys));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -379,7 +379,7 @@ void BM_from_json_to_raw_map_value_width(nvbench::state& state)
   auto const json_strings = generate_input(
     size_bytes, make_all_string_column_types(num_keys), {.value_width = value_width});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -397,7 +397,7 @@ void BM_from_json_to_raw_map_null_density(nvbench::state& state)
   auto const json_strings =
     generate_input(size_bytes, make_all_string_column_types(num_keys), {.null_pct = null_pct});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -413,7 +413,7 @@ void BM_from_json_to_raw_map_micro_size(nvbench::state& state)
 
   auto const json_strings = generate_input(size_bytes, make_all_string_column_types(num_keys));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -438,7 +438,7 @@ void BM_from_json_to_raw_map_row_shape(nvbench::state& state)
   auto const json_strings =
     generate_input(/*size_bytes=*/0, make_all_string_column_types(num_keys), options);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -456,7 +456,7 @@ void BM_from_json_to_raw_map_key_name_len(nvbench::state& state)
   auto const json_strings = generate_input(
     size_bytes, make_all_string_column_types(num_keys), {.key_name_len = key_name_len});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -476,7 +476,7 @@ void BM_from_json_to_raw_map_array_values(nvbench::state& state)
 
   auto const json_strings = generate_map_of_array_input(num_rows, keys_per_row, array_len);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -500,7 +500,7 @@ void BM_from_json_to_raw_map_array_values_null_density(nvbench::state& state)
     {.element_null_pct = static_cast<double>(state.get_int64("element_null_pct")) / 100.0,
      .value_null_pct   = static_cast<double>(state.get_int64("value_null_pct")) / 100.0});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -517,7 +517,7 @@ void BM_from_json_to_raw_map_array_values_keys_per_row(nvbench::state& state)
 
   auto const json_strings = generate_map_of_array_input(num_rows, keys_per_row, array_len);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -538,7 +538,7 @@ void BM_from_json_to_raw_map_array_values_key_name_len(nvbench::state& state)
     array_len,
     {.key_name_len = static_cast<int>(state.get_int64("key_name_len"))});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -562,7 +562,7 @@ void BM_from_json_to_raw_map_array_values_type_mismatch(nvbench::state& state)
     array_len,
     {.mismatch_pct = static_cast<double>(state.get_int64("mismatch_pct")) / 100.0});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(

--- a/src/main/cpp/benchmarks/from_json_to_structs.cu
+++ b/src/main/cpp/benchmarks/from_json_to_structs.cu
@@ -80,7 +80,7 @@ void BM_from_json_to_structs(nvbench::state& state)
   auto const scales       = nested_schema_scales();
   auto const precisions   = nested_schema_precisions();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output =
       spark_rapids_jni::from_json_to_structs(cudf::strings_column_view{input->view()},

--- a/src/main/cpp/benchmarks/get_json_object.cu
+++ b/src/main/cpp/benchmarks/get_json_object.cu
@@ -44,7 +44,7 @@ struct strings_to_host_fn {
   void operator()(std::vector<std::string>& host_data,
                   char const* chars,
                   cudf::column_view const& offsets,
-                  rmm::cuda_stream_view stream)
+                  cuda::stream_ref stream)
   {
     auto const h_offsets = cudf::detail::make_std_vector_sync(
       cudf::device_span<OffsetType const>(offsets.data<OffsetType>(), offsets.size()), stream);
@@ -62,7 +62,7 @@ struct strings_to_host_fn {
   void operator()(std::vector<std::string>&,
                   char const*,
                   cudf::column_view const&,
-                  rmm::cuda_stream_view)
+                  cuda::stream_ref)
   {
     CUDF_FAIL("invalid offsets type");
   }
@@ -147,7 +147,7 @@ void BM_get_json_object(nvbench::state& state)
     instructions.emplace_back(path_instruction_type::NAMED, "0", -1);
   }
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     // Can also verify at https://jsonpath.com/.
     [[maybe_unused]] auto const output = spark_rapids_jni::get_json_object(

--- a/src/main/cpp/src/aggregation64_utils.cu
+++ b/src/main/cpp/src/aggregation64_utils.cu
@@ -75,7 +75,7 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> extract_chunk32_from_64bit(cudf::column_view const& in_col,
                                                          cudf::data_type type,
                                                          int chunk_idx,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(
@@ -112,7 +112,7 @@ std::unique_ptr<cudf::column> extract_chunk32_from_64bit(cudf::column_view const
 // Reassemble a column of 64-bit values from two 64-bit integer columns with overflow detection.
 std::unique_ptr<cudf::table> assemble64_from_sum(cudf::table_view const& chunks_table,
                                                  cudf::data_type output_type,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(

--- a/src/main/cpp/src/aggregation64_utils.hpp
+++ b/src/main/cpp/src/aggregation64_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/aggregation64_utils.hpp
+++ b/src/main/cpp/src/aggregation64_utils.hpp
@@ -20,7 +20,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -46,7 +46,7 @@ std::unique_ptr<cudf::column> extract_chunk32_from_64bit(
   cudf::column_view const& col,
   cudf::data_type dtype,
   int chunk_idx,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -70,7 +70,7 @@ std::unique_ptr<cudf::column> extract_chunk32_from_64bit(
 std::unique_ptr<cudf::table> assemble64_from_sum(
   cudf::table_view const& chunks_table,
   cudf::data_type output_type,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/bloom_filter.cu
+++ b/src/main/cpp/src/bloom_filter.cu
@@ -32,12 +32,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/atomic>
 #include <cuda/functional>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/logical.h>
 
 #include <byteswap.h>
@@ -154,7 +154,7 @@ struct bloom_probe_functor {
 
 void pack_bloom_filter_header(cudf::device_span<uint8_t> buf,
                               bloom_filter_header const& header,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               int32_t seed)
 {
   if (header.version == bloom_filter_version_1) {
@@ -188,7 +188,7 @@ void pack_bloom_filter_header(cudf::device_span<uint8_t> buf,
       for V2, the value stored in the serialized header.
 */
 std::tuple<bloom_filter_header, cudf::device_span<cudf::bitmask_type const>, int64_t, int32_t>
-unpack_bloom_filter(cudf::device_span<uint8_t const> bloom_filter, rmm::cuda_stream_view stream)
+unpack_bloom_filter(cudf::device_span<uint8_t const> bloom_filter, cuda::stream_ref stream)
 {
   CUDF_EXPECTS(bloom_filter.size() >= static_cast<size_t>(bloom_filter_header_v1_size_bytes),
                "Encountered truncated bloom filter");
@@ -201,7 +201,7 @@ unpack_bloom_filter(cudf::device_span<uint8_t const> bloom_filter, rmm::cuda_str
   // Refer to https://github.com/NVIDIA/spark-rapids-jni/issues/4407.
   CUDF_CUDA_TRY(
     cudaMemcpyAsync(raw_ints, bloom_filter.data(), read_size, cudaMemcpyDefault, stream));
-  stream.synchronize();
+  stream.sync();
 
   int const version = byte_swap_int32(raw_ints[0]);
   CUDF_EXPECTS(version == bloom_filter_version_1 || version == bloom_filter_version_2,
@@ -237,7 +237,7 @@ unpack_bloom_filter(cudf::device_span<uint8_t const> bloom_filter, rmm::cuda_str
 }
 
 std::tuple<bloom_filter_header, cudf::device_span<cudf::bitmask_type const>, int64_t, int32_t>
-unpack_bloom_filter(cudf::column_view const& bloom_filter, rmm::cuda_stream_view stream)
+unpack_bloom_filter(cudf::column_view const& bloom_filter, cuda::stream_ref stream)
 {
   return unpack_bloom_filter(
     cudf::device_span<uint8_t const>{bloom_filter.data<uint8_t>(),
@@ -300,7 +300,7 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(int version,
                                                        int num_hashes,
                                                        int bloom_filter_longs,
                                                        int seed,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -333,7 +333,7 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(int version,
 
 void bloom_filter_put(cudf::list_scalar& bloom_filter,
                       cudf::column_view const& input,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   SRJ_FUNC_RANGE();
   auto [header, buffer, bloom_filter_bits, seed] = unpack_bloom_filter(bloom_filter.view(), stream);
@@ -351,7 +351,7 @@ void bloom_filter_put(cudf::list_scalar& bloom_filter,
 
   auto launch = [&](auto version_tag, auto nullable_tag) {
     gpu_bloom_filter_put<decltype(version_tag)::value, decltype(nullable_tag)::value>
-      <<<grid.num_blocks, block_size, 0, stream.value()>>>(
+      <<<grid.num_blocks, block_size, 0, stream.get()>>>(
         mutable_buffer, bloom_filter_bits, *d_input, header.num_hashes, seed);
   };
 
@@ -373,7 +373,7 @@ void bloom_filter_put(cudf::list_scalar& bloom_filter,
 }
 
 std::unique_ptr<cudf::list_scalar> bloom_filter_merge(cudf::column_view const& bloom_filters,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -450,7 +450,7 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_merge(cudf::column_view const& b
 
 std::unique_ptr<cudf::column> bloom_filter_probe(cudf::column_view const& input,
                                                  cudf::device_span<uint8_t const> bloom_filter,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -489,7 +489,7 @@ std::unique_ptr<cudf::column> bloom_filter_probe(cudf::column_view const& input,
 
 std::unique_ptr<cudf::column> bloom_filter_probe(cudf::column_view const& input,
                                                  cudf::list_scalar& bloom_filter,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/bloom_filter.hpp
+++ b/src/main/cpp/src/bloom_filter.hpp
@@ -21,8 +21,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -90,7 +91,7 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(
   int num_hashes,
   int bloom_filter_longs,
   int seed                          = 0,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -105,7 +106,7 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(
  */
 void bloom_filter_put(cudf::list_scalar& bloom_filter,
                       cudf::column_view const& input,
-                      rmm::cuda_stream_view stream = cudf::get_default_stream());
+                      cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Probe a bloom filter with an input column of int64_t values.
@@ -121,7 +122,7 @@ void bloom_filter_put(cudf::list_scalar& bloom_filter,
 std::unique_ptr<cudf::column> bloom_filter_probe(
   cudf::column_view const& input,
   cudf::device_span<uint8_t const> bloom_filter,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -138,7 +139,7 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
 std::unique_ptr<cudf::column> bloom_filter_probe(
   cudf::column_view const& input,
   cudf::list_scalar& bloom_filter,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -156,7 +157,7 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
  */
 std::unique_ptr<cudf::list_scalar> bloom_filter_merge(
   cudf::column_view const& bloom_filters,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/case_when.cu
+++ b/src/main/cpp/src/case_when.cu
@@ -67,7 +67,7 @@ struct select_first_true_fn {
 }  // anonymous namespace
 
 std::unique_ptr<cudf::column> select_first_true_index(cudf::table_view const& when_bool_columns,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr)
 {
   // checks
@@ -95,7 +95,7 @@ std::unique_ptr<cudf::column> select_first_true_index(cudf::table_view const& wh
 }  // namespace detail
 
 std::unique_ptr<cudf::column> select_first_true_index(cudf::table_view const& when_bool_columns,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr)
 {
   return detail::select_first_true_index(when_bool_columns, stream, mr);

--- a/src/main/cpp/src/case_when.hpp
+++ b/src/main/cpp/src/case_when.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/case_when.hpp
+++ b/src/main/cpp/src/case_when.hpp
@@ -47,7 +47,7 @@ namespace spark_rapids_jni {
  */
 std::unique_ptr<cudf::column> select_first_true_index(
   cudf::table_view const& when_bool_columns,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -29,13 +29,13 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/algorithm>
 #include <cuda/std/climits>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/generate.h>
@@ -180,7 +180,7 @@ struct decimal_to_non_ansi_string_fn {
 struct dispatch_decimal_to_non_ansi_string_fn {
   template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
   std::unique_ptr<column> operator()(column_view const& input,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr) const
   {
     using DecimalType = device_storage_type_t<T>;  // underlying value type
@@ -199,7 +199,7 @@ struct dispatch_decimal_to_non_ansi_string_fn {
 
   template <typename T, std::enable_if_t<not cudf::is_fixed_point<T>()>* = nullptr>
   std::unique_ptr<column> operator()(column_view const&,
-                                     rmm::cuda_stream_view,
+                                     cuda::stream_ref,
                                      rmm::device_async_resource_ref) const
   {
     CUDF_FAIL("Values for decimal_to_non_ansi_string function must be a decimal type.");
@@ -209,7 +209,7 @@ struct dispatch_decimal_to_non_ansi_string_fn {
 }  // namespace
 
 std::unique_ptr<column> decimal_to_non_ansi_string(column_view const& input,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) return make_empty_column(type_id::STRING);
@@ -221,7 +221,7 @@ std::unique_ptr<column> decimal_to_non_ansi_string(column_view const& input,
 // external API
 
 std::unique_ptr<column> decimal_to_non_ansi_string(column_view const& input,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/cast_float_to_string.cu
+++ b/src/main/cpp/src/cast_float_to_string.cu
@@ -24,8 +24,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
+
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -76,7 +77,7 @@ template <bool json_string>
 struct dispatch_float_to_string_fn {
   template <typename FloatType, CUDF_ENABLE_IF(cuda::std::is_floating_point_v<FloatType>)>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& floats,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
   {
     auto const strings_count = floats.size();
@@ -98,7 +99,7 @@ struct dispatch_float_to_string_fn {
   // non-float types throw an exception
   template <typename T, CUDF_ENABLE_IF(not cuda::std::is_floating_point_v<T>)>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
-                                           rmm::cuda_stream_view,
+                                           cuda::stream_ref,
                                            rmm::device_async_resource_ref)
   {
     CUDF_FAIL("Values for float_to_string function must be a float type.");
@@ -110,7 +111,7 @@ struct dispatch_float_to_string_fn {
 // This will convert all float column types into a strings column.
 std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
                                               bool json_string,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   return json_string
@@ -123,7 +124,7 @@ std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
 
 // external API
 std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   return float_to_string(floats, false, stream, mr);
@@ -131,7 +132,7 @@ std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
 
 std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
                                               bool json_string,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/cast_long_to_binary_string.cu
+++ b/src/main/cpp/src/cast_long_to_binary_string.cu
@@ -24,8 +24,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
+
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -96,7 +97,7 @@ CUDF_KERNEL void long_to_binary_string_kernel(cudf::column_device_view d_longs,
 }  // namespace
 
 std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& input,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::INT64, "Input column must be long type");
@@ -113,8 +114,7 @@ std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& inp
   cudf::size_type* d_sizes  = output_sizes.data();
   auto constexpr block_size = 256;
   auto grid                 = cudf::detail::grid_1d{strings_count, block_size};
-  compute_output_size_kernel<<<grid.num_blocks, block_size, 0, stream.value()>>>(*d_column,
-                                                                                 d_sizes);
+  compute_output_size_kernel<<<grid.num_blocks, block_size, 0, stream.get()>>>(*d_column, d_sizes);
 
   // Convert the sizes to offsets
   auto [offsets, bytes] = cudf::strings::detail::make_offsets_child_column(
@@ -131,7 +131,7 @@ std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& inp
   auto new_grid = cudf::detail::grid_1d{strings_count * num_threads_per_row, block_size};
   if (bytes > 0) {
     long_to_binary_string_kernel<num_threads_per_row>
-      <<<new_grid.num_blocks, block_size, 0, stream.value()>>>(*d_column, d_chars, d_offsets);
+      <<<new_grid.num_blocks, block_size, 0, stream.get()>>>(*d_column, d_chars, d_offsets);
   }
 
   return cudf::make_strings_column(input.size(),
@@ -145,7 +145,7 @@ std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& inp
 
 // external API
 std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& input,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -610,7 +610,7 @@ struct row_valid_fn {
  */
 void validate_ansi_column(column_view const& col,
                           strings_column_view const& source_col,
-                          rmm::cuda_stream_view stream)
+                          cuda::stream_ref stream)
 {
   auto const num_nulls      = col.null_count();
   auto const incoming_nulls = source_col.null_count();
@@ -627,8 +627,8 @@ void validate_ansi_column(column_view const& col,
                     &source_col.offsets().data<size_type>()[*first_error],
                     sizeof(size_type) * 2,
                     cudaMemcpyDefault,
-                    stream.value());
-    stream.synchronize();
+                    stream.get());
+    stream.sync();
 
     std::string dest;
     dest.resize(string_bounds[1] - string_bounds[0]);
@@ -637,8 +637,8 @@ void validate_ansi_column(column_view const& col,
                     &source_col.chars_begin(stream)[string_bounds[0]],
                     string_bounds[1] - string_bounds[0],
                     cudaMemcpyDefault,
-                    stream.value());
-    stream.synchronize();
+                    stream.get());
+    stream.sync();
 
     throw cast_error(*first_error, dest);
   }
@@ -659,7 +659,7 @@ struct string_to_integer_impl {
   std::unique_ptr<column> operator()(strings_column_view const& string_col,
                                      bool ansi_mode,
                                      bool strip,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     if (string_col.size() == 0) {
@@ -674,7 +674,7 @@ struct string_to_integer_impl {
     dim3 const blocks(util::div_rounding_up_unsafe(string_col.size(), detail::NUM_THREADS));
     dim3 const threads{detail::NUM_THREADS};
 
-    detail::string_to_integer_kernel<<<blocks, threads, 0, stream.value()>>>(
+    detail::string_to_integer_kernel<<<blocks, threads, 0, stream.get()>>>(
       data.data(),
       null_mask.data(),
       string_col.chars_begin(stream),
@@ -704,7 +704,7 @@ struct string_to_integer_impl {
   std::unique_ptr<column> operator()(strings_column_view const& string_col,
                                      bool ansi_mode,
                                      bool strip,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     CUDF_FAIL("Invalid integer column type");
@@ -731,7 +731,7 @@ struct string_to_decimal_impl {
                                      strings_column_view const& string_col,
                                      bool ansi_mode,
                                      bool strip,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     using Type = device_storage_type_t<T>;
@@ -743,7 +743,7 @@ struct string_to_decimal_impl {
     dim3 const blocks(util::div_rounding_up_unsafe(string_col.size(), detail::NUM_THREADS));
     dim3 const threads{detail::NUM_THREADS};
 
-    detail::string_to_decimal_kernel<<<blocks, threads, 0, stream.value()>>>(
+    detail::string_to_decimal_kernel<<<blocks, threads, 0, stream.get()>>>(
       data.data(),
       null_mask.data(),
       string_col.chars_begin(stream),
@@ -773,7 +773,7 @@ struct string_to_decimal_impl {
                                      strings_column_view const& string_col,
                                      bool ansi_mode,
                                      bool strip,
-                                     rmm::cuda_stream_view stream,
+                                     cuda::stream_ref stream,
                                      rmm::device_async_resource_ref mr)
   {
     CUDF_FAIL("Invalid decimal column type");
@@ -798,7 +798,7 @@ std::unique_ptr<column> string_to_integer(data_type dtype,
                                           strings_column_view const& string_col,
                                           bool ansi_mode,
                                           bool strip,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(
@@ -823,7 +823,7 @@ std::unique_ptr<column> string_to_decimal(int32_t precision,
                                           strings_column_view const& string_col,
                                           bool ansi_mode,
                                           bool strip,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   data_type dtype = [precision, scale]() {

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -79,7 +79,7 @@ std::unique_ptr<cudf::column> string_to_integer(
   cudf::strings_column_view const& string_col,
   bool ansi_mode,
   bool strip,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -101,7 +101,7 @@ std::unique_ptr<cudf::column> string_to_decimal(
   cudf::strings_column_view const& string_col,
   bool ansi_mode,
   bool strip,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -119,34 +119,34 @@ std::unique_ptr<cudf::column> string_to_float(
   cudf::data_type dtype,
   cudf::strings_column_view const& string_col,
   bool ansi_mode,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> format_float(
   cudf::column_view const& input,
   int const digits,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> float_to_string(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 [[nodiscard]] std::unique_ptr<cudf::column> float_to_string(
   cudf::column_view const& input,
   bool json_string,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> long_to_binary_string(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -177,7 +177,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings(
   cudf::column_view const& tz_name_to_index_map,
   cudf::table_view const& tz_info_table,
   spark_rapids_jni::spark_system const& spark_system,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -199,7 +199,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings(
  */
 std::unique_ptr<cudf::column> parse_strings_to_date(
   cudf::strings_column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -245,7 +245,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings_with_format(
   std::string const& format,
   bool legacy,
   bool exception_policy,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -261,7 +261,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings_with_format(
  */
 std::unique_ptr<cudf::column> bytes_to_hex(
   cudf::strings_column_view const& input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_string_to_datetime.cu
+++ b/src/main/cpp/src/cast_string_to_datetime.cu
@@ -27,10 +27,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
@@ -875,7 +875,7 @@ std::unique_ptr<cudf::column> parse_ts_strings(cudf::strings_column_view const& 
                                                cudf::table_view const& tz_info_table,
                                                bool is_spark_320,
                                                bool is_spark_400_or_later_or_db_14_3_or_later,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   auto const num_rows = input.size();
@@ -1078,7 +1078,7 @@ struct parse_string_to_date_fn {
  * Parse strings to dates.
  */
 std::unique_ptr<cudf::column> parse_to_date(cudf::strings_column_view const& input,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   auto const num_rows = input.size();
@@ -1120,7 +1120,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings(
   cudf::column_view const& tz_name_to_index_map,
   cudf::table_view const& tz_info_table,
   spark_rapids_jni::spark_system const& spark_system,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   bool is_spark_320 = spark_system.is_vanilla_320();
@@ -1139,7 +1139,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings(
 }
 
 std::unique_ptr<cudf::column> parse_strings_to_date(cudf::strings_column_view const& input,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   return parse_to_date(input, stream, mr);

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -886,7 +886,7 @@ CUDF_KERNEL void string_to_float_kernel(T* out,
 std::unique_ptr<column> string_to_float(data_type dtype,
                                         strings_column_view const& string_col,
                                         bool ansi_mode,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(dtype == data_type{type_id::FLOAT32} || dtype == data_type{type_id::FLOAT64},
@@ -941,8 +941,8 @@ std::unique_ptr<column> string_to_float(data_type dtype,
                       &string_col.offsets().data<size_type>()[error_row],
                       sizeof(size_type) * 2,
                       cudaMemcpyDefault,
-                      stream.value());
-      stream.synchronize();
+                      stream.get());
+      stream.sync();
 
       std::string dest;
       dest.resize(string_bounds[1] - string_bounds[0]);
@@ -951,8 +951,8 @@ std::unique_ptr<column> string_to_float(data_type dtype,
                       &string_col.chars_begin(stream)[string_bounds[0]],
                       string_bounds[1] - string_bounds[0],
                       cudaMemcpyDefault,
-                      stream.value());
-      stream.synchronize();
+                      stream.get());
+      stream.sync();
 
       throw cast_error(error_row, dest);
     }

--- a/src/main/cpp/src/charset_decode.cu
+++ b/src/main/cpp/src/charset_decode.cu
@@ -202,7 +202,7 @@ struct gbk_decode_fn {
 
 decode_result decode_gbk(cudf::column_view const& input,
                          error_action action,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::LIST,
@@ -257,7 +257,7 @@ decode_result decode_gbk(cudf::column_view const& input,
 decode_result decode_charset(cudf::column_view const& input,
                              charset_type charset,
                              error_action action,
-                             rmm::cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/charset_decode.hpp
+++ b/src/main/cpp/src/charset_decode.hpp
@@ -21,8 +21,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/per_device_resource.hpp>
+
+#include <cuda/stream_ref>
 
 #include <cstdint>
 
@@ -77,7 +78,7 @@ struct decode_result {
   cudf::column_view const& input,
   charset_type charset,
   error_action action,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/datetime_rebase.cu
+++ b/src/main/cpp/src/datetime_rebase.cu
@@ -53,7 +53,7 @@ __device__ __inline__ auto days_from_julian(cuda::std::chrono::year_month_day co
 // days since the epoch from that Julian local date.
 // This is to match with Apache Spark's `localRebaseGregorianToJulianDays` function.
 std::unique_ptr<cudf::column> gregorian_to_julian_days(cudf::column_view const& input,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::TIMESTAMP_DAYS,
@@ -124,7 +124,7 @@ __device__ __inline__ cuda::std::chrono::year_month_day julian_from_days(int32_t
 // of days since the epoch from that Gregorian local date. This is to match with Apache Spark's
 // `localRebaseJulianToGregorianDays` function.
 std::unique_ptr<cudf::column> julian_to_gregorian_days(cudf::column_view const& input,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::TIMESTAMP_DAYS,
@@ -224,7 +224,7 @@ __device__ __inline__ time_components get_time_components(int64_t micros)
 // This is to match with Apache Spark's `rebaseGregorianToJulianMicros` function with timezone
 // fixed to UTC.
 std::unique_ptr<cudf::column> gregorian_to_julian_micros(cudf::column_view const& input,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::TIMESTAMP_MICROSECONDS,
@@ -287,7 +287,7 @@ std::unique_ptr<cudf::column> gregorian_to_julian_micros(cudf::column_view const
 // This is to match with Apache Spark's `rebaseJulianToGregorianMicros` function with timezone
 // fixed to UTC.
 std::unique_ptr<cudf::column> julian_to_gregorian_micros(cudf::column_view const& input,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::TIMESTAMP_MICROSECONDS,
@@ -341,7 +341,7 @@ std::unique_ptr<cudf::column> julian_to_gregorian_micros(cudf::column_view const
 namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> rebase_gregorian_to_julian(cudf::column_view const& input,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -357,7 +357,7 @@ std::unique_ptr<cudf::column> rebase_gregorian_to_julian(cudf::column_view const
 }
 
 std::unique_ptr<cudf::column> rebase_julian_to_gregorian(cudf::column_view const& input,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/datetime_truncate.cu
+++ b/src/main/cpp/src/datetime_truncate.cu
@@ -26,13 +26,13 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/functional>
 #include <cuda/std/optional>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
@@ -266,7 +266,7 @@ template <typename Timestamp, typename FormatT>
 std::unique_ptr<cudf::column> truncate_datetime(cudf::column_view const& datetime,
                                                 FormatT const& format,
                                                 cudf::size_type output_size,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   auto output = cudf::make_fixed_width_column(
@@ -318,7 +318,7 @@ template <typename FormatT>
 std::unique_ptr<cudf::column> truncate_dispatcher(cudf::column_view const& datetime,
                                                   FormatT const& format,
                                                   cudf::size_type output_size,
-                                                  rmm::cuda_stream_view stream,
+                                                  cuda::stream_ref stream,
                                                   rmm::device_async_resource_ref mr)
 {
   if (datetime.type().id() == cudf::type_id::TIMESTAMP_DAYS) {
@@ -345,7 +345,7 @@ void check_types(cudf::column_view const& datetime, cudf::column_view const& for
 
 std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
                                        cudf::column_view const& format,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   check_types(datetime, format);
@@ -364,7 +364,7 @@ std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
 
 std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
                                        std::string const& format,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   check_type(datetime);
@@ -382,7 +382,7 @@ std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
 
 std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
                                        cudf::column_view const& format,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -391,7 +391,7 @@ std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
 
 std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
                                        std::string const& format,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/datetime_utils.hpp
+++ b/src/main/cpp/src/datetime_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/datetime_utils.hpp
+++ b/src/main/cpp/src/datetime_utils.hpp
@@ -21,24 +21,24 @@
 namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> rebase_gregorian_to_julian(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> rebase_julian_to_gregorian(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> truncate(
   cudf::column_view const& datetime,
   cudf::column_view const& format,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> truncate(
   cudf::column_view const& datetime,
   std::string const& format,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -969,7 +969,7 @@ std::unique_ptr<cudf::table> multiply_decimal128(cudf::column_view const& a,
                                                  cudf::column_view const& b,
                                                  int32_t product_scale,
                                                  bool const cast_interim_result,
-                                                 rmm::cuda_stream_view stream)
+                                                 cuda::stream_ref stream)
 {
   CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
   CUDF_EXPECTS(b.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
@@ -1004,7 +1004,7 @@ std::unique_ptr<cudf::table> multiply_decimal128(cudf::column_view const& a,
 std::unique_ptr<cudf::table> divide_decimal128(cudf::column_view const& a,
                                                cudf::column_view const& b,
                                                int32_t quotient_scale,
-                                               rmm::cuda_stream_view stream)
+                                               cuda::stream_ref stream)
 {
   CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
   CUDF_EXPECTS(b.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
@@ -1038,7 +1038,7 @@ std::unique_ptr<cudf::table> divide_decimal128(cudf::column_view const& a,
 std::unique_ptr<cudf::table> integer_divide_decimal128(cudf::column_view const& a,
                                                        cudf::column_view const& b,
                                                        int32_t quotient_scale,
-                                                       rmm::cuda_stream_view stream)
+                                                       cuda::stream_ref stream)
 {
   CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
   CUDF_EXPECTS(b.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
@@ -1071,7 +1071,7 @@ std::unique_ptr<cudf::table> integer_divide_decimal128(cudf::column_view const& 
 std::unique_ptr<cudf::table> remainder_decimal128(cudf::column_view const& a,
                                                   cudf::column_view const& b,
                                                   int32_t remainder_scale,
-                                                  rmm::cuda_stream_view stream)
+                                                  cuda::stream_ref stream)
 {
   CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
   CUDF_EXPECTS(b.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
@@ -1104,7 +1104,7 @@ std::unique_ptr<cudf::table> remainder_decimal128(cudf::column_view const& a,
 std::unique_ptr<cudf::table> add_decimal128(cudf::column_view const& a,
                                             cudf::column_view const& b,
                                             int32_t target_scale,
-                                            rmm::cuda_stream_view stream)
+                                            cuda::stream_ref stream)
 {
   CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
   CUDF_EXPECTS(b.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
@@ -1137,7 +1137,7 @@ std::unique_ptr<cudf::table> add_decimal128(cudf::column_view const& a,
 std::unique_ptr<cudf::table> sub_decimal128(cudf::column_view const& a,
                                             cudf::column_view const& b,
                                             int32_t target_scale,
-                                            rmm::cuda_stream_view stream)
+                                            cuda::stream_ref stream)
 {
   CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
   CUDF_EXPECTS(b.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
@@ -1365,7 +1365,7 @@ struct floating_point_to_decimal_dispatcher {
                   cudf::size_type* failure_row_id,
                   int32_t decimal_places,
                   int32_t precision,
-                  rmm::cuda_stream_view stream) const
+                  cuda::stream_ref stream) const
   {
     using DecimalRepType = cudf::device_storage_type_t<DecimalType>;
 
@@ -1388,7 +1388,7 @@ std::pair<std::unique_ptr<cudf::column>, cudf::size_type> floating_point_to_deci
   cudf::column_view const& input,
   cudf::data_type output_type,
   int32_t precision,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto output = cudf::make_fixed_point_column(

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -20,7 +20,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
@@ -31,37 +31,35 @@ std::unique_ptr<cudf::table> multiply_decimal128(
   cudf::column_view const& b,
   int32_t product_scale,
   bool const cast_interim_result,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+  cuda::stream_ref stream = cudf::get_default_stream());
 
 std::unique_ptr<cudf::table> divide_decimal128(
   cudf::column_view const& a,
   cudf::column_view const& b,
   int32_t quotient_scale,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+  cuda::stream_ref stream = cudf::get_default_stream());
 
 std::unique_ptr<cudf::table> integer_divide_decimal128(
   cudf::column_view const& a,
   cudf::column_view const& b,
   int32_t quotient_scale,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+  cuda::stream_ref stream = cudf::get_default_stream());
 
 std::unique_ptr<cudf::table> remainder_decimal128(
   cudf::column_view const& a,
   cudf::column_view const& b,
   int32_t remainder_scale,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+  cuda::stream_ref stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table> add_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t quotient_scale,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+std::unique_ptr<cudf::table> add_decimal128(cudf::column_view const& a,
+                                            cudf::column_view const& b,
+                                            int32_t quotient_scale,
+                                            cuda::stream_ref stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table> sub_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t quotient_scale,
-  rmm::cuda_stream_view stream = cudf::get_default_stream());
+std::unique_ptr<cudf::table> sub_decimal128(cudf::column_view const& a,
+                                            cudf::column_view const& b,
+                                            int32_t quotient_scale,
+                                            cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Cast floating point values to decimals, matching the behavior of Spark.
@@ -78,7 +76,7 @@ std::pair<std::unique_ptr<cudf::column>, cudf::size_type> floating_point_to_deci
   cudf::column_view const& input,
   cudf::data_type output_type,
   int32_t precision,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace cudf::jni

--- a/src/main/cpp/src/exception_with_row_index_utilities.cu
+++ b/src/main/cpp/src/exception_with_row_index_utilities.cu
@@ -91,7 +91,7 @@ struct row_invalid_ternary_fn {
 
 void throw_row_error_if_any(cudf::column_view const& input,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   CUDF_EXPECTS(input.size() == result.size(),
                "The row counts of the input and result columns must match.");
@@ -115,7 +115,7 @@ void throw_row_error_if_any(cudf::column_view const& input,
 void throw_row_error_if_any(cudf::column_view const& input1,
                             cudf::column_view const& input2,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   CUDF_EXPECTS((input1.size() == input2.size() && input2.size() == result.size()),
                "The row counts of the input and result columns must match.");
@@ -138,7 +138,7 @@ void throw_row_error_if_any(cudf::column_view const& input1,
                             cudf::column_view const& input2,
                             cudf::column_view const& input3,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   CUDF_EXPECTS((input1.size() == input2.size() && input2.size() == input3.size() &&
                 input3.size() == result.size()),
@@ -162,7 +162,7 @@ void throw_row_error_if_any(cudf::column_view const& input1,
 void throw_row_error_if_any(cudf::column_view const& input1,
                             cudf::scalar const& input2,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   CUDF_EXPECTS(input1.size() == result.size(),
                "The row counts of the input and result columns must match.");
@@ -180,7 +180,7 @@ void throw_row_error_if_any(cudf::column_view const& input1,
 void throw_row_error_if_any(cudf::scalar const& input1,
                             cudf::column_view const& input2,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   throw_row_error_if_any(input2, input1, result, stream);
 }

--- a/src/main/cpp/src/exception_with_row_index_utilities.hpp
+++ b/src/main/cpp/src/exception_with_row_index_utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/exception_with_row_index_utilities.hpp
+++ b/src/main/cpp/src/exception_with_row_index_utilities.hpp
@@ -32,7 +32,7 @@ namespace spark_rapids_jni {
  */
 void throw_row_error_if_any(cudf::column_view const& input,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream = cudf::get_default_stream());
+                            cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Throws exception_with_row_index if has any row is invalid for a binary operation.
@@ -47,7 +47,7 @@ void throw_row_error_if_any(cudf::column_view const& input,
 void throw_row_error_if_any(cudf::column_view const& input1,
                             cudf::column_view const& input2,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream = cudf::get_default_stream());
+                            cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Throws exception_with_row_index if has any row is invalid for a ternary operation.
@@ -64,7 +64,7 @@ void throw_row_error_if_any(cudf::column_view const& input1,
                             cudf::column_view const& input2,
                             cudf::column_view const& input3,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream = cudf::get_default_stream());
+                            cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Throws exception_with_row_index if has any row is invalid for a binary operation.
@@ -79,7 +79,7 @@ void throw_row_error_if_any(cudf::column_view const& input1,
 void throw_row_error_if_any(cudf::column_view const& input1,
                             cudf::scalar const& input2,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream = cudf::get_default_stream());
+                            cuda::stream_ref stream = cudf::get_default_stream());
 
 /**
  * @brief Throws exception_with_row_index if has any row is invalid for a binary operation.
@@ -94,6 +94,6 @@ void throw_row_error_if_any(cudf::column_view const& input1,
 void throw_row_error_if_any(cudf::scalar const& input1,
                             cudf::column_view const& input2,
                             cudf::column_view const& result,
-                            rmm::cuda_stream_view stream = cudf::get_default_stream());
+                            cuda::stream_ref stream = cudf::get_default_stream());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/format_float.cu
+++ b/src/main/cpp/src/format_float.cu
@@ -24,10 +24,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -80,7 +80,7 @@ struct dispatch_format_float_fn {
   template <typename FloatType, CUDF_ENABLE_IF(cuda::std::is_floating_point_v<FloatType>)>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& floats,
                                            int const digits,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const
   {
     auto const strings_count = floats.size();
@@ -103,7 +103,7 @@ struct dispatch_format_float_fn {
   template <typename T, CUDF_ENABLE_IF(not cuda::std::is_floating_point_v<T>)>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
                                            int const,
-                                           rmm::cuda_stream_view,
+                                           cuda::stream_ref,
                                            rmm::device_async_resource_ref) const
   {
     CUDF_FAIL("Values for format_float function must be a float type.");
@@ -115,7 +115,7 @@ struct dispatch_format_float_fn {
 // This will convert all float column types into a strings column.
 std::unique_ptr<cudf::column> format_float(cudf::column_view const& floats,
                                            int const digits,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   return type_dispatcher(floats.type(), dispatch_format_float_fn{}, floats, digits, stream, mr);
@@ -126,7 +126,7 @@ std::unique_ptr<cudf::column> format_float(cudf::column_view const& floats,
 // external API
 std::unique_ptr<cudf::column> format_float(cudf::column_view const& floats,
                                            int const digits,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -30,7 +30,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -42,6 +41,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/limits>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -69,7 +69,7 @@ OutputIterator copy_if(InputIterator begin,
                        StencilIterator stencil,
                        OutputIterator result,
                        Predicate predicate,
-                       rmm::cuda_stream_view stream)
+                       cuda::stream_ref stream)
 {
   auto const num_items = cuda::std::distance(begin, end);
 
@@ -85,7 +85,7 @@ OutputIterator copy_if(InputIterator begin,
                                              num_selected.data(),
                                              num_items,
                                              predicate,
-                                             stream.value()));
+                                             stream.get()));
 
   auto d_temp_storage =
     rmm::device_buffer(temp_storage_bytes, stream, cudf::get_current_device_resource_ref());
@@ -98,7 +98,7 @@ OutputIterator copy_if(InputIterator begin,
                                              num_selected.data(),
                                              num_items,
                                              predicate,
-                                             stream.value()));
+                                             stream.get()));
 
   return result + num_selected.value(stream);
 }
@@ -108,7 +108,7 @@ OutputIterator copy_if(InputIterator begin,
                        InputIterator end,
                        OutputIterator output,
                        Predicate predicate,
-                       rmm::cuda_stream_view stream)
+                       cuda::stream_ref stream)
 {
   auto const num_items = cuda::std::distance(begin, end);
 
@@ -125,7 +125,7 @@ OutputIterator copy_if(InputIterator begin,
                                       num_selected.data(),
                                       num_items,
                                       predicate,
-                                      stream.value()));
+                                      stream.get()));
 
   // Allocate temporary storage
   rmm::device_buffer d_temp_storage(
@@ -139,7 +139,7 @@ OutputIterator copy_if(InputIterator begin,
                                       num_selected.data(),
                                       num_items,
                                       predicate,
-                                      stream.value()));
+                                      stream.get()));
 
   // Copy number of selected elements back to host via pinned memory
   return output + num_selected.value(stream);
@@ -149,7 +149,7 @@ OutputIterator copy_if(InputIterator begin,
 // value-child type selects the map flavor: an empty `STRING` gives `make_empty_map`'s output, an
 // empty `List<String>` gives `make_empty_map_array`'s.
 std::unique_ptr<cudf::column> make_empty_map_from_value(std::unique_ptr<cudf::column> value_child,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(value_child->size() == 0, "value_child must be an empty column.");
@@ -163,7 +163,7 @@ std::unique_ptr<cudf::column> make_empty_map_from_value(std::unique_ptr<cudf::co
   return cudf::make_lists_column(0, std::move(offsets), std::move(child), 0, rmm::device_buffer{});
 }
 
-std::unique_ptr<cudf::column> make_empty_map(rmm::cuda_stream_view stream,
+std::unique_ptr<cudf::column> make_empty_map(cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   return make_empty_map_from_value(
@@ -173,7 +173,7 @@ std::unique_ptr<cudf::column> make_empty_map(rmm::cuda_stream_view stream,
 // Concatenating all input strings into one string, for which each input string is appended by a
 // delimiter character that does not exist in the input column.
 std::tuple<rmm::device_buffer, char, std::unique_ptr<cudf::column>> unify_json_strings(
-  cudf::strings_column_view const& input, rmm::cuda_stream_view stream)
+  cudf::strings_column_view const& input, cuda::stream_ref stream)
 {
   auto const default_mr = cudf::get_current_device_resource_ref();
   auto [concatenated_buff, delimiter, should_be_nullified] =
@@ -224,7 +224,7 @@ struct is_node {
 // This is copied from cudf's `json_tree.cu`.
 rmm::device_uvector<TreeDepthT> compute_node_levels(std::size_t num_nodes,
                                                     cudf::device_span<PdaTokenT const> tokens,
-                                                    rmm::cuda_stream_view stream)
+                                                    cuda::stream_ref stream)
 {
   auto token_levels = rmm::device_uvector<TreeDepthT>(tokens.size(), stream);
 
@@ -279,7 +279,7 @@ rmm::device_uvector<TreeDepthT> compute_node_levels(std::size_t num_nodes,
 
 // Compute the map from nodes to their indices in the list of all tokens.
 rmm::device_uvector<NodeIndexT> compute_node_to_token_index_map(
-  std::size_t num_nodes, cudf::device_span<PdaTokenT const> tokens, rmm::cuda_stream_view stream)
+  std::size_t num_nodes, cudf::device_span<PdaTokenT const> tokens, cuda::stream_ref stream)
 {
   auto node_token_ids   = rmm::device_uvector<NodeIndexT>(num_nodes, stream);
   auto const node_id_it = thrust::counting_iterator<NodeIndexT>(0);
@@ -301,7 +301,7 @@ rmm::device_uvector<NodeIndexT> compute_node_to_token_index_map(
 // This is copied from cudf's `json_tree.cu`.
 template <typename KeyType, typename IndexType = cudf::size_type>
 std::pair<rmm::device_uvector<KeyType>, rmm::device_uvector<IndexType>> stable_sorted_key_order(
-  cudf::device_span<KeyType const> keys, rmm::cuda_stream_view stream)
+  cudf::device_span<KeyType const> keys, cuda::stream_ref stream)
 {
   // Buffers used for storing intermediate results during sorting.
   rmm::device_uvector<KeyType> keys_buffer1(keys.size(), stream);
@@ -330,7 +330,7 @@ std::pair<rmm::device_uvector<KeyType>, rmm::device_uvector<IndexType>> stable_s
                                   keys.size(),
                                   0,
                                   sizeof(KeyType) * 8,
-                                  stream.value());
+                                  stream.get());
 
   return std::pair{keys_buffer.Current() == keys_buffer1.data() ? std::move(keys_buffer1)
                                                                 : std::move(keys_buffer2),
@@ -341,7 +341,7 @@ std::pair<rmm::device_uvector<KeyType>, rmm::device_uvector<IndexType>> stable_s
 // This is copied from cudf's `json_tree.cu`.
 void propagate_parent_to_siblings(cudf::device_span<TreeDepthT const> node_levels,
                                   cudf::device_span<NodeIndexT> parent_node_ids,
-                                  rmm::cuda_stream_view stream)
+                                  cuda::stream_ref stream)
 {
   auto const [sorted_node_levels, sorted_order] = stable_sorted_key_order(node_levels, stream);
 
@@ -360,7 +360,7 @@ void propagate_parent_to_siblings(cudf::device_span<TreeDepthT const> node_level
 rmm::device_uvector<NodeIndexT> compute_parent_node_ids(
   cudf::device_span<PdaTokenT const> tokens,
   cudf::device_span<NodeIndexT const> node_token_ids,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const first_childs_parent_token_id =
     cuda::proclaim_return_type<NodeIndexT>([tokens] __device__(auto i) -> NodeIndexT {
@@ -423,7 +423,7 @@ constexpr int32_t list_nesting_weight{1 << 8};
 
 // Check for each node if it is a key or a value field.
 rmm::device_uvector<node_kind> check_key_or_value_nodes(
-  cudf::device_span<NodeIndexT const> parent_node_ids, rmm::cuda_stream_view stream)
+  cudf::device_span<NodeIndexT const> parent_node_ids, cuda::stream_ref stream)
 {
   auto key_or_value       = rmm::device_uvector<node_kind>(parent_node_ids.size(), stream);
   auto const transform_it = thrust::counting_iterator<int>(0);
@@ -475,7 +475,7 @@ struct tokenized_input {
 // this and diverge only after it returns.
 tokenized_input tokenize_and_classify(cudf::strings_column_view const& input,
                                       json_parse_options const& options,
-                                      rmm::cuda_stream_view stream)
+                                      cuda::stream_ref stream)
 {
   auto [concat_json_buff, delimiter, should_be_nullified] = unify_json_strings(input, stream);
   auto concat_buff_wrapper =
@@ -675,7 +675,7 @@ rmm::device_uvector<cuda::std::pair<SymbolOffsetT, SymbolOffsetT>> compute_node_
   cudf::device_span<NodeIndexT const> node_token_ids,
   cudf::device_span<NodeIndexT const> parent_node_ids,
   cudf::device_span<node_kind const> key_or_value,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const num_nodes = node_token_ids.size();
   auto node_ranges =
@@ -723,7 +723,7 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
   cudf::device_span<cuda::std::pair<SymbolOffsetT, SymbolOffsetT> const> node_ranges,
   cudf::device_span<node_kind const> key_or_value,
   cudf::device_span<char const> input_json,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const is_key_or_value = cuda::proclaim_return_type<bool>(
@@ -753,7 +753,7 @@ std::unique_ptr<cudf::column> compute_list_offsets(
   cudf::size_type n_lists,
   cudf::device_span<NodeIndexT const> parent_node_ids,
   cudf::device_span<node_kind const> key_or_value,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // Count the number of children nodes for the json object nodes.
@@ -859,7 +859,7 @@ std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
   cudf::device_span<NodeIndexT const> node_token_ids,
   cudf::device_span<NodeIndexT const> parent_node_ids,
   cudf::device_span<NodeIndexT const> precomputed_line_begin,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const num_nodes = node_token_ids.size();
@@ -951,7 +951,7 @@ __device__ inline bool is_json_null_literal(char const* json,
 
 // Zero-row `List<Struct<String, List<String>>>` for empty input. Sibling of `make_empty_map`;
 // the struct's value child is an empty `List<String>` instead of an empty `STRING`.
-std::unique_ptr<cudf::column> make_empty_map_array(rmm::cuda_stream_view stream,
+std::unique_ptr<cudf::column> make_empty_map_array(cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   return make_empty_map_from_value(
@@ -1017,7 +1017,7 @@ struct element_classify_fn {
 
 std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view const& input,
                                                    json_parse_options options,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1090,7 +1090,7 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
 std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   cudf::strings_column_view const& input,
   json_parse_options options,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/from_json_to_raw_map_debug.cuh
+++ b/src/main/cpp/src/from_json_to_raw_map_debug.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/from_json_to_raw_map_debug.cuh
+++ b/src/main/cpp/src/from_json_to_raw_map_debug.cuh
@@ -25,8 +25,9 @@
 #include <cudf/strings/strings_column_view.hpp>
 
 //
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 //
 #include <sstream>
@@ -61,7 +62,7 @@ template <typename T, typename U = int>
 void print_debug(rmm::device_uvector<T> const& input,
                  std::string const& name,
                  std::string const& separator,
-                 rmm::cuda_stream_view stream)
+                 cuda::stream_ref stream)
 {
   auto const h_input = cudf::detail::make_host_vector_sync(
     cudf::device_span<T const>{input.data(), input.size()}, stream);
@@ -78,7 +79,7 @@ void print_debug(rmm::device_uvector<T> const& input,
 template <typename T, typename U = int>
 void print_map_debug(rmm::device_uvector<T> const& input,
                      std::string const& name,
-                     rmm::cuda_stream_view stream)
+                     cuda::stream_ref stream)
 {
   auto const h_input = cudf::detail::make_host_vector_sync(
     cudf::device_span<T const>{input.data(), input.size()}, stream);
@@ -94,7 +95,7 @@ void print_map_debug(rmm::device_uvector<T> const& input,
 template <typename T, typename U = int>
 void print_pair_debug(rmm::device_uvector<T> const& input,
                       std::string const& name,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   auto const h_input = cudf::detail::make_host_vector_sync(
     cudf::device_span<T const>{input.data(), input.size()}, stream);
@@ -111,7 +112,7 @@ void print_pair_debug(rmm::device_uvector<T> const& input,
 void print_output_spark_map(std::unique_ptr<cudf::column> const& list_offsets,
                             std::unique_ptr<cudf::column> const& extracted_keys,
                             std::unique_ptr<cudf::column> const& extracted_values,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   if (extracted_keys->size() == 0) {
     std::cerr << "Extract keys-values are all empty.\n" << std::endl;

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -35,7 +35,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -46,6 +45,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
@@ -160,7 +160,7 @@ std::pair<cudf::io::schema_element, schema_element_with_precision> generate_stru
 
 std::unique_ptr<cudf::column> make_empty_column_from_schema(
   schema_element_with_precision const& schema,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (schema.type.id() == cudf::type_id::LIST) {
@@ -191,7 +191,7 @@ std::unique_ptr<cudf::column> make_empty_column_from_schema(
 
 void nullify_rows(cudf::column& input,
                   std::span<cudf::size_type const> row_indices,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   rmm::device_async_resource_ref mr)
 {
   if (row_indices.empty()) { return; }
@@ -266,7 +266,7 @@ void nullify_rows(cudf::column& input,
   cudf::size_type null_count,
   rmm::device_buffer&& null_mask,
   bool did_nullify_schema_mismatch_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   std::vector<std::unique_ptr<cudf::column>> children;
@@ -292,7 +292,7 @@ void nullify_rows(cudf::column& input,
   cudf::size_type null_count,
   rmm::device_buffer&& null_mask,
   bool did_nullify_schema_mismatch_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (did_nullify_schema_mismatch_rows && null_count > 0) {
@@ -312,7 +312,7 @@ void nullify_rows(cudf::column& input,
 using string_index_pair = cuda::std::pair<char const*, cudf::size_type>;
 
 std::unique_ptr<cudf::column> cast_strings_to_booleans(cudf::column_view const& input,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -367,7 +367,7 @@ std::unique_ptr<cudf::column> cast_strings_to_booleans(cudf::column_view const& 
 
 std::unique_ptr<cudf::column> cast_strings_to_integers(cudf::column_view const& input,
                                                        cudf::data_type output_type,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -435,7 +435,7 @@ std::unique_ptr<cudf::column> cast_strings_to_integers(cudf::column_view const& 
 }
 
 std::pair<std::unique_ptr<cudf::column>, bool> try_remove_quotes_for_floats(
-  cudf::column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  cudf::column_view const& input, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
 
@@ -521,7 +521,7 @@ std::pair<std::unique_ptr<cudf::column>, bool> try_remove_quotes_for_floats(
 std::unique_ptr<cudf::column> cast_strings_to_floats(cudf::column_view const& input,
                                                      cudf::data_type output_type,
                                                      bool allow_nonnumeric_numbers,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -548,7 +548,7 @@ std::unique_ptr<cudf::column> cast_strings_to_decimals(cudf::column_view const& 
                                                        cudf::data_type output_type,
                                                        int precision,
                                                        bool is_us_locale,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -597,7 +597,7 @@ std::unique_ptr<cudf::column> cast_strings_to_decimals(cudf::column_view const& 
                                        in_offsets + 1,
                                        plus_op,
                                        count_type{0, 0},
-                                       stream.value());
+                                       stream.get());
     auto d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
     cub::DeviceSegmentedReduce::Reduce(d_temp_storage.data(),
                                        temp_storage_bytes,
@@ -608,7 +608,7 @@ std::unique_ptr<cudf::column> cast_strings_to_decimals(cudf::column_view const& 
                                        in_offsets + 1,
                                        plus_op,
                                        count_type{0, 0},
-                                       stream.value());
+                                       stream.get());
   }
 
   auto const out_size_it = spark_rapids_jni::util::make_counting_transform_iterator(
@@ -691,7 +691,7 @@ std::unique_ptr<cudf::column> cast_strings_to_decimals(cudf::column_view const& 
 std::pair<std::unique_ptr<cudf::column>, bool> try_remove_quotes(
   cudf::strings_column_view const& input,
   bool nullify_if_not_quoted,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -776,7 +776,7 @@ std::unique_ptr<cudf::column> convert_data_type(InputType&& input,
                                                 bool allow_nonnumeric_numbers,
                                                 bool is_us_locale,
                                                 bool did_nullify_schema_mismatch_rows,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -993,7 +993,7 @@ std::unique_ptr<cudf::column> from_json_to_structs(cudf::strings_column_view con
                                                    bool allow_nonnumeric_numbers,
                                                    bool allow_unquoted_control,
                                                    bool is_us_locale,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   auto const [concat_input, delimiter, should_be_nullified] =
@@ -1093,7 +1093,7 @@ std::unique_ptr<cudf::column> from_json_to_structs(cudf::strings_column_view con
                                                    bool allow_nonnumeric_numbers,
                                                    bool allow_unquoted_control,
                                                    bool is_us_locale,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1120,7 +1120,7 @@ std::unique_ptr<cudf::column> convert_from_strings(cudf::strings_column_view con
                                                    std::vector<int> const& precisions,
                                                    bool allow_nonnumeric_numbers,
                                                    bool is_us_locale,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1146,7 +1146,7 @@ std::unique_ptr<cudf::column> convert_from_strings(cudf::strings_column_view con
 
 std::unique_ptr<cudf::column> remove_quotes(cudf::strings_column_view const& input,
                                             bool nullify_if_not_quoted,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -870,7 +870,7 @@ struct kernel_launcher {
   static void exec(cudf::column_device_view const& input,
                    cudf::device_span<json_path_processing_data> path_data,
                    int8_t* max_path_depth_exceeded,
-                   rmm::cuda_stream_view stream)
+                   cuda::stream_ref stream)
   {
     // The optimal values for block_size and min_block_per_sm were found through testing,
     // which are either 128-8 or 256-4. The pair 128-8 seems a bit better.
@@ -885,7 +885,7 @@ struct kernel_launcher {
     auto const num_blocks = cudf::util::div_rounding_up_safe(num_threads_per_row * input.size(),
                                                              static_cast<std::size_t>(block_size));
     get_json_object_kernel<block_size, min_block_per_sm>
-      <<<num_blocks, block_size, 0, stream.value()>>>(
+      <<<num_blocks, block_size, 0, stream.get()>>>(
         input, path_data, num_threads_per_row, max_path_depth_exceeded);
   }
 };
@@ -906,7 +906,7 @@ std::tuple<std::vector<rmm::device_uvector<path_instruction>>,
 construct_path_commands(
   std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t> const>> const&
     json_paths,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   // Concatenate all names from path instructions.
   auto h_inst_names = [&] {
@@ -966,7 +966,7 @@ construct_path_commands(
 
 int64_t calc_scratch_size(cudf::strings_column_view const& input,
                           cudf::detail::input_offsetalator const& in_offsets,
-                          rmm::cuda_stream_view stream)
+                          cuda::stream_ref stream)
 {
   auto const max_row_size = thrust::transform_reduce(
     rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -1018,7 +1018,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
   std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t> const>> const&
     json_paths,
   int64_t scratch_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const [d_json_paths, h_json_paths, d_inst_names, h_inst_names] =
@@ -1173,7 +1173,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
     json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const num_outputs = json_paths.size();
@@ -1247,7 +1247,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
 std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& input,
   std::vector<std::tuple<path_instruction_type, std::string, int32_t>> const& instructions,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1260,7 +1260,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
     json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -44,7 +44,7 @@ enum class path_instruction_type : int8_t { WILDCARD, INDEX, NAMED };
 std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& input,
   std::vector<std::tuple<path_instruction_type, std::string, int32_t>> const& instructions,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -66,7 +66,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
     json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash/hash.hpp
+++ b/src/main/cpp/src/hash/hash.hpp
@@ -19,7 +19,6 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/stream_ref>
@@ -42,7 +41,7 @@ constexpr int MAX_STACK_DEPTH           = 8;
 std::unique_ptr<cudf::column> murmur_hash3_32(
   cudf::table_view const& input,
   uint32_t seed                     = 0,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -58,7 +57,7 @@ std::unique_ptr<cudf::column> murmur_hash3_32(
 std::unique_ptr<cudf::column> xxhash64(
   cudf::table_view const& input,
   int64_t seed                      = DEFAULT_XXHASH64_SEED,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -72,7 +71,7 @@ std::unique_ptr<cudf::column> xxhash64(
  */
 std::unique_ptr<cudf::column> hive_hash(
   cudf::table_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**

--- a/src/main/cpp/src/hash/hive_hash.cu
+++ b/src/main/cpp/src/hash/hive_hash.cu
@@ -23,12 +23,12 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/bit>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tabulate.h>
 
@@ -471,7 +471,7 @@ void check_nested_depth(cudf::table_view const& input)
 }  // namespace
 
 std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   auto output = cudf::make_numeric_column(cudf::data_type(cudf::type_to_id<hive_hash_value_t>()),

--- a/src/main/cpp/src/hash/murmur_hash.cu
+++ b/src/main/cpp/src/hash/murmur_hash.cu
@@ -22,11 +22,11 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tabulate.h>
 
@@ -191,7 +191,7 @@ void check_hash_compatibility(cudf::table_view const& input)
 
 std::unique_ptr<cudf::column> murmur_hash3_32(cudf::table_view const& input,
                                               uint32_t seed,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   auto output =

--- a/src/main/cpp/src/hash/xxhash64.cu
+++ b/src/main/cpp/src/hash/xxhash64.cu
@@ -22,13 +22,13 @@
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/array>
 #include <cuda/std/bit>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/tabulate.h>
 
 namespace spark_rapids_jni {
@@ -552,7 +552,7 @@ void check_nested_depth(cudf::table_view const& input)
 
 std::unique_ptr<cudf::column> xxhash64(cudf::table_view const& input,
                                        int64_t _seed,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   hash_value_type seed = static_cast<hash_value_type>(_seed);

--- a/src/main/cpp/src/hex.cu
+++ b/src/main/cpp/src/hex.cu
@@ -25,10 +25,10 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
@@ -83,7 +83,7 @@ struct write_hex_fn {
 }  // namespace
 
 std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& input,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::type_id::STRING); }
@@ -119,7 +119,7 @@ std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& inpu
 }  // namespace detail
 
 std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& input,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -164,7 +164,7 @@ struct percentile_dispatcher {
                          cudf::device_span<double const> percentages,
                          bool has_null,
                          cudf::size_type num_histograms,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr) const
   {
     // Returns all nulls for totally empty input.
@@ -255,7 +255,7 @@ std::unique_ptr<cudf::column> wrap_in_list(std::unique_ptr<cudf::column>&& input
                                            cudf::size_type null_count,
                                            cudf::size_type num_histograms,
                                            cudf::size_type num_percentages,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   if (input->size() == 0) { return cudf::make_empty_lists_column(input->type()); }
@@ -275,7 +275,7 @@ std::unique_ptr<cudf::column> wrap_in_list(std::unique_ptr<cudf::column>&& input
 std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const& values,
                                                         cudf::column_view const& frequencies,
                                                         bool output_as_lists,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(
@@ -416,7 +416,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
 std::unique_ptr<cudf::column> percentile_from_histogram(cudf::column_view const& input,
                                                         std::vector<double> const& percentages,
                                                         bool output_as_list,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   check_input(input, percentages);

--- a/src/main/cpp/src/histogram.hpp
+++ b/src/main/cpp/src/histogram.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/histogram.hpp
+++ b/src/main/cpp/src/histogram.hpp
@@ -19,8 +19,9 @@
 #include <cudf/utilities/default_stream.hpp>
 
 //
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -51,7 +52,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(
   cudf::column_view const& values,
   cudf::column_view const& frequencies,
   bool output_as_lists,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -71,7 +72,7 @@ std::unique_ptr<cudf::column> percentile_from_histogram(
   cudf::column_view const& input,
   std::vector<double> const& percentage,
   bool output_as_lists,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/iceberg/iceberg_bucket.cu
+++ b/src/main/cpp/src/iceberg/iceberg_bucket.cu
@@ -383,7 +383,7 @@ struct bucket_decimal128_fn {
 template <typename GeneratorFunc>
 void generate_buckets(GeneratorFunc generator,
                       cudf::mutable_column_view output,
-                      rmm::cuda_stream_view stream)
+                      cuda::stream_ref stream)
 {
   thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    output.begin<int32_t>(),
@@ -393,7 +393,7 @@ void generate_buckets(GeneratorFunc generator,
 
 std::unique_ptr<cudf::column> compute_bucket_impl(cudf::column_view const& input,
                                                   int32_t num_buckets,
-                                                  rmm::cuda_stream_view stream,
+                                                  cuda::stream_ref stream,
                                                   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_buckets > 0, "num_buckets must be positive");
@@ -467,7 +467,7 @@ std::unique_ptr<cudf::column> compute_bucket_impl(cudf::column_view const& input
 
 std::unique_ptr<cudf::column> compute_bucket(cudf::column_view const& input,
                                              int32_t num_buckets,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/iceberg/iceberg_bucket.hpp
+++ b/src/main/cpp/src/iceberg/iceberg_bucket.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/iceberg/iceberg_bucket.hpp
+++ b/src/main/cpp/src/iceberg/iceberg_bucket.hpp
@@ -50,7 +50,7 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> compute_bucket(
   cudf::column_view const& input,
   int32_t num_buckets,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/iceberg/iceberg_datetime_util.cu
+++ b/src/main/cpp/src/iceberg/iceberg_datetime_util.cu
@@ -136,7 +136,7 @@ struct hours_from_epoch_for_ts_fn {
 };
 
 std::unique_ptr<cudf::column> compute_years_from_epoch(cudf::column_view const& input,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32}); }
@@ -165,7 +165,7 @@ std::unique_ptr<cudf::column> compute_years_from_epoch(cudf::column_view const& 
 }
 
 std::unique_ptr<cudf::column> compute_months_from_epoch(cudf::column_view const& input,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32}); }
@@ -194,7 +194,7 @@ std::unique_ptr<cudf::column> compute_months_from_epoch(cudf::column_view const&
 }
 
 std::unique_ptr<cudf::column> compute_days_from_epoch(cudf::column_view const& input,
-                                                      rmm::cuda_stream_view stream,
+                                                      cuda::stream_ref stream,
                                                       rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) {
@@ -225,7 +225,7 @@ std::unique_ptr<cudf::column> compute_days_from_epoch(cudf::column_view const& i
 }
 
 std::unique_ptr<cudf::column> compute_hours_from_epoch(cudf::column_view const& input,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32}); }
@@ -251,7 +251,7 @@ std::unique_ptr<cudf::column> compute_hours_from_epoch(cudf::column_view const& 
 }  // anonymous namespace
 
 std::unique_ptr<cudf::column> years_from_epoch(cudf::column_view const& input,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -259,7 +259,7 @@ std::unique_ptr<cudf::column> years_from_epoch(cudf::column_view const& input,
 }
 
 std::unique_ptr<cudf::column> months_from_epoch(cudf::column_view const& input,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -267,7 +267,7 @@ std::unique_ptr<cudf::column> months_from_epoch(cudf::column_view const& input,
 }
 
 std::unique_ptr<cudf::column> days_from_epoch(cudf::column_view const& input,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -275,7 +275,7 @@ std::unique_ptr<cudf::column> days_from_epoch(cudf::column_view const& input,
 }
 
 std::unique_ptr<cudf::column> hours_from_epoch(cudf::column_view const& input,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/iceberg/iceberg_datetime_util.hpp
+++ b/src/main/cpp/src/iceberg/iceberg_datetime_util.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/iceberg/iceberg_datetime_util.hpp
+++ b/src/main/cpp/src/iceberg/iceberg_datetime_util.hpp
@@ -37,7 +37,7 @@ namespace spark_rapids_jni {
  */
 std::unique_ptr<cudf::column> years_from_epoch(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -52,7 +52,7 @@ std::unique_ptr<cudf::column> years_from_epoch(
  */
 std::unique_ptr<cudf::column> months_from_epoch(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -67,7 +67,7 @@ std::unique_ptr<cudf::column> months_from_epoch(
  */
 std::unique_ptr<cudf::column> days_from_epoch(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -82,7 +82,7 @@ std::unique_ptr<cudf::column> days_from_epoch(
  */
 std::unique_ptr<cudf::column> hours_from_epoch(
   cudf::column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/iceberg/iceberg_truncate.cu
+++ b/src/main/cpp/src/iceberg/iceberg_truncate.cu
@@ -131,7 +131,7 @@ template <typename RepT>
 void truncate_integral_and_fill(std::unique_ptr<cudf::column>& output,
                                 cudf::column_device_view d_input,
                                 int32_t width,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    output->mutable_view().begin<RepT>(),
@@ -141,7 +141,7 @@ void truncate_integral_and_fill(std::unique_ptr<cudf::column>& output,
 
 std::unique_ptr<cudf::column> truncate_integral_impl(cudf::column_view const& input,
                                                      int32_t width,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(width != 0, "Width must not be zero");
@@ -170,7 +170,7 @@ std::unique_ptr<cudf::column> truncate_integral_impl(cudf::column_view const& in
 
 std::unique_ptr<cudf::column> truncate_string_impl(cudf::column_view const& input,
                                                    int32_t truncate_length,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::STRING, "Input must be STRING");
@@ -198,7 +198,7 @@ std::unique_ptr<cudf::column> truncate_string_impl(cudf::column_view const& inpu
 
 std::unique_ptr<cudf::column> truncate_binary_impl(cudf::column_view const& input,
                                                    int32_t truncate_length,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(truncate_length > 0, "Length must be positive");
@@ -243,7 +243,7 @@ std::unique_ptr<cudf::column> truncate_binary_impl(cudf::column_view const& inpu
 
 std::unique_ptr<cudf::column> truncate_integral(cudf::column_view const& input,
                                                 int32_t width,
-                                                rmm::cuda_stream_view stream,
+                                                cuda::stream_ref stream,
                                                 rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -252,7 +252,7 @@ std::unique_ptr<cudf::column> truncate_integral(cudf::column_view const& input,
 
 std::unique_ptr<cudf::column> truncate_string(cudf::column_view const& input,
                                               int32_t truncate_length,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -261,7 +261,7 @@ std::unique_ptr<cudf::column> truncate_string(cudf::column_view const& input,
 
 std::unique_ptr<cudf::column> truncate_binary(cudf::column_view const& input,
                                               int32_t truncate_length,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/iceberg/iceberg_truncate.hpp
+++ b/src/main/cpp/src/iceberg/iceberg_truncate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/iceberg/iceberg_truncate.hpp
+++ b/src/main/cpp/src/iceberg/iceberg_truncate.hpp
@@ -54,7 +54,7 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> truncate_integral(
   cudf::column_view const& input,
   int32_t width,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -77,7 +77,7 @@ std::unique_ptr<cudf::column> truncate_integral(
 std::unique_ptr<cudf::column> truncate_string(
   cudf::column_view const& input,
   int32_t length,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -93,7 +93,7 @@ std::unique_ptr<cudf::column> truncate_string(
 std::unique_ptr<cudf::column> truncate_binary(
   cudf::column_view const& input,
   int32_t length,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/join_primitives.cu
+++ b/src/main/cpp/src/join_primitives.cu
@@ -31,10 +31,10 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
@@ -96,7 +96,7 @@ filter_by_conditional_impl(cudf::device_span<cudf::size_type const> left_indices
                            cudf::table_device_view const& right_table,
                            cudf::ast::detail::expression_device_view device_expression_data,
                            cudf::size_type num_intermediates,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref mr)
 {
   auto const num_pairs = left_indices.size();
@@ -135,13 +135,13 @@ filter_by_conditional_impl(cudf::device_span<cudf::size_type const> left_indices
   auto const shmem_size = static_cast<size_t>(block_size) * static_cast<size_t>(per_thread_bytes);
 
   filter_join_indices_kernel<has_nulls>
-    <<<grid_size, block_size, shmem_size, stream.value()>>>(left_indices.data(),
-                                                            right_indices.data(),
-                                                            num_pairs,
-                                                            left_table,
-                                                            right_table,
-                                                            device_expression_data,
-                                                            keep_mask.data());
+    <<<grid_size, block_size, shmem_size, stream.get()>>>(left_indices.data(),
+                                                          right_indices.data(),
+                                                          num_pairs,
+                                                          left_table,
+                                                          right_table,
+                                                          device_expression_data,
+                                                          keep_mask.data());
 
   // Surface any kernel launch errors immediately
   CUDF_CUDA_TRY(cudaPeekAtLastError());
@@ -183,7 +183,7 @@ sort_merge_inner_join(cudf::table_view const& left_keys,
                       cudf::sorted is_left_sorted,
                       cudf::sorted is_right_sorted,
                       cudf::null_equality compare_nulls,
-                      rmm::cuda_stream_view stream,
+                      cuda::stream_ref stream,
                       rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -208,7 +208,7 @@ std::pair<rmm::device_uvector<cudf::size_type>, rmm::device_uvector<cudf::size_t
 hash_inner_join(cudf::table_view const& left_keys,
                 cudf::table_view const& right_keys,
                 cudf::null_equality compare_nulls,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -240,7 +240,7 @@ filter_gather_maps_by_ast(cudf::device_span<cudf::size_type const> left_indices,
                           cudf::table_view const& left_table,
                           cudf::table_view const& right_table,
                           cudf::ast::expression const& binary_predicate,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -308,13 +308,13 @@ namespace {
 std::pair<rmm::device_uvector<bool>, cudf::size_type> compute_side_match_info(
   cudf::device_span<cudf::size_type const> indices,
   cudf::size_type table_size,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   // Create a boolean mask to track which rows have matches
   // Note: Temporary buffers use current device resource for allocation
   auto has_match =
     rmm::device_uvector<bool>(table_size, stream, cudf::get_current_device_resource_ref());
-  CUDF_CUDA_TRY(cudaMemsetAsync(has_match.data(), 0, has_match.size(), stream.value()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(has_match.data(), 0, has_match.size(), stream.get()));
 
   // Mark rows that have matches
   thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -343,7 +343,7 @@ void populate_outer_result(cudf::size_type table_size,
                            cudf::size_type unmatched_offset,
                            rmm::device_uvector<cudf::size_type>& out_indices,
                            rmm::device_uvector<cudf::size_type>& out_other_indices,
-                           rmm::cuda_stream_view stream)
+                           cuda::stream_ref stream)
 {
   // Copy unmatched rows
   auto unmatched_iter = out_indices.begin() + unmatched_offset;
@@ -369,7 +369,7 @@ make_left_outer(cudf::device_span<cudf::size_type const> left_indices,
                 cudf::device_span<cudf::size_type const> right_indices,
                 cudf::size_type left_table_size,
                 cudf::size_type right_table_size,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -414,7 +414,7 @@ make_full_outer(cudf::device_span<cudf::size_type const> left_indices,
                 cudf::device_span<cudf::size_type const> right_indices,
                 cudf::size_type left_table_size,
                 cudf::size_type right_table_size,
-                rmm::cuda_stream_view stream,
+                cuda::stream_ref stream,
                 rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -476,7 +476,7 @@ make_full_outer(cudf::device_span<cudf::size_type const> left_indices,
 rmm::device_uvector<cudf::size_type> make_semi(
   cudf::device_span<cudf::size_type const> left_indices,
   cudf::size_type left_table_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -520,7 +520,7 @@ rmm::device_uvector<cudf::size_type> make_semi(
 rmm::device_uvector<cudf::size_type> make_anti(
   cudf::device_span<cudf::size_type const> left_indices,
   cudf::size_type left_table_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -567,7 +567,7 @@ rmm::device_uvector<cudf::size_type> make_anti(
 
 std::unique_ptr<cudf::column> get_matched_rows(cudf::device_span<cudf::size_type const> gather_map,
                                                cudf::size_type table_size,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -580,7 +580,7 @@ std::unique_ptr<cudf::column> get_matched_rows(cudf::device_span<cudf::size_type
   auto result_data = result_view.data<bool>();
 
   // Initialize all to false
-  CUDF_CUDA_TRY(cudaMemsetAsync(result_data, 0, table_size, stream.value()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(result_data, 0, table_size, stream.get()));
 
   // Mark rows that appear in the gather map as true
   thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),

--- a/src/main/cpp/src/join_primitives.hpp
+++ b/src/main/cpp/src/join_primitives.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/join_primitives.hpp
+++ b/src/main/cpp/src/join_primitives.hpp
@@ -24,8 +24,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 #include <utility>
@@ -67,7 +68,7 @@ sort_merge_inner_join(cudf::table_view const& left_keys,
                       cudf::sorted is_left_sorted       = cudf::sorted::NO,
                       cudf::sorted is_right_sorted      = cudf::sorted::NO,
                       cudf::null_equality compare_nulls = cudf::null_equality::EQUAL,
-                      rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                      cuda::stream_ref stream           = cudf::get_default_stream(),
                       rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -88,7 +89,7 @@ std::pair<rmm::device_uvector<cudf::size_type>, rmm::device_uvector<cudf::size_t
 hash_inner_join(cudf::table_view const& left_keys,
                 cudf::table_view const& right_keys,
                 cudf::null_equality compare_nulls = cudf::null_equality::EQUAL,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 // =============================================================================
@@ -119,7 +120,7 @@ filter_gather_maps_by_ast(
   cudf::table_view const& left_table,
   cudf::table_view const& right_table,
   cudf::ast::expression const& binary_predicate,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 // =============================================================================
@@ -146,7 +147,7 @@ make_left_outer(cudf::device_span<cudf::size_type const> left_indices,
                 cudf::device_span<cudf::size_type const> right_indices,
                 cudf::size_type left_table_size,
                 cudf::size_type right_table_size,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -170,7 +171,7 @@ make_full_outer(cudf::device_span<cudf::size_type const> left_indices,
                 cudf::device_span<cudf::size_type const> right_indices,
                 cudf::size_type left_table_size,
                 cudf::size_type right_table_size,
-                rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+                cuda::stream_ref stream           = cudf::get_default_stream(),
                 rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 // =============================================================================
@@ -194,7 +195,7 @@ make_full_outer(cudf::device_span<cudf::size_type const> left_indices,
 rmm::device_uvector<cudf::size_type> make_semi(
   cudf::device_span<cudf::size_type const> indices,
   cudf::size_type table_size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -213,7 +214,7 @@ rmm::device_uvector<cudf::size_type> make_semi(
 rmm::device_uvector<cudf::size_type> make_anti(
   cudf::device_span<cudf::size_type const> indices,
   cudf::size_type table_size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 // =============================================================================
@@ -237,7 +238,7 @@ rmm::device_uvector<cudf::size_type> make_anti(
 std::unique_ptr<cudf::column> get_matched_rows(
   cudf::device_span<cudf::size_type const> gather_map,
   cudf::size_type table_size,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -24,7 +24,6 @@
 #include <cudf/transform.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
@@ -32,6 +31,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
+#include <cuda/stream_ref>
 #include <thrust/fill.h>
 #include <thrust/find.h>
 #include <thrust/for_each.h>
@@ -119,7 +119,7 @@ __host__ __device__ constexpr std::uint8_t delimiter_candidate(int candidate_ind
 std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::column>> concat_json(
   cudf::strings_column_view const& input,
   bool nullify_invalid_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) {
@@ -209,7 +209,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
                                                     lower_level,
                                                     upper_level,
                                                     num_chars,
-                                                    stream.value()));
+                                                    stream.get()));
   {
     rmm::device_buffer d_temp(temp_storage_bytes, stream);
     CUDF_CUDA_TRY(cub::DeviceHistogram::HistogramEven(d_temp.data(),
@@ -220,7 +220,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
                                                       lower_level,
                                                       upper_level,
                                                       num_chars,
-                                                      stream.value()));
+                                                      stream.get()));
   }
 
   auto const candidates_begin         = thrust::make_counting_iterator(0);
@@ -303,7 +303,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
 std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::column>> concat_json(
   cudf::strings_column_view const& input,
   bool nullify_invalid_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/json_utils.hpp
+++ b/src/main/cpp/src/json_utils.hpp
@@ -20,8 +20,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -43,7 +44,7 @@ struct json_parse_options {
 std::unique_ptr<cudf::column> from_json_to_raw_map(
   cudf::strings_column_view const& input,
   json_parse_options options,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -65,7 +66,7 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(
 std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   cudf::strings_column_view const& input,
   json_parse_options options,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -85,7 +86,7 @@ std::unique_ptr<cudf::column> from_json_to_structs(
   bool allow_nonnumeric_numbers,
   bool allow_unquoted_control,
   bool is_us_locale,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -101,7 +102,7 @@ std::unique_ptr<cudf::column> convert_from_strings(
   std::vector<int> const& precisions,
   bool allow_nonnumeric_numbers,
   bool is_us_locale,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -113,7 +114,7 @@ std::unique_ptr<cudf::column> convert_from_strings(
 std::unique_ptr<cudf::column> remove_quotes(
   cudf::strings_column_view const& input,
   bool nullify_if_not_quoted,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -139,7 +140,7 @@ std::unique_ptr<cudf::column> remove_quotes(
 std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::column>> concat_json(
   cudf::strings_column_view const& input,
   bool nullify_invalid_rows         = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/list_slice.cu
+++ b/src/main/cpp/src/list_slice.cu
@@ -26,10 +26,10 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/logical.h>
 
 using namespace cudf;
@@ -40,7 +40,7 @@ namespace detail {
 
 namespace {
 
-void assert_start_is_not_zero(column_device_view const& start, rmm::cuda_stream_view stream)
+void assert_start_is_not_zero(column_device_view const& start, cuda::stream_ref stream)
 {
   bool start_valid =
     thrust::all_of(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -53,7 +53,7 @@ void assert_start_is_not_zero(column_device_view const& start, rmm::cuda_stream_
   CUDF_EXPECTS(start_valid, "Invalid start value: start must not be 0");
 }
 
-void assert_length_is_not_negative(column_device_view const& length, rmm::cuda_stream_view stream)
+void assert_length_is_not_negative(column_device_view const& length, cuda::stream_ref stream)
 {
   bool length_valid =
     thrust::all_of(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -148,7 +148,7 @@ auto generate_starts_and_sizes(size_type const* offsets_of_input_lists,
                                size_type const num_rows,
                                SRART_ITERATOR const start_iterator,
                                LENGTH_ITERATOR const length_iterator,
-                               rmm::cuda_stream_view stream)
+                               cuda::stream_ref stream)
 {
   auto starts              = make_numeric_column(data_type{type_id::INT32},
                                     num_rows,
@@ -162,7 +162,7 @@ auto generate_starts_and_sizes(size_type const* offsets_of_input_lists,
                                    cudf::get_current_device_resource_ref());
   constexpr int block_size = 256;
   auto grid                = cudf::detail::grid_1d{num_rows, block_size};
-  compute_starts_and_sizes_kernel<<<grid.num_blocks, block_size, 0, stream.value()>>>(
+  compute_starts_and_sizes_kernel<<<grid.num_blocks, block_size, 0, stream.get()>>>(
     offsets_of_input_lists,
     num_rows,
     start_iterator,
@@ -175,7 +175,7 @@ auto generate_starts_and_sizes(size_type const* offsets_of_input_lists,
 std::unique_ptr<cudf::column> legal_list_slice(lists_column_view const& input,
                                                column_view const& starts,
                                                column_view const& sizes,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   auto const num_rows = input.size();
@@ -187,7 +187,7 @@ std::unique_ptr<cudf::column> legal_list_slice(lists_column_view const& input,
   constexpr int block_size = 256;
   auto grid                = cudf::detail::grid_1d{num_rows, block_size};
   rmm::device_uvector<int32_t> gather_map(num_total_elements, stream);
-  compute_gather_map<<<grid.num_blocks, block_size, 0, stream.value()>>>(
+  compute_gather_map<<<grid.num_blocks, block_size, 0, stream.get()>>>(
     num_rows,
     input.offsets_begin(),
     starts.begin<int32_t>(),
@@ -220,7 +220,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          size_type const start,
                                          size_type const length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   if (check_start_length) {
@@ -244,7 +244,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          size_type const start,
                                          column_view const& length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(length.type().id() == type_id::INT32,
@@ -277,7 +277,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          column_view const& start,
                                          size_type const length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(start.type().id() == type_id::INT32,
@@ -310,7 +310,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          column_view const& start,
                                          column_view const& length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(start.type().id() == type_id::INT32,
@@ -353,7 +353,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          size_type const start,
                                          size_type const length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -364,7 +364,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          size_type const start,
                                          column_view const& length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -375,7 +375,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          column_view const& start,
                                          size_type const length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -386,7 +386,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          column_view const& start,
                                          column_view const& length,
                                          bool check_start_length,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/list_slice.hpp
+++ b/src/main/cpp/src/list_slice.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/list_slice.hpp
+++ b/src/main/cpp/src/list_slice.hpp
@@ -70,7 +70,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::size_type const start,
   cudf::size_type const length,
   bool check_start_length           = true,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -123,7 +123,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::size_type const start,
   cudf::column_view const& length,
   bool check_start_length           = true,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -176,7 +176,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::column_view const& start,
   cudf::size_type const length,
   bool check_start_length           = true,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -239,7 +239,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::column_view const& start,
   cudf::column_view const& length,
   bool check_start_length           = true,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/map.cu
+++ b/src/main/cpp/src/map.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/map.cu
+++ b/src/main/cpp/src/map.cu
@@ -28,7 +28,7 @@ namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& input,
                                               cudf::order sort_order,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.type().id() == cudf::type_id::LIST,

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -18,7 +18,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -39,7 +39,7 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> sort_map_column(
   cudf::column_view const& input,
   cudf::order sort_order,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -32,7 +32,6 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
@@ -40,6 +39,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cub/device/device_reduce.cuh>
+#include <cuda/stream_ref>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/scan.h>
 
@@ -174,7 +174,7 @@ struct phase1_state_summary {
 
 phase1_state_summary run_phase1_state(cudf::column_view const& input,
                                       bool throw_on_null_key,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref temp_mr)
 {
   auto const num_rows = input.size();
@@ -189,15 +189,15 @@ phase1_state_summary run_phase1_state(cudf::column_view const& input,
   {
     constexpr int block_size = 256;
     auto const grid_size     = cudf::util::div_rounding_up_safe(num_rows, block_size);
-    compute_row_state_kernel<<<grid_size, block_size, 0, stream.value()>>>(input.null_mask(),
-                                                                           lists_cv.offsets_begin(),
-                                                                           structs.null_mask(),
-                                                                           keys.null_mask(),
-                                                                           throw_on_null_key,
-                                                                           num_rows,
-                                                                           row_state.data(),
-                                                                           row_size.data());
-    CUDF_CHECK_CUDA(stream.value());
+    compute_row_state_kernel<<<grid_size, block_size, 0, stream.get()>>>(input.null_mask(),
+                                                                         lists_cv.offsets_begin(),
+                                                                         structs.null_mask(),
+                                                                         keys.null_mask(),
+                                                                         throw_on_null_key,
+                                                                         num_rows,
+                                                                         row_state.data(),
+                                                                         row_size.data());
+    CUDF_CHECK_CUDA(stream.get());
   }
 
   // Max + Min reductions on row_state — the state ordering encodes both "must throw?" and
@@ -207,28 +207,28 @@ phase1_state_summary run_phase1_state(cudf::column_view const& input,
   {
     std::size_t bytes = 0;
     CUDF_CUDA_TRY(cub::DeviceReduce::Max(
-      nullptr, bytes, row_state.data(), max_state_d.data(), num_rows, stream.value()));
+      nullptr, bytes, row_state.data(), max_state_d.data(), num_rows, stream.get()));
     rmm::device_buffer tmp(bytes, stream, temp_mr);
     CUDF_CUDA_TRY(cub::DeviceReduce::Max(
-      tmp.data(), bytes, row_state.data(), max_state_d.data(), num_rows, stream.value()));
+      tmp.data(), bytes, row_state.data(), max_state_d.data(), num_rows, stream.get()));
   }
   {
     std::size_t bytes = 0;
     CUDF_CUDA_TRY(cub::DeviceReduce::Min(
-      nullptr, bytes, row_state.data(), min_state_d.data(), num_rows, stream.value()));
+      nullptr, bytes, row_state.data(), min_state_d.data(), num_rows, stream.get()));
     rmm::device_buffer tmp(bytes, stream, temp_mr);
     CUDF_CUDA_TRY(cub::DeviceReduce::Min(
-      tmp.data(), bytes, row_state.data(), min_state_d.data(), num_rows, stream.value()));
+      tmp.data(), bytes, row_state.data(), min_state_d.data(), num_rows, stream.get()));
   }
 
   // Bundled D→H pull — two async copies, one stream sync.
   std::uint8_t max_state{};
   std::uint8_t min_state{};
   CUDF_CUDA_TRY(cudaMemcpyAsync(
-    &max_state, max_state_d.data(), sizeof(std::uint8_t), cudaMemcpyDefault, stream.value()));
+    &max_state, max_state_d.data(), sizeof(std::uint8_t), cudaMemcpyDefault, stream.get()));
   CUDF_CUDA_TRY(cudaMemcpyAsync(
-    &min_state, min_state_d.data(), sizeof(std::uint8_t), cudaMemcpyDefault, stream.value()));
-  stream.synchronize();
+    &min_state, min_state_d.data(), sizeof(std::uint8_t), cudaMemcpyDefault, stream.get()));
+  stream.sync();
 
   return phase1_state_summary{std::move(row_state), std::move(row_size), max_state, min_state};
 }
@@ -237,7 +237,7 @@ phase1_state_summary run_phase1_state(cudf::column_view const& input,
 
 bool is_valid_map(cudf::column_view const& input,
                   bool throw_on_null_key,
-                  rmm::cuda_stream_view stream,
+                  cuda::stream_ref stream,
                   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -257,7 +257,7 @@ bool is_valid_map(cudf::column_view const& input,
 
 std::unique_ptr<cudf::column> map_from_entries(cudf::column_view const& input,
                                                bool throw_on_null_key,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -284,7 +284,7 @@ std::unique_ptr<cudf::column> map_from_entries(cudf::column_view const& input,
   auto const structs  = lists_cv.child();
 
   rmm::device_uvector<cudf::size_type> out_offsets(num_rows + 1, stream, mr);
-  CUDF_CUDA_TRY(cudaMemsetAsync(out_offsets.data(), 0, sizeof(cudf::size_type), stream.value()));
+  CUDF_CUDA_TRY(cudaMemsetAsync(out_offsets.data(), 0, sizeof(cudf::size_type), stream.get()));
   thrust::inclusive_scan(rmm::exec_policy_nosync(stream, temp_mr),
                          p1.row_size.begin(),
                          p1.row_size.end(),
@@ -295,8 +295,8 @@ std::unique_ptr<cudf::column> map_from_entries(cudf::column_view const& input,
                                 out_offsets.data() + num_rows,
                                 sizeof(cudf::size_type),
                                 cudaMemcpyDefault,
-                                stream.value()));
-  stream.synchronize();
+                                stream.get()));
+  stream.sync();
 
   // ── Phase 2: clean output construction (no dirty intermediate result) ─────
   // 2a. Null mask from row_state via an explicit `state == STATE_VALID` predicate.  Avoids
@@ -317,12 +317,12 @@ std::unique_ptr<cudf::column> map_from_entries(cudf::column_view const& input,
   {
     constexpr int block_size = 256;
     auto const grid_size     = cudf::util::div_rounding_up_safe(num_rows, block_size);
-    build_gather_map_kernel<<<grid_size, block_size, 0, stream.value()>>>(p1.row_state.data(),
-                                                                          lists_cv.offsets_begin(),
-                                                                          out_offsets.data(),
-                                                                          num_rows,
-                                                                          gather_map.data());
-    CUDF_CHECK_CUDA(stream.value());
+    build_gather_map_kernel<<<grid_size, block_size, 0, stream.get()>>>(p1.row_state.data(),
+                                                                        lists_cv.offsets_begin(),
+                                                                        out_offsets.data(),
+                                                                        num_rows,
+                                                                        gather_map.data());
+    CUDF_CHECK_CUDA(stream.get());
   }
 
   // 2c. Single gather over the struct child — handles arbitrary nested key/value types.

--- a/src/main/cpp/src/map_utils.hpp
+++ b/src/main/cpp/src/map_utils.hpp
@@ -20,7 +20,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -58,7 +58,7 @@ namespace spark_rapids_jni {
 [[nodiscard]] bool is_valid_map(
   cudf::column_view const& input,
   bool throw_on_null_key,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -97,7 +97,7 @@ namespace spark_rapids_jni {
 [[nodiscard]] std::unique_ptr<cudf::column> map_from_entries(
   cudf::column_view const& input,
   bool throw_on_null_key,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/map_zip_with_utils.cu
+++ b/src/main/cpp/src/map_zip_with_utils.cu
@@ -50,7 +50,7 @@ namespace {
 std::unique_ptr<column> generate_labels(
   lists_column_view const& input,
   size_type n_elements,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref())
 {
   auto labels = make_numeric_column(
@@ -112,8 +112,7 @@ std::unique_ptr<column> generate_labels(
 std::unique_ptr<column> indices_of(
   lists_column_view const& search_keys,    // Column containing lists of keys to search for
   lists_column_view const& search_values,  // Column containing lists of values to search through
-  rmm::cuda_stream_view stream =
-    cudf::get_default_stream(),  // CUDA stream for asynchronous execution
+  cuda::stream_ref stream = cudf::get_default_stream(),  // CUDA stream for asynchronous execution
   rmm::device_async_resource_ref mr =
     cudf::get_current_device_resource_ref())  // Memory resource for allocations
 {
@@ -310,7 +309,7 @@ std::unique_ptr<column> indices_of(
 std::unique_ptr<cudf::column> map_zip(
   cudf::lists_column_view const& col1,  // First map column containing key-value pairs
   cudf::lists_column_view const& col2,  // Second map column containing key-value pairs
-  rmm::cuda_stream_view stream,         // CUDA stream for asynchronous execution
+  cuda::stream_ref stream,              // CUDA stream for asynchronous execution
   rmm::device_async_resource_ref mr)    // Memory resource for allocations
 {
   CUDF_EXPECTS(col1.child().type().id() == cudf::type_id::STRUCT,

--- a/src/main/cpp/src/map_zip_with_utils.hpp
+++ b/src/main/cpp/src/map_zip_with_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/map_zip_with_utils.hpp
+++ b/src/main/cpp/src/map_zip_with_utils.hpp
@@ -60,7 +60,7 @@ namespace spark_rapids_jni {
 [[maybe_unused]] std::unique_ptr<cudf::column> map_zip(
   cudf::lists_column_view const& col1,
   cudf::lists_column_view const& col2,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/multiply.cu
+++ b/src/main/cpp/src/multiply.cu
@@ -181,7 +181,7 @@ std::unique_ptr<cudf::column> multiply_impl(cudf::data_type type,
                                             RIGHT_ACCESSOR right_accessor,
                                             bool check_overflow,
                                             bool both_inputs_valid,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   auto result =
@@ -239,7 +239,7 @@ struct dispatch_multiply {
   std::unique_ptr<cudf::column> operator()(cudf::data_type type,
                                            cudf::size_type num_rows,
                                            bool check_overflow,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const
   {
     if (left_cv != nullptr && right_cv != nullptr) {
@@ -307,7 +307,7 @@ struct dispatch_multiply {
   std::unique_ptr<cudf::column> operator()(cudf::data_type type,
                                            cudf::size_type num_rows,
                                            bool check_overflow,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr) const
   {
     CUDF_FAIL("Unsupported type when multiply.");
@@ -320,7 +320,7 @@ std::unique_ptr<cudf::column> multiply(cudf::column_view const& left_cv,
                                        cudf::column_view const& right_cv,
                                        bool is_ansi_mode,
                                        bool is_try_mode,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   check_multiply_inputs(
@@ -344,7 +344,7 @@ std::unique_ptr<cudf::column> multiply(cudf::column_view const& left_cv,
                                        cudf::scalar const& right_scalar,
                                        bool is_ansi_mode,
                                        bool is_try_mode,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   check_multiply_inputs(
@@ -368,7 +368,7 @@ std::unique_ptr<cudf::column> multiply(cudf::scalar const& left_scalar,
                                        cudf::column_view const& right_cv,
                                        bool is_ansi_mode,
                                        bool is_try_mode,
-                                       rmm::cuda_stream_view stream,
+                                       cuda::stream_ref stream,
                                        rmm::device_async_resource_ref mr)
 {
   check_multiply_inputs(left_scalar.type(),

--- a/src/main/cpp/src/multiply.hpp
+++ b/src/main/cpp/src/multiply.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/multiply.hpp
+++ b/src/main/cpp/src/multiply.hpp
@@ -51,7 +51,7 @@ std::unique_ptr<cudf::column> multiply(
   cudf::column_view const& right_input,
   bool is_ansi_mode,
   bool is_try_mode,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -84,7 +84,7 @@ std::unique_ptr<cudf::column> multiply(
   cudf::scalar const& right_input,
   bool is_ansi_mode,
   bool is_try_mode,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -117,7 +117,7 @@ std::unique_ptr<cudf::column> multiply(
   cudf::column_view const& right_input,
   bool is_ansi_mode,
   bool is_try_mode,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/number_converter.cu
+++ b/src/main/cpp/src/number_converter.cu
@@ -368,7 +368,7 @@ std::unique_ptr<cudf::column> convert_impl(cudf::size_type num_rows,
                                            STR_ITERATOR input,
                                            FROM_BASE_ITERATOR from_base,
                                            TO_BASE_ITERATOR to_base,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   static constexpr bool IS_CONST_BASES = cuda::std::is_same_v<const_base, FROM_BASE_ITERATOR> &&
@@ -454,7 +454,7 @@ bool is_convert_overflow_impl(cudf::size_type num_rows,
                               STR_ITERATOR input,
                               FROM_BASE_ITERATOR from_base,
                               TO_BASE_ITERATOR to_base,
-                              rmm::cuda_stream_view stream,
+                              cuda::stream_ref stream,
                               rmm::device_async_resource_ref mr)
 {
   static constexpr bool IS_CONST_BASES = cuda::std::is_same_v<const_base, FROM_BASE_ITERATOR> &&
@@ -479,7 +479,7 @@ bool is_cv(convert_number_t const& t) { return std::holds_alternative<cudf::colu
 void check_types(convert_number_t const& input,
                  convert_number_t const& from_base,
                  convert_number_t const& to_base,
-                 rmm::cuda_stream_view stream)
+                 cuda::stream_ref stream)
 {
   // check input type
   if (is_cv(input)) {
@@ -513,7 +513,7 @@ void check_types(convert_number_t const& input,
 std::unique_ptr<cudf::column> convert(convert_number_t const& input,
                                       convert_number_t const& from_base,
                                       convert_number_t const& to_base,
-                                      rmm::cuda_stream_view stream,
+                                      cuda::stream_ref stream,
                                       rmm::device_async_resource_ref mr)
 {
   check_types(input, from_base, to_base, stream);
@@ -627,7 +627,7 @@ std::unique_ptr<cudf::column> convert(convert_number_t const& input,
 bool is_convert_overflow(convert_number_t const& input,
                          convert_number_t const& from_base,
                          convert_number_t const& to_base,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr)
 {
   check_types(input, from_base, to_base, stream);

--- a/src/main/cpp/src/number_converter.hpp
+++ b/src/main/cpp/src/number_converter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/number_converter.hpp
+++ b/src/main/cpp/src/number_converter.hpp
@@ -49,7 +49,7 @@ std::unique_ptr<cudf::column> convert(
   convert_number_t const& input,
   convert_number_t const& from_base,
   convert_number_t const& to_base,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -68,7 +68,7 @@ bool is_convert_overflow(
   convert_number_t const& input,
   convert_number_t const& from_base,
   convert_number_t const& to_base,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_timestamp_with_format.cu
+++ b/src/main/cpp/src/parse_timestamp_with_format.cu
@@ -31,12 +31,12 @@
 #include <cudf/utilities/span.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/atomic>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
@@ -361,7 +361,7 @@ std::unique_ptr<cudf::column> parse_timestamp_strings_with_format(
   std::string const& format,
   bool legacy,
   bool exception_policy,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -32,12 +32,12 @@
 #include <cudf/transform.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
 #include <cuda/std/optional>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/tabulate.h>
 
 #include <memory>
@@ -887,7 +887,7 @@ CUDF_KERNEL void parse_uri(column_device_view const in_strings,
 std::unique_ptr<column> parse_uri(strings_column_view const& input,
                                   URI_chunks chunk,
                                   std::optional<strings_column_view const> query_match,
-                                  rmm::cuda_stream_view stream,
+                                  cuda::stream_ref stream,
                                   rmm::device_async_resource_ref mr)
 {
   size_type strings_count = input.size();
@@ -920,7 +920,7 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
   // count number of bytes in each string after parsing and store it in offsets_column
   auto offsets_view         = offsets_column->view();
   auto offsets_mutable_view = offsets_column->mutable_view();
-  parse_uri_char_counter<<<num_threadblocks, threadblock_size, 0, stream.value()>>>(
+  parse_uri_char_counter<<<num_threadblocks, threadblock_size, 0, stream.get()>>>(
     *d_strings,
     chunk,
     input.chars_begin(stream),
@@ -946,7 +946,7 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
   auto d_out_chars = rmm::device_buffer(out_chars_bytes, stream, mr);
 
   // copy the characters from the input column to the output column
-  parse_uri<<<num_threadblocks, threadblock_size, 0, stream.value()>>>(
+  parse_uri<<<num_threadblocks, threadblock_size, 0, stream.get()>>>(
     *d_strings,
     input.chars_begin(stream),
     src_offsets.data(),
@@ -963,7 +963,7 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
                              std::move(null_mask));
 }
 
-void validate_input_uris(strings_column_view const& input, rmm::cuda_stream_view stream)
+void validate_input_uris(strings_column_view const& input, cuda::stream_ref stream)
 {
   if (input.size() == 0) { return; }
 
@@ -1007,7 +1007,7 @@ void validate_input_uris(strings_column_view const& input, rmm::cuda_stream_view
 
 std::unique_ptr<column> parse_uri_to_protocol(strings_column_view const& input,
                                               bool ansi_mode,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1017,7 +1017,7 @@ std::unique_ptr<column> parse_uri_to_protocol(strings_column_view const& input,
 
 std::unique_ptr<column> parse_uri_to_host(strings_column_view const& input,
                                           bool ansi_mode,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1027,7 +1027,7 @@ std::unique_ptr<column> parse_uri_to_host(strings_column_view const& input,
 
 std::unique_ptr<column> parse_uri_to_query(strings_column_view const& input,
                                            bool ansi_mode,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1038,7 +1038,7 @@ std::unique_ptr<column> parse_uri_to_query(strings_column_view const& input,
 std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const& input,
                                                  std::string const& query_match,
                                                  bool ansi_mode,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1054,7 +1054,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const
 std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const& input,
                                                  cudf::strings_column_view const& query_match,
                                                  bool ansi_mode,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -1066,7 +1066,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const
 
 std::unique_ptr<column> parse_uri_to_path(strings_column_view const& input,
                                           bool ansi_mode,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -20,8 +20,9 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -38,7 +39,7 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> parse_uri_to_protocol(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -52,7 +53,7 @@ std::unique_ptr<cudf::column> parse_uri_to_protocol(
 std::unique_ptr<cudf::column> parse_uri_to_host(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -66,7 +67,7 @@ std::unique_ptr<cudf::column> parse_uri_to_host(
 std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -82,7 +83,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
   std::string const& query_match,
   bool ansi_mode                    = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -98,7 +99,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
   cudf::strings_column_view const& query_match,
   bool ansi_mode                    = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
@@ -112,7 +113,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
 std::unique_ptr<cudf::column> parse_uri_to_path(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -41,7 +41,7 @@ namespace detail {
 std::unique_ptr<cudf::column> make_null_column_with_schema(protobuf_schema const& schema,
                                                            int schema_idx,
                                                            cudf::size_type num_rows,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr)
 {
   auto const& field = schema[schema_idx];
@@ -293,7 +293,7 @@ bool protobuf_schema::is_output(int schema_idx) const
 
 std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const& binary_input,
                                                         protobuf_decode_context const& context,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   protobuf_schema schema_context{context};
@@ -374,7 +374,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     track_permissive_null_rows ? num_rows : 0, stream, scratch_mr);
   if (track_permissive_null_rows) {
     CUDF_CUDA_TRY(
-      cudaMemsetAsync(d_row_force_null.data(), 0, num_rows * sizeof(bool), stream.value()));
+      cudaMemsetAsync(d_row_force_null.data(), 0, num_rows * sizeof(bool), stream.get()));
   }
   auto const decode_ctx        = protobuf_decode_runtime_context{&d_row_force_null, &d_error};
   auto const recursive_context = recursive_decode_context{schema_context, decode_ctx};
@@ -519,8 +519,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
           auto const batch_input = batched_scalar_input_view<T>{
             input, d_locations.data(), num_scalar, d_descs.data(), nf, d_error.data()};
           extract_scalar_batched_kernel<T, DecodeFn>
-            <<<grid, threads, 0, stream.value()>>>(batch_input);
-          CUDF_CHECK_CUDA(stream.value());
+            <<<grid, threads, 0, stream.get()>>>(batch_input);
+          CUDF_CHECK_CUDA(stream.get());
         }
 
         for (int j = 0; j < nf; j++) {
@@ -721,11 +721,11 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   {
     using enum protobuf_error;
-    CUDF_CHECK_CUDA(stream.value());
+    CUDF_CHECK_CUDA(stream.get());
     protobuf_error h_error = NONE;
     CUDF_CUDA_TRY(
       cudf::detail::memcpy_async(&h_error, d_error.data(), sizeof(protobuf_error), stream));
-    stream.synchronize();
+    stream.sync();
     if (h_error == SCHEMA_TOO_LARGE || h_error == REPEATED_COUNT_MISMATCH) {
       throw cudf::logic_error(error_message(h_error));
     }
@@ -766,7 +766,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
 std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const& binary_input,
                                                         protobuf_decode_context const& context,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/protobuf/protobuf.hpp
+++ b/src/main/cpp/src/protobuf/protobuf.hpp
@@ -21,8 +21,9 @@
 #include <cudf/detail/utilities/host_vector.hpp>
 #include <cudf/types.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <cstdint>
 #include <memory>
@@ -98,7 +99,7 @@ void validate_decode_context(protobuf_decode_context const& context);
 
 std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const& binary_input,
                                                         protobuf_decode_context const& context,
-                                                        rmm::cuda_stream_view stream,
+                                                        cuda::stream_ref stream,
                                                         rmm::device_async_resource_ref mr);
 
 }  // namespace spark_rapids_jni::protobuf

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -35,7 +35,7 @@ namespace spark_rapids_jni::protobuf::detail {
 
 field_descriptor_bundle make_field_descriptors(std::vector<int> const& field_indices,
                                                protobuf_schema const& schema,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr,
                                                std::span<int const> output_indices)
 {
@@ -58,7 +58,7 @@ namespace {
 inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_parent_locations(
   field_location const* parent_locs,
   int num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_rows >= 0, std::string{__func__} + ": row count must be non-negative");
@@ -106,7 +106,7 @@ inline std::unique_ptr<cudf::column> make_list_column_with_parent_nulls(
   std::unique_ptr<cudf::column> offsets_col,
   std::unique_ptr<cudf::column> child_col,
   field_location const* parent_locs,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto [list_mask, list_null_count] =
@@ -122,7 +122,7 @@ std::unique_ptr<cudf::column> make_list_column_with_input_nulls(
   std::unique_ptr<cudf::column> offsets_col,
   std::unique_ptr<cudf::column> child_col,
   cudf::column_view const& binary_input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const input_null_count = binary_input.null_count();
@@ -139,7 +139,7 @@ std::unique_ptr<cudf::column> make_list_column_with_input_nulls(
 
 std::unique_ptr<cudf::column> make_null_column(cudf::data_type dtype,
                                                cudf::size_type num_rows,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr)
 {
   if (num_rows == 0) { return cudf::make_empty_column(dtype); }
@@ -181,7 +181,7 @@ std::unique_ptr<cudf::column> make_null_column(cudf::data_type dtype,
 }
 
 std::unique_ptr<cudf::column> make_empty_column_safe(cudf::data_type dtype,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   switch (dtype.id()) {
@@ -193,7 +193,7 @@ std::unique_ptr<cudf::column> make_empty_column_safe(cudf::data_type dtype,
                                        rmm::device_buffer{},
                                        0);
       CUDF_CUDA_TRY(cudaMemsetAsync(
-        offsets_col->mutable_view().data<int32_t>(), 0, sizeof(int32_t), stream.value()));
+        offsets_col->mutable_view().data<int32_t>(), 0, sizeof(int32_t), stream.get()));
       auto child_col = std::make_unique<cudf::column>(
         cudf::data_type{cudf::type_id::UINT8}, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
       return cudf::make_lists_column(
@@ -211,7 +211,7 @@ std::unique_ptr<cudf::column> make_empty_column_safe(cudf::data_type dtype,
 std::unique_ptr<cudf::column> make_null_list_column_with_child(
   std::unique_ptr<cudf::column> child_col,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
@@ -223,7 +223,7 @@ std::unique_ptr<cudf::column> make_null_list_column_with_child(
 }
 
 std::unique_ptr<cudf::column> make_empty_list_column(std::unique_ptr<cudf::column> element_col,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
@@ -231,8 +231,8 @@ std::unique_ptr<cudf::column> make_empty_list_column(std::unique_ptr<cudf::colum
                                                     rmm::device_buffer(sizeof(int32_t), stream, mr),
                                                     rmm::device_buffer{},
                                                     0);
-  CUDF_CUDA_TRY(cudaMemsetAsync(
-    offsets_col->mutable_view().data<int32_t>(), 0, sizeof(int32_t), stream.value()));
+  CUDF_CUDA_TRY(
+    cudaMemsetAsync(offsets_col->mutable_view().data<int32_t>(), 0, sizeof(int32_t), stream.get()));
   return cudf::make_lists_column(
     0, std::move(offsets_col), std::move(element_col), 0, rmm::device_buffer{});
 }
@@ -257,7 +257,7 @@ struct enum_string_lookup_tables {
 enum_string_lookup_tables make_enum_string_lookup_tables(
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   auto const scratch_mr = cudf::get_current_device_resource_ref();
   auto d_valid_enums    = cudf::detail::make_device_uvector_async(valid_enums, stream, scratch_mr);
@@ -300,7 +300,7 @@ std::unique_ptr<cudf::column> build_enum_string_values_column(
   rmm::device_uvector<bool>& valid,
   enum_string_lookup_tables const& lookup,
   int num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const scratch_mr = cudf::get_current_device_resource_ref();
@@ -325,7 +325,7 @@ std::unique_ptr<cudf::column> build_enum_string_values_column(
 std::unique_ptr<cudf::column> build_enum_string_column(rmm::device_uvector<int32_t>& enum_values,
                                                        rmm::device_uvector<bool>& valid,
                                                        protobuf_field_decode_request request,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr)
 {
   auto const field = request.context.schema.field(request.schema_idx);
@@ -342,7 +342,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   protobuf_input_view input,
   recursive_decode_context context,
   repeated_field_work work,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   validate_nonempty_repeated_field_work(work, input.num_rows);
@@ -383,7 +383,7 @@ std::unique_ptr<cudf::column> build_repeated_string_column(cudf::column_view con
                                                            protobuf_input_view input,
                                                            repeated_field_work work,
                                                            bool is_bytes,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr)
 {
   validate_nonempty_repeated_field_work(work, input.num_rows);
@@ -397,8 +397,8 @@ std::unique_ptr<cudf::column> build_repeated_string_column(cudf::column_view con
   repeated_location_provider loc_provider{
     input.row_offsets, input.base_offset, work.occurrences->data()};
   extract_lengths_kernel<repeated_location_provider>
-    <<<blocks, threads, 0, stream.value()>>>(loc_provider, total_count, str_lengths.data());
-  CUDF_CHECK_CUDA(stream.value());
+    <<<blocks, threads, 0, stream.get()>>>(loc_provider, total_count, str_lengths.data());
+  CUDF_CHECK_CUDA(stream.get());
 
   auto [str_offsets_col, total_chars] = cudf::strings::detail::make_offsets_child_column(
     str_lengths.begin(), str_lengths.end(), stream, mr);
@@ -434,7 +434,7 @@ std::unique_ptr<cudf::column> build_repeated_string_column(cudf::column_view con
 
     size_t temp_storage_bytes = 0;
     CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(
-      nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, total_count, stream.value()));
+      nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, total_count, stream.get()));
     rmm::device_buffer temp_storage(temp_storage_bytes, stream, scratch_mr);
     CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(temp_storage.data(),
                                              temp_storage_bytes,
@@ -442,7 +442,7 @@ std::unique_ptr<cudf::column> build_repeated_string_column(cudf::column_view con
                                              dst_iter,
                                              size_iter,
                                              total_count,
-                                             stream.value()));
+                                             stream.get()));
   }
 
   std::unique_ptr<cudf::column> child_col;
@@ -481,7 +481,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<int> const& child_field_indices,
   recursive_decode_context context,
   int depth,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const& schema = context.schema;
@@ -621,7 +621,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(protobuf_input_vi
                                                                nested_parent_view parent,
                                                                recursive_decode_context context,
                                                                repeated_field_work work,
-                                                               rmm::cuda_stream_view stream,
+                                                               cuda::stream_ref stream,
                                                                rmm::device_async_resource_ref mr)
 {
   auto const& schema = context.schema;

--- a/src/main/cpp/src/protobuf/protobuf_device_helpers.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_device_helpers.cuh
@@ -20,11 +20,10 @@
 
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/atomic>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 
 #include <concepts>
 #include <type_traits>
@@ -80,7 +79,7 @@ __device__ __forceinline__ void write_varint_value(T* dst, uint64_t val)
 
 void set_error_once_async(protobuf_error* error_flag,
                           protobuf_error error,
-                          rmm::cuda_stream_view stream);
+                          cuda::stream_ref stream);
 
 __device__ inline int get_wire_type_size(proto_wire_type wt, uint8_t const* cur, uint8_t const* end)
 {

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -24,12 +24,12 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/utilities/error.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -93,7 +93,7 @@ struct field_descriptor_bundle {
 
 field_descriptor_bundle make_field_descriptors(std::vector<int> const& field_indices,
                                                protobuf_schema const& schema,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr,
                                                std::span<int const> output_indices = {});
 
@@ -175,7 +175,7 @@ inline list_offsets_from_counts_result make_list_offsets_from_counts(
   CountIterator counts_begin,
   int num_rows,
   char const* count_context,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref output_mr,
   rmm::device_async_resource_ref scratch_mr)
 {
@@ -223,7 +223,7 @@ inline repeated_field_work_bundle make_repeated_field_work_bundle(
   int num_rows,
   protobuf_schema const& schema,
   char const* count_context,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref output_mr,
   rmm::device_async_resource_ref scratch_mr)
 {
@@ -262,7 +262,7 @@ inline repeated_field_work_bundle make_repeated_field_work_bundle(
 inline rmm::device_uvector<int32_t> make_top_row_indices(
   rmm::device_uvector<field_occurrence> const& occurrences,
   int32_t const* parent_top_row_indices,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<int32_t> result(occurrences.size(), stream, mr);
@@ -291,7 +291,7 @@ inline rmm::device_uvector<int32_t> make_top_row_indices(
 template <typename FieldNumberFn>
 inline cudf::detail::host_vector<int> build_lookup_table(FieldNumberFn get_field_number,
                                                          int num_entries,
-                                                         rmm::cuda_stream_view stream)
+                                                         cuda::stream_ref stream)
 {
   if (num_entries == 0) { return cudf::detail::make_pinned_vector_async<int>(0, stream); }
 
@@ -313,7 +313,7 @@ inline cudf::detail::host_vector<int> build_lookup_table(FieldNumberFn get_field
 template <typename FieldDesc>
 inline cudf::detail::host_vector<int> build_field_lookup_table(FieldDesc const* descs,
                                                                int num_fields,
-                                                               rmm::cuda_stream_view stream)
+                                                               cuda::stream_ref stream)
 {
   return build_lookup_table([&](int i) { return descs[i].field_number; }, num_fields, stream);
 }
@@ -334,7 +334,7 @@ struct field_occurrence_scan_bundle {
 
 inline field_occurrence_scan_bundle make_field_occurrence_scan_bundle(
   cudf::detail::host_vector<field_occurrence_scan_desc> const& host_descriptors,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto descriptors = cudf::detail::make_device_uvector_async(host_descriptors, stream, mr);
@@ -371,11 +371,11 @@ inline std::vector<int> const& find_child_field_indices(protobuf_schema const& s
 
 // Forward declarations needed by make_empty_struct_column_with_schema
 std::unique_ptr<cudf::column> make_empty_column_safe(cudf::data_type dtype,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> make_empty_list_column(std::unique_ptr<cudf::column> element_col,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr);
 
 // Forward declaration for the mutual recursion with make_empty_struct_column_from_children.
@@ -383,7 +383,7 @@ template <typename SchemaT>
 std::unique_ptr<cudf::column> make_empty_struct_column_with_schema(
   SchemaT const& schema,
   int parent_idx,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 // Build an empty (0-row) STRUCT column from an explicit child-index list, recursing into
@@ -393,7 +393,7 @@ template <typename SchemaT>
 std::unique_ptr<cudf::column> make_empty_struct_column_from_children(
   SchemaT const& schema,
   std::vector<int> const& child_indices,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   std::vector<std::unique_ptr<cudf::column>> children;
@@ -419,10 +419,7 @@ std::unique_ptr<cudf::column> make_empty_struct_column_from_children(
 
 template <typename SchemaT>
 std::unique_ptr<cudf::column> make_empty_struct_column_with_schema(
-  SchemaT const& schema,
-  int parent_idx,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
+  SchemaT const& schema, int parent_idx, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   auto const& child_indices = find_child_field_indices(schema, parent_idx);
   return make_empty_struct_column_from_children(schema, child_indices, stream, mr);
@@ -432,26 +429,26 @@ void maybe_check_required_fields(required_field_input_view input,
                                  std::vector<int> const& field_indices,
                                  std::vector<nested_field_descriptor> const& schema,
                                  protobuf_decode_runtime_context decode_ctx,
-                                 rmm::cuda_stream_view stream);
+                                 cuda::stream_ref stream);
 
 void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_invalid,
                                           protobuf_decode_runtime_context decode_ctx,
                                           protobuf_value_domain_view value_domain,
-                                          rmm::cuda_stream_view stream);
+                                          cuda::stream_ref stream);
 
 void validate_enum_and_propagate_rows(rmm::device_uvector<int32_t> const& values,
                                       rmm::device_uvector<bool>& valid,
                                       enum_domain_device_view enum_domain,
                                       protobuf_decode_runtime_context decode_ctx,
                                       protobuf_value_domain_view value_domain,
-                                      rmm::cuda_stream_view stream);
+                                      cuda::stream_ref stream);
 
 void validate_enum_and_propagate_rows(rmm::device_uvector<int32_t> const& values,
                                       rmm::device_uvector<bool>& valid,
                                       cudf::detail::host_vector<int32_t> const& valid_enums,
                                       protobuf_decode_runtime_context decode_ctx,
                                       protobuf_value_domain_view value_domain,
-                                      rmm::cuda_stream_view stream);
+                                      cuda::stream_ref stream);
 
 // ============================================================================
 // Forward declarations of builder/utility functions
@@ -459,7 +456,7 @@ void validate_enum_and_propagate_rows(rmm::device_uvector<int32_t> const& values
 
 std::unique_ptr<cudf::column> make_null_column(cudf::data_type dtype,
                                                cudf::size_type num_rows,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr);
 
 // Schema-aware all-null builder: recurses into STRUCT children and wraps repeated fields
@@ -468,19 +465,19 @@ std::unique_ptr<cudf::column> make_null_column(cudf::data_type dtype,
 std::unique_ptr<cudf::column> make_null_column_with_schema(protobuf_schema const& schema,
                                                            int schema_idx,
                                                            cudf::size_type num_rows,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> make_null_list_column_with_child(
   std::unique_ptr<cudf::column> child_col,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> build_enum_string_column(rmm::device_uvector<int32_t>& enum_values,
                                                        rmm::device_uvector<bool>& valid,
                                                        protobuf_field_decode_request request,
-                                                       rmm::cuda_stream_view stream,
+                                                       cuda::stream_ref stream,
                                                        rmm::device_async_resource_ref mr);
 
 // Wrap offsets + child into a LIST column, propagating the input's null mask. Note: when
@@ -491,7 +488,7 @@ std::unique_ptr<cudf::column> make_list_column_with_input_nulls(
   std::unique_ptr<cudf::column> offsets_col,
   std::unique_ptr<cudf::column> child_col,
   cudf::column_view const& binary_input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> build_repeated_enum_string_column(
@@ -499,14 +496,14 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   protobuf_input_view input,
   recursive_decode_context context,
   repeated_field_work work,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> build_repeated_string_column(cudf::column_view const& binary_input,
                                                            protobuf_input_view input,
                                                            repeated_field_work work,
                                                            bool is_bytes,
-                                                           rmm::cuda_stream_view stream,
+                                                           cuda::stream_ref stream,
                                                            rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> build_nested_struct_column(
@@ -515,14 +512,14 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<int> const& child_field_indices,
   recursive_decode_context context,
   int depth,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);
 
 std::unique_ptr<cudf::column> build_repeated_child_list_column(protobuf_input_view input,
                                                                nested_parent_view parent,
                                                                recursive_decode_context context,
                                                                repeated_field_work work,
-                                                               rmm::cuda_stream_view stream,
+                                                               cuda::stream_ref stream,
                                                                rmm::device_async_resource_ref mr);
 
 }  // namespace spark_rapids_jni::protobuf::detail

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -732,53 +732,51 @@ CUDF_KERNEL void copy_enum_string_chars_kernel(enum_value_device_view input,
 // Host wrapper functions — callable from other translation units
 // ============================================================================
 
-void set_error_once_async(protobuf_error* error_flag,
-                          protobuf_error error,
-                          rmm::cuda_stream_view stream)
+void set_error_once_async(protobuf_error* error_flag, protobuf_error error, cuda::stream_ref stream)
 {
-  set_error_if_unset_kernel<<<1, 1, 0, stream.value()>>>(error_flag, error);
-  CUDF_CHECK_CUDA(stream.value());
+  set_error_if_unset_kernel<<<1, 1, 0, stream.get()>>>(error_flag, error);
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_scan_all_fields(cudf::column_device_view const& d_in,
                             field_scan_view fields,
                             protobuf_error* error_flag,
                             bool* row_has_invalid_data,
-                            rmm::cuda_stream_view stream)
+                            cuda::stream_ref stream)
 {
   auto const num_rows = d_in.size();
   if (num_rows == 0) return;
   auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  scan_all_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  scan_all_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     d_in, fields, error_flag, row_has_invalid_data);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_count_repeated_fields(cudf::column_device_view const& d_in,
                                   field_scan_view fields,
                                   protobuf_error* error_flag,
                                   bool* row_has_invalid_data,
-                                  rmm::cuda_stream_view stream)
+                                  cuda::stream_ref stream)
 {
   auto const num_rows = d_in.size();
   if (num_rows == 0) return;
   auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  count_repeated_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  count_repeated_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     d_in, fields, error_flag, row_has_invalid_data);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_scan_all_field_occurrences(cudf::column_device_view const& d_in,
                                        field_occurrence_scan_view fields,
                                        protobuf_error* error_flag,
-                                       rmm::cuda_stream_view stream)
+                                       cuda::stream_ref stream)
 {
   auto const num_rows = d_in.size();
   if (num_rows == 0) return;
   auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  scan_all_field_occurrences_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  scan_all_field_occurrences_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     d_in, fields, error_flag);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_extract_strided_locations(field_location const* nested_locations,
@@ -786,13 +784,13 @@ void launch_extract_strided_locations(field_location const* nested_locations,
                                       int num_fields,
                                       field_location* parent_locs,
                                       int num_rows,
-                                      rmm::cuda_stream_view stream)
+                                      cuda::stream_ref stream)
 {
   if (num_rows == 0) return;
   auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  extract_strided_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  extract_strided_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     nested_locations, field_idx, num_fields, parent_locs, num_rows);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_scan_nested_message_fields(protobuf_input_view input,
@@ -800,85 +798,85 @@ void launch_scan_nested_message_fields(protobuf_input_view input,
                                        field_scan_view fields,
                                        protobuf_error* error_flag,
                                        bool* row_has_invalid_data,
-                                       rmm::cuda_stream_view stream)
+                                       cuda::stream_ref stream)
 {
   if (input.num_rows == 0) return;
   auto const blocks =
     static_cast<int>((input.num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  scan_nested_message_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  scan_nested_message_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     input, parent, fields, error_flag, row_has_invalid_data);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_scan_all_field_occurrences_in_nested(protobuf_input_view input,
                                                  nested_parent_view parent,
                                                  field_occurrence_scan_view fields,
                                                  protobuf_error* error_flag,
-                                                 rmm::cuda_stream_view stream)
+                                                 cuda::stream_ref stream)
 {
   if (input.num_rows == 0) return;
   auto const blocks =
     static_cast<int>((input.num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  scan_all_field_occurrences_in_nested_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  scan_all_field_occurrences_in_nested_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     input, parent, fields, error_flag);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_compute_grandchild_parent_locations(nested_location_provider loc_provider,
                                                 field_location* gc_parent_locs,
                                                 int num_rows,
                                                 protobuf_error* error_flag,
-                                                rmm::cuda_stream_view stream)
+                                                cuda::stream_ref stream)
 {
   if (num_rows == 0) return;
   auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  compute_grandchild_parent_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  compute_grandchild_parent_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     loc_provider, gc_parent_locs, num_rows, error_flag);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_validate_enum_values(enum_value_device_view input,
                                  bool* row_has_invalid_enum,
                                  enum_domain_device_view domain,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
 {
   if (input.size == 0) return;
   auto const blocks = static_cast<int>((input.size + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  validate_enum_values_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  validate_enum_values_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     input, row_has_invalid_enum, domain);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_compute_enum_string_lengths(enum_value_device_view input,
                                         enum_string_lookup_device_view lookup,
                                         int32_t* lengths,
-                                        rmm::cuda_stream_view stream)
+                                        cuda::stream_ref stream)
 {
   if (input.size == 0) return;
   auto const blocks = static_cast<int>((input.size + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  compute_enum_string_lengths_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  compute_enum_string_lengths_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     input, lookup, lengths);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void launch_copy_enum_string_chars(enum_value_device_view input,
                                    enum_string_lookup_device_view lookup,
                                    int32_t const* output_offsets,
                                    char* out_chars,
-                                   rmm::cuda_stream_view stream)
+                                   cuda::stream_ref stream)
 {
   if (input.size == 0) return;
   auto const blocks = static_cast<int>((input.size + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  copy_enum_string_chars_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  copy_enum_string_chars_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     input, lookup, output_offsets, out_chars);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void maybe_check_required_fields(required_field_input_view input,
                                  std::vector<int> const& field_indices,
                                  std::vector<nested_field_descriptor> const& schema,
                                  protobuf_decode_runtime_context decode_ctx,
-                                 rmm::cuda_stream_view stream)
+                                 cuda::stream_ref stream)
 {
   if (input.values.size == 0 || field_indices.empty()) { return; }
 
@@ -897,19 +895,19 @@ void maybe_check_required_fields(required_field_input_view input,
 
   auto const blocks =
     static_cast<int>((input.values.size + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  check_required_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+  check_required_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     input,
     d_is_required.data(),
     static_cast<int>(field_indices.size()),
     !decode_ctx.row_force_null->is_empty() ? decode_ctx.row_force_null->data() : nullptr,
     decode_ctx.error->data());
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 }
 
 void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_invalid,
                                           protobuf_decode_runtime_context decode_ctx,
                                           protobuf_value_domain_view value_domain,
-                                          rmm::cuda_stream_view stream)
+                                          cuda::stream_ref stream)
 {
   auto& row_invalid            = *decode_ctx.row_force_null;
   auto const num_items         = value_domain.size;
@@ -955,7 +953,7 @@ void validate_enum_and_propagate_rows(rmm::device_uvector<int32_t> const& values
                                       enum_domain_device_view enum_domain,
                                       protobuf_decode_runtime_context decode_ctx,
                                       protobuf_value_domain_view value_domain,
-                                      rmm::cuda_stream_view stream)
+                                      cuda::stream_ref stream)
 {
   if (value_domain.size == 0 || enum_domain.size == 0) return;
 
@@ -974,7 +972,7 @@ void validate_enum_and_propagate_rows(rmm::device_uvector<int32_t> const& values
                                       cudf::detail::host_vector<int32_t> const& valid_enums,
                                       protobuf_decode_runtime_context decode_ctx,
                                       protobuf_value_domain_view value_domain,
-                                      rmm::cuda_stream_view stream)
+                                      cuda::stream_ref stream)
 {
   if (value_domain.size == 0 || valid_enums.empty()) return;
 

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -390,38 +390,38 @@ void launch_count_repeated_fields(cudf::column_device_view const& d_in,
                                   field_scan_view fields,
                                   protobuf_error* error_flag,
                                   bool* row_has_invalid_data,
-                                  rmm::cuda_stream_view stream);
+                                  cuda::stream_ref stream);
 
 void launch_scan_all_field_occurrences(cudf::column_device_view const& d_in,
                                        field_occurrence_scan_view fields,
                                        protobuf_error* error_flag,
-                                       rmm::cuda_stream_view stream);
+                                       cuda::stream_ref stream);
 
 void launch_extract_strided_locations(field_location const* nested_locations,
                                       int field_idx,
                                       int num_fields,
                                       field_location* parent_locs,
                                       int num_rows,
-                                      rmm::cuda_stream_view stream);
+                                      cuda::stream_ref stream);
 
 void launch_scan_nested_message_fields(protobuf_input_view input,
                                        nested_parent_view parent,
                                        field_scan_view fields,
                                        protobuf_error* error_flag,
                                        bool* row_has_invalid_data,
-                                       rmm::cuda_stream_view stream);
+                                       cuda::stream_ref stream);
 
 void launch_scan_all_field_occurrences_in_nested(protobuf_input_view input,
                                                  nested_parent_view parent,
                                                  field_occurrence_scan_view fields,
                                                  protobuf_error* error_flag,
-                                                 rmm::cuda_stream_view stream);
+                                                 cuda::stream_ref stream);
 
 void launch_compute_grandchild_parent_locations(nested_location_provider loc_provider,
                                                 field_location* gc_parent_locs,
                                                 int num_rows,
                                                 protobuf_error* error_flag,
-                                                rmm::cuda_stream_view stream);
+                                                cuda::stream_ref stream);
 
 // ============================================================================
 // Host-side template helpers that launch CUDA kernels
@@ -432,7 +432,7 @@ template <typename T>
 inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_valid(
   rmm::device_uvector<T> const& valid,
   cudf::size_type num_rows,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_rows >= 0, "num_rows must be non-negative");
@@ -456,14 +456,14 @@ inline void extract_scalar_into_buffers(uint8_t const* message_data,
                                         proto_encoding encoding,
                                         scalar_decode_options<T> options,
                                         scalar_value_output<T> output,
-                                        rmm::cuda_stream_view stream)
+                                        cuda::stream_ref stream)
 {
   auto constexpr threads = THREADS_PER_BLOCK;
   auto const blocks      = static_cast<int>((num_rows + threads - 1u) / threads);
   dispatch_scalar_decoder<T>(get_scalar_decode_kind<T>(encoding), [&]<auto DecodeFn>() {
-    extract_scalar_kernel<T, DecodeFn><<<blocks, threads, 0, stream.value()>>>(
-      message_data, loc_provider, num_rows, output, options);
-    CUDF_CHECK_CUDA(stream.value());
+    extract_scalar_kernel<T, DecodeFn>
+      <<<blocks, threads, 0, stream.get()>>>(message_data, loc_provider, num_rows, output, options);
+    CUDF_CHECK_CUDA(stream.get());
   });
 }
 
@@ -488,7 +488,7 @@ std::unique_ptr<cudf::column> extract_and_build_scalar_field_column(
   LocationProvider const& loc_provider,
   int num_rows,
   protobuf_decode_runtime_context decode_ctx,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   if (num_rows == 0) { return cudf::make_empty_column(field.output_type); }
@@ -517,7 +517,7 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
   ValidityFn validity_fn,
   bool has_default,
   cudf::detail::host_vector<uint8_t> const& default_bytes,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   int32_t def_len       = has_default ? static_cast<int32_t>(default_bytes.size()) : 0;
@@ -530,9 +530,9 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
   rmm::device_uvector<int32_t> lengths(num_rows, stream, scratch_mr);
   auto const threads = THREADS_PER_BLOCK;
   auto const blocks  = static_cast<int>((num_rows + threads - 1u) / threads);
-  extract_lengths_kernel<LocationProvider><<<blocks, threads, 0, stream.value()>>>(
+  extract_lengths_kernel<LocationProvider><<<blocks, threads, 0, stream.get()>>>(
     loc_provider, num_rows, lengths.data(), has_default, def_len);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 
   auto [offsets_col, total_size] =
     cudf::strings::detail::make_offsets_child_column(lengths.begin(), lengths.end(), stream, mr);
@@ -573,7 +573,7 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
 
     size_t temp_storage_bytes = 0;
     CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(
-      nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, num_rows, stream.value()));
+      nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, num_rows, stream.get()));
     rmm::device_buffer temp_storage(temp_storage_bytes, stream, scratch_mr);
     CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(temp_storage.data(),
                                              temp_storage_bytes,
@@ -581,7 +581,7 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
                                              dst_iter,
                                              size_iter,
                                              num_rows,
-                                             stream.value()));
+                                             stream.get()));
   }
 
   if (num_rows == 0) {
@@ -616,7 +616,7 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
 template <typename LocationProvider>
 inline std::unique_ptr<cudf::column> extract_typed_column(protobuf_field_decode_request request,
                                                           LocationProvider const& loc_provider,
-                                                          rmm::cuda_stream_view stream,
+                                                          cuda::stream_ref stream,
                                                           rmm::device_async_resource_ref mr)
 {
   auto const field           = request.context.schema.field(request.schema_idx);
@@ -676,7 +676,7 @@ inline std::unique_ptr<cudf::column> build_protobuf_field_values_column(
   LocationProvider const& loc_provider,
   ValidityFn validity_fn,
   TopRowIndexProvider get_top_row_indices,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto const message_data = request.message_data;
@@ -755,7 +755,7 @@ inline std::unique_ptr<cudf::column> build_repeated_scalar_column(
   protobuf_field_meta_view field,
   repeated_field_work work,
   rmm::device_uvector<protobuf_error>& d_error,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   validate_nonempty_repeated_field_work(work, input.num_rows);
@@ -788,22 +788,22 @@ void launch_scan_all_fields(cudf::column_device_view const& d_in,
                             field_scan_view fields,
                             protobuf_error* error_flag,
                             bool* row_has_invalid_data,
-                            rmm::cuda_stream_view stream);
+                            cuda::stream_ref stream);
 
 void launch_validate_enum_values(enum_value_device_view input,
                                  bool* row_has_invalid_enum,
                                  enum_domain_device_view domain,
-                                 rmm::cuda_stream_view stream);
+                                 cuda::stream_ref stream);
 
 void launch_compute_enum_string_lengths(enum_value_device_view input,
                                         enum_string_lookup_device_view lookup,
                                         int32_t* lengths,
-                                        rmm::cuda_stream_view stream);
+                                        cuda::stream_ref stream);
 
 void launch_copy_enum_string_chars(enum_value_device_view input,
                                    enum_string_lookup_device_view lookup,
                                    int32_t const* output_offsets,
                                    char* out_chars,
-                                   rmm::cuda_stream_view stream);
+                                   cuda::stream_ref stream);
 
 }  // namespace spark_rapids_jni::protobuf::detail

--- a/src/main/cpp/src/regex_rewrite_utils.cu
+++ b/src/main/cpp/src/regex_rewrite_utils.cu
@@ -26,9 +26,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/stream_ref>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
@@ -69,7 +69,7 @@ std::unique_ptr<cudf::column> find_literal_range_pattern(cudf::strings_column_vi
                                                          int const range_len,
                                                          int const start,
                                                          int const end,
-                                                         rmm::cuda_stream_view stream,
+                                                         cuda::stream_ref stream,
                                                          rmm::device_async_resource_ref mr)
 {
   auto const strings_count = strings.size();
@@ -126,7 +126,7 @@ std::unique_ptr<cudf::column> literal_range_pattern(cudf::strings_column_view co
                                                     int const range_len,
                                                     int const start,
                                                     int const end,
-                                                    rmm::cuda_stream_view stream,
+                                                    cuda::stream_ref stream,
                                                     rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/regex_rewrite_utils.hpp
+++ b/src/main/cpp/src/regex_rewrite_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/regex_rewrite_utils.hpp
+++ b/src/main/cpp/src/regex_rewrite_utils.hpp
@@ -40,6 +40,6 @@ std::unique_ptr<cudf::column> literal_range_pattern(
   int const len,
   int const start,
   int const end,
-  rmm::cuda_stream_view stream      = rmm::cuda_stream_default,
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/reverse_strings.cu
+++ b/src/main/cpp/src/reverse_strings.cu
@@ -25,11 +25,11 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/iterator>
 #include <cuda/std/algorithm>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 
 #include <stdint.h>
@@ -94,7 +94,7 @@ struct reverse_characters_fn {
 }  // namespace
 
 std::unique_ptr<cudf::column> reverse_strings(cudf::strings_column_view const& input,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::type_id::STRING); }
@@ -118,7 +118,7 @@ std::unique_ptr<cudf::column> reverse_strings(cudf::strings_column_view const& i
 }  // namespace detail
 
 std::unique_ptr<cudf::column> reverse_strings(cudf::strings_column_view const& input,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/reverse_strings.hpp
+++ b/src/main/cpp/src/reverse_strings.hpp
@@ -42,7 +42,7 @@ namespace spark_rapids_jni {
  */
 std::unique_ptr<cudf::column> reverse_strings(
   cudf::strings_column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/round_float.cu
+++ b/src/main/cpp/src/round_float.cu
@@ -27,10 +27,10 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 #include <thrust/find.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
@@ -100,7 +100,7 @@ struct half_even_negative {
 template <typename T, template <typename> typename RoundFunctor>
 std::unique_ptr<cudf::column> round_with(cudf::column_view const& input,
                                          int32_t decimal_places,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
   requires(std::is_floating_point_v<T>)
 {
@@ -139,7 +139,7 @@ struct round_type_dispatcher {
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
                                            int32_t decimal_places,
                                            cudf::rounding_method method,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
     requires(std::is_floating_point_v<T>)
   {
@@ -162,7 +162,7 @@ struct round_type_dispatcher {
 std::unique_ptr<cudf::column> round(cudf::column_view const& input,
                                     int32_t decimal_places,
                                     cudf::rounding_method method,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -260,7 +260,7 @@ template <typename T>
 cudf::size_type find_first_overflow_for_integral_type(cudf::column_view const& input,
                                                       int32_t decimal_places,
                                                       cudf::rounding_method method,
-                                                      rmm::cuda_stream_view stream)
+                                                      cuda::stream_ref stream)
 {
   static_assert(std::is_integral_v<T>, "T must be an integral type");
 
@@ -297,7 +297,7 @@ struct find_overflow_dispatcher {
   cudf::size_type operator()(cudf::column_view const& input,
                              int32_t decimal_places,
                              cudf::rounding_method method,
-                             rmm::cuda_stream_view stream) const
+                             cuda::stream_ref stream) const
   {
     if constexpr (std::is_integral_v<T>) {
       return find_first_overflow_for_integral_type<T>(input, decimal_places, method, stream);
@@ -313,7 +313,7 @@ std::unique_ptr<cudf::column> round(cudf::column_view const& input,
                                     int32_t decimal_places,
                                     cudf::rounding_method method,
                                     bool is_ansi_mode,
-                                    rmm::cuda_stream_view stream,
+                                    cuda::stream_ref stream,
                                     rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/round_float.hpp
+++ b/src/main/cpp/src/round_float.hpp
@@ -23,8 +23,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -66,7 +67,7 @@ std::unique_ptr<cudf::column> round(
   cudf::column_view const& input,
   int32_t decimal_places            = 0,
   cudf::rounding_method method      = cudf::rounding_method::HALF_UP,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -101,7 +102,7 @@ std::unique_ptr<cudf::column> round(
   int32_t decimal_places,
   cudf::rounding_method method,
   bool is_ansi_mode,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -36,7 +36,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
@@ -48,6 +47,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/scan.h>
 
@@ -219,7 +219,7 @@ struct batch_data {
 std::pair<rmm::device_uvector<size_type>, rmm::device_uvector<cudf::detail::input_offsetalator>>
 build_string_row_offsets(table_view const& tbl,
                          size_type fixed_width_and_validity_size,
-                         rmm::cuda_stream_view stream)
+                         cuda::stream_ref stream)
 {
   auto const num_rows = tbl.num_rows();
   rmm::device_uvector<size_type> d_row_sizes(num_rows, stream);
@@ -1269,7 +1269,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
   rmm::device_uvector<bitmask_type const*>& input_nm,
   scalar const& zero,
   scalar const& scalar_size_per_row,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   int64_t const total_allocation = size_per_row * num_rows;
@@ -1292,7 +1292,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
   int shared_size =
     detail::calc_fixed_width_kernel_dims(num_columns, num_rows, size_per_row, blocks, threads);
 
-  copy_to_rows_fixed_width_optimized<<<blocks, threads, shared_size, stream.value()>>>(
+  copy_to_rows_fixed_width_optimized<<<blocks, threads, shared_size, stream.get()>>>(
     start_row,
     num_rows,
     num_columns,
@@ -1507,7 +1507,7 @@ template <typename RowSize>
 batch_data build_batches(size_type num_rows,
                          RowSize row_sizes,
                          bool all_fixed_width,
-                         rmm::cuda_stream_view stream,
+                         cuda::stream_ref stream,
                          rmm::device_async_resource_ref mr)
 {
   auto const total_size =
@@ -1601,7 +1601,7 @@ batch_data build_batches(size_type num_rows,
                                     output_batch_row_offsets.data(),
                                     num_rows_in_batch * sizeof(size_type),
                                     cudaMemcpyDefault,
-                                    stream.value()));
+                                    stream.get()));
     }
 
     batch_row_boundaries.push_back(row_end);
@@ -1627,7 +1627,7 @@ batch_data build_batches(size_type num_rows,
  */
 int compute_tile_counts(device_span<size_type const> const& batch_row_boundaries,
                         int desired_tile_height,
-                        rmm::cuda_stream_view stream)
+                        cuda::stream_ref stream)
 {
   size_type const num_batches = batch_row_boundaries.size() - 1;
   device_uvector<size_type> num_tiles(num_batches, stream);
@@ -1668,7 +1668,7 @@ size_type build_tiles(
   int column_end,
   int desired_tile_height,
   int total_number_of_rows,
-  rmm::cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   size_type const num_batches = batch_row_boundaries.size() - 1;
   device_uvector<size_type> num_tiles(num_batches, stream);
@@ -1831,7 +1831,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   offsetFunctor offset_functor,
   column_info_s const& column_info,
   std::optional<rmm::device_uvector<cudf::detail::input_offsetalator>> variable_width_offsets,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   int device_id;
@@ -1948,7 +1948,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
   // blast through the entire table and convert it
   detail::copy_to_rows<BLOCK_SIZE>
-    <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+    <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.get()>>>(
       num_rows,
       tbl.num_columns(),
       shmem_limit_per_tile,
@@ -1962,7 +1962,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
   // note that validity gets the entire table and not the fixed-width portion
   detail::copy_validity_to_rows<BLOCK_SIZE>
-    <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+    <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.get()>>>(
       num_rows,
       tbl.num_columns(),
       shmem_limit_per_tile,
@@ -2005,7 +2005,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
       // batch_num_rows) so the inner loop guard `row < num_rows` works for every batch,
       // including batches whose start lies past per-batch row_count.
       detail::copy_strings_to_rows<NUM_STRING_ROWS_PER_BLOCK_TO_ROWS>
-        <<<string_blocks, NUM_STRING_ROWS_PER_BLOCK_TO_ROWS, 0, stream.value()>>>(
+        <<<string_blocks, NUM_STRING_ROWS_PER_BLOCK_TO_ROWS, 0, stream.get()>>>(
           batch_row_offset + batch_num_rows,
           variable_width_table.num_columns(),
           dev_variable_input_data.data(),
@@ -2019,7 +2019,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
     // Drain the async H2D uploads above before variable_width_input_data goes out of scope:
     // CUDA 13+ may read the host source only when the stream executes the copy.
-    stream.synchronize();
+    stream.sync();
   }
 
   // split up the output buffer into multiple buffers based on row batch sizes and create list of
@@ -2054,7 +2054,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   // Drain the async H2D uploads above before input_data, input_nm, output_data and
   // validity_tile_infos go out of scope: CUDA 13+ may read the host source only when the stream
   // executes the copy.
-  stream.synchronize();
+  stream.sync();
 
   return ret;
 }
@@ -2121,7 +2121,7 @@ inline void check_supported_schema(std::vector<data_type> const& schema, bool fi
  * @return vector of list columns containing byte columns of the JCUDF row data
  */
 std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
-                                                     rmm::cuda_stream_view stream,
+                                                     cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -2184,7 +2184,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
 }
 
 std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
-  table_view const& tbl, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
+  table_view const& tbl, cuda::stream_ref stream, rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
   // check_supported_columns rejects non-fixed-width columns up front, so the body below does not
@@ -2225,11 +2225,11 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
   auto dev_input_nm   = make_device_uvector_async(input_nm, stream, mr);
 
   using ScalarType = scalar_type_t<size_type>;
-  auto zero        = make_numeric_scalar(data_type(type_id::INT32), stream.value());
+  auto zero        = make_numeric_scalar(data_type(type_id::INT32), stream.get());
   zero->set_valid_async(true, stream);
   static_cast<ScalarType*>(zero.get())->set_value(0, stream);
 
-  auto step = make_numeric_scalar(data_type(type_id::INT32), stream.value());
+  auto step = make_numeric_scalar(data_type(type_id::INT32), stream.get());
   step->set_valid_async(true, stream);
   static_cast<ScalarType*>(step.get())->set_value(static_cast<size_type>(size_per_row), stream);
 
@@ -2253,7 +2253,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
 
   // Drain the async H2D uploads above before column_start, column_size, input_data and input_nm
   // go out of scope: CUDA 13+ may read the host source only when the stream executes the copy.
-  stream.synchronize();
+  stream.sync();
 
   return ret;
 }
@@ -2262,7 +2262,7 @@ namespace {
 
 /// @brief Calculates and sets null counts for specified columns
 void fixup_null_counts(std::vector<std::unique_ptr<column>>& output_columns,
-                       rmm::cuda_stream_view stream)
+                       cuda::stream_ref stream)
 {
   for (auto& col : output_columns) {
     col->set_null_count(cudf::null_count(col->view().null_mask(), 0, col->size(), stream));
@@ -2282,7 +2282,7 @@ void fixup_null_counts(std::vector<std::unique_ptr<column>>& output_columns,
  */
 std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
                                          std::vector<data_type> const& schema,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -2353,7 +2353,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     auto make_col = [&output_data, &output_nm](data_type type,
                                                size_type num_rows,
                                                bool include_nm,
-                                               rmm::cuda_stream_view stream,
+                                               cuda::stream_ref stream,
                                                rmm::device_async_resource_ref mr) {
       auto column =
         make_fixed_width_column(type,
@@ -2458,7 +2458,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     detail::fixed_width_row_offset_functor offset_functor(size_per_row);
 
     detail::copy_from_rows<BLOCK_SIZE>
-      <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+      <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.get()>>>(
         num_rows,
         num_columns,
         shmem_limit_per_tile,
@@ -2471,7 +2471,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
         child.data<int8_t>());
 
     detail::copy_validity_from_rows<BLOCK_SIZE>
-      <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+      <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.get()>>>(
         num_rows,
         num_columns,
         shmem_limit_per_tile,
@@ -2485,7 +2485,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
   } else {
     detail::string_row_offset_functor offset_functor(device_span<size_type const>{input.offsets()});
     detail::copy_from_rows<BLOCK_SIZE>
-      <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+      <<<gpu_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.get()>>>(
         num_rows,
         num_columns,
         shmem_limit_per_tile,
@@ -2498,7 +2498,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
         child.data<int8_t>());
 
     detail::copy_validity_from_rows<BLOCK_SIZE>
-      <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.value()>>>(
+      <<<validity_tile_infos.size(), BLOCK_SIZE, total_shmem_in_bytes, stream.get()>>>(
         num_rows,
         num_columns,
         shmem_limit_per_tile,
@@ -2545,7 +2545,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
                MAX_STRING_BLOCKS));
 
     detail::copy_strings_from_rows<NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS>
-      <<<string_blocks, NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS, 0, stream.value()>>>(
+      <<<string_blocks, NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS, 0, stream.get()>>>(
         offset_functor,
         dev_string_row_offsets.data(),
         dev_string_lengths.data(),
@@ -2575,7 +2575,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
 
     // Drain the async H2D uploads above before string_col_offset_ptrs and string_data_col_ptrs
     // go out of scope: CUDA 13+ may read the host source only when the stream executes the copy.
-    stream.synchronize();
+    stream.sync();
   }
 
   // Set null counts, because output_columns are modified via mutable-view,
@@ -2586,14 +2586,14 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
   // Explicitly drain async H2D uploads before the host staging vectors go out of scope
   // (CUDA 13+ may read the host source only at stream-execution time). Not left to the
   // incidental sync in fixup_null_counts, which vanishes if null counts move into the kernel.
-  stream.synchronize();
+  stream.sync();
 
   return std::make_unique<table>(std::move(output_columns));
 }
 
 std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view const& input,
                                                                std::vector<data_type> const& schema,
-                                                               rmm::cuda_stream_view stream,
+                                                               cuda::stream_ref stream,
                                                                rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -2646,7 +2646,7 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
   int shared_size =
     detail::calc_fixed_width_kernel_dims(num_columns, num_rows, size_per_row, blocks, threads);
 
-  detail::copy_from_rows_fixed_width_optimized<<<blocks, threads, shared_size, stream.value()>>>(
+  detail::copy_from_rows_fixed_width_optimized<<<blocks, threads, shared_size, stream.get()>>>(
     num_rows,
     num_columns,
     size_per_row,
@@ -2664,7 +2664,7 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
   // Explicitly drain async H2D uploads before the host staging vectors go out of scope
   // (CUDA 13+ may read the host source only at stream-execution time). Not left to the
   // incidental sync in fixup_null_counts, which vanishes if null counts move into the kernel.
-  stream.synchronize();
+  stream.sync();
 
   return std::make_unique<table>(std::move(output_columns));
 }

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -20,8 +20,9 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -30,25 +31,25 @@ namespace spark_rapids_jni {
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows_fixed_width_optimized(
   cudf::table_view const& tbl,
   // TODO need something for validity
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows(
   cudf::table_view const& tbl,
   // TODO need something for validity
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
   cudf::lists_column_view const& input,
   std::vector<cudf::data_type> const& schema,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::table> convert_from_rows(
   cudf::lists_column_view const& input,
   std::vector<cudf::data_type> const& schema,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -35,7 +35,6 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_memcpy.cuh>
@@ -43,6 +42,7 @@
 #include <cuda/std/bit>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
@@ -176,7 +176,7 @@ int compute_offset_column_info_traverse(cudf::host_span<shuffle_split_col_data c
  */
 rmm::device_uvector<offset_column_info> compute_offset_column_info(
   shuffle_split_metadata const& metadata,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   std::vector<offset_column_info> offset_info;
@@ -295,7 +295,7 @@ std::tuple<rmm::device_uvector<assemble_column_info>,
 assemble_build_column_info(shuffle_split_metadata const& h_global_metadata,
                            cudf::device_span<uint8_t const> partitions,
                            cudf::device_span<size_t const> partition_offsets,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            rmm::device_async_resource_ref mr)
 {
   auto temp_mr = cudf::get_current_device_resource_ref();
@@ -422,7 +422,7 @@ assemble_build_column_info(shuffle_split_metadata const& h_global_metadata,
     // each partition linearly. to fix this, we'd have to change the kudo format in a way that would
     // increase it's size. I'm doing this as a kernel instead of through thrust so that I can
     // guarantee each partition is being marched by a seperate block to avoid thread divergence.
-    compute_offset_child_row_counts<<<num_partitions, 32, 0, stream.value()>>>(
+    compute_offset_child_row_counts<<<num_partitions, 32, 0, stream.get()>>>(
       offset_column_info,
       global_metadata,
       column_instance_info,
@@ -652,7 +652,7 @@ rmm::device_uvector<std::invoke_result_t<GroupFunction>> transform_expand(
   SizeIterator first,
   SizeIterator last,
   GroupFunction op,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto temp_mr = cudf::get_current_device_resource_ref();
@@ -870,7 +870,7 @@ std::pair<shuffle_assemble_result, rmm::device_uvector<assemble_batch>> assemble
   cudf::device_span<uint8_t const> partitions,
   cudf::device_span<size_t const> partition_offsets,
   size_t per_partition_metadata_size,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   auto temp_mr                    = cudf::get_current_device_resource_ref();
@@ -1348,7 +1348,7 @@ std::pair<shuffle_assemble_result, rmm::device_uvector<assemble_batch>> assemble
   // Drain the async H2D uploads above before h_dst_buffers and the batched_memset span vector
   // (spans_to_zero) go out of scope: CUDA 13+ may read the host source only when the stream
   // executes the copy.
-  stream.synchronize();
+  stream.sync();
 
   // Return shuffle assemble result with slices and copy batches (column_views will be populated
   // later)
@@ -1588,7 +1588,7 @@ __global__ void copy_offsets(cudf::device_span<assemble_batch> batches)
 void assemble_copy(cudf::device_span<assemble_batch> batches,
                    cudf::device_span<assemble_column_info const> column_info,
                    cudf::host_span<assemble_column_info> h_column_info,
-                   rmm::cuda_stream_view stream)
+                   cuda::stream_ref stream)
 {
   // TODO: it might make sense to launch these three copies on separate streams. It is likely that
   // the validity and offset copies will be much smaller than the data copies and could
@@ -1636,12 +1636,12 @@ void assemble_copy(cudf::device_span<assemble_batch> batches,
   // copy validity
   constexpr int copy_validity_block_size = 128;
   copy_validity<copy_validity_block_size>
-    <<<batches.size(), copy_validity_block_size, 0, stream.value()>>>(batches);
+    <<<batches.size(), copy_validity_block_size, 0, stream.get()>>>(batches);
 
   // copy offsets
   constexpr int copy_offsets_block_size = 128;
   copy_offsets<copy_offsets_block_size>
-    <<<batches.size(), copy_offsets_block_size, 0, stream.value()>>>(batches);
+    <<<batches.size(), copy_offsets_block_size, 0, stream.get()>>>(batches);
 
   // we have to sync because the build_table step will need the cpu-side valid_count in
   // h_column_info when constructing the columns.
@@ -1650,7 +1650,7 @@ void assemble_copy(cudf::device_span<assemble_batch> batches,
                   column_info.size() * sizeof(assemble_column_info),
                   cudaMemcpyDefault,
                   stream);
-  stream.synchronize();
+  stream.sync();
 }
 
 }  // namespace
@@ -1706,7 +1706,7 @@ calculate_empty_buffer_sizes(cudf::host_span<shuffle_split_col_data const> col_i
 }
 
 // initialize buffers for empty columns
-void initialize_empty_buffers(uint8_t* buffer_base, size_t total_size, rmm::cuda_stream_view stream)
+void initialize_empty_buffers(uint8_t* buffer_base, size_t total_size, cuda::stream_ref stream)
 {
   // Initialize all buffers to 0, which is correct for:
   // - Validity: all bits 0 (but since num_rows=0, no bits matter)
@@ -1752,7 +1752,7 @@ struct assemble_column_view_functor {
   cudf::host_span<shuffle_split_col_data const> column_meta;
   cudf::host_span<assemble_column_info const> assemble_data;
   shuffle_assemble_result const& assemble_result;
-  rmm::cuda_stream_view stream;
+  cuda::stream_ref stream;
   rmm::device_async_resource_ref mr;
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_fixed_width<T>())>
@@ -1918,7 +1918,7 @@ struct assemble_column_view_functor {
 void build_table(cudf::host_span<shuffle_split_col_data const> column_meta,
                  cudf::host_span<assemble_column_info const> assemble_data,
                  shuffle_assemble_result& assemble_result,
-                 rmm::cuda_stream_view stream,
+                 cuda::stream_ref stream,
                  rmm::device_async_resource_ref mr)
 {
   // create native cudf::column_view objects pointing to slices in the shared buffer
@@ -1947,7 +1947,7 @@ void build_table(cudf::host_span<shuffle_split_col_data const> column_meta,
 shuffle_assemble_result shuffle_assemble(shuffle_split_metadata const& metadata,
                                          cudf::device_span<uint8_t const> partitions,
                                          cudf::device_span<size_t const> _partition_offsets,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/shuffle_split.cu
+++ b/src/main/cpp/src/shuffle_split.cu
@@ -34,11 +34,11 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_memcpy.cuh>
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -274,7 +274,7 @@ void setup_source_buf_info(InputIter begin,
                            src_buf_info*& data_cur,
                            int& offset_stack_pos,
                            int& col_index,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            int parent_offset_index = -1,
                            int offset_depth        = 0);
 
@@ -296,7 +296,7 @@ struct buf_info_functor {
                   int& offset_stack_pos,
                   int parent_offset_index,
                   int offset_depth,
-                  rmm::cuda_stream_view)
+                  cuda::stream_ref)
   {
     if (include_nulls_for_column(col)) {
       add_null_buffer(
@@ -354,7 +354,7 @@ void buf_info_functor::operator()<cudf::string_view>(column_view const& col,
                                                      int& offset_stack_pos,
                                                      int parent_offset_index,
                                                      int offset_depth,
-                                                     rmm::cuda_stream_view)
+                                                     cuda::stream_ref)
 {
   if (include_nulls_for_column(col)) {
     add_null_buffer(
@@ -414,7 +414,7 @@ void buf_info_functor::operator()<cudf::list_view>(column_view const& col,
                                                    int& offset_stack_pos,
                                                    int parent_offset_index,
                                                    int offset_depth,
-                                                   rmm::cuda_stream_view stream)
+                                                   cuda::stream_ref stream)
 {
   lists_column_view lcv(col);
 
@@ -479,7 +479,7 @@ void buf_info_functor::operator()<cudf::struct_view>(column_view const& col,
                                                      int& offset_stack_pos,
                                                      int parent_offset_index,
                                                      int offset_depth,
-                                                     rmm::cuda_stream_view stream)
+                                                     cuda::stream_ref stream)
 {
   if (include_nulls_for_column(col)) {
     add_null_buffer(
@@ -530,7 +530,7 @@ void setup_source_buf_info(InputIter begin,
                            src_buf_info*& data_cur,
                            int& offset_stack_pos,
                            int& col_index,
-                           rmm::cuda_stream_view stream,
+                           cuda::stream_ref stream,
                            int parent_offset_index,
                            int offset_depth)
 {
@@ -708,7 +708,7 @@ void split_copy(src_buf_info const* src_bufs,
                 uint8_t* dst_buf,
                 size_t num_bufs,
                 dst_buf_info const* d_dst_buf_info,
-                rmm::cuda_stream_view stream)
+                cuda::stream_ref stream)
 {
   auto input_iter = spark_rapids_jni::util::make_counting_transform_iterator(
     0, cuda::proclaim_return_type<void*>([src_bufs, d_dst_buf_info] __device__(size_t i) {
@@ -797,7 +797,7 @@ shuffle_split_metadata compute_metadata(cudf::table_view const& input,
  */
 shuffle_split_output shuffle_split(cudf::table_view const& input,
                                    std::vector<size_type> const& splits,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();
@@ -890,7 +890,7 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
 
   // HtoD indices and source buf info to device
   CUDF_CUDA_TRY(cudaMemcpyAsync(
-    d_indices, h_indices, indices_size + src_buf_info_size, cudaMemcpyDefault, stream.value()));
+    d_indices, h_indices, indices_size + src_buf_info_size, cudaMemcpyDefault, stream.get()));
 
   // packed block of memory 2. partition buffer sizes, dst_buf_info structs and per-partition
   // has-validity buffer
@@ -1136,7 +1136,7 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
     });
 
   // allocate output buffer
-  stream.synchronize();  // for dst_buf_total_size from above
+  stream.sync();  // for dst_buf_total_size from above
   rmm::device_buffer dst_buf(dst_buf_total_size, stream, mr);
 
   // pack per-partition data. one thread per (flattened) column.
@@ -1147,13 +1147,13 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
   pack_per_partition_metadata_kernel<<<grid.num_blocks,
                                        grid.num_threads_per_block,
                                        0,
-                                       stream.value()>>>(static_cast<uint8_t*>(dst_buf.data()),
-                                                         d_partition_offsets.data(),
-                                                         num_partitions,
-                                                         total_flattened_columns,
-                                                         d_indices,
-                                                         d_flattened_col_inst_has_validity,
-                                                         d_partition_sizes);
+                                       stream.get()>>>(static_cast<uint8_t*>(dst_buf.data()),
+                                                       d_partition_offsets.data(),
+                                                       num_partitions,
+                                                       total_flattened_columns,
+                                                       d_indices,
+                                                       d_flattened_col_inst_has_validity,
+                                                       d_partition_sizes);
 
   // perform the copy.
   split_copy(
@@ -1163,7 +1163,7 @@ shuffle_split_output shuffle_split(cudf::table_view const& input,
   // function only uses the cpu).
   auto metadata = compute_metadata(input, total_flattened_columns);
 
-  stream.synchronize();
+  stream.sync();
   return {shuffle_split_result{std::make_unique<rmm::device_buffer>(std::move(dst_buf)),
                                std::move(d_partition_offsets)},
           std::move(metadata)};

--- a/src/main/cpp/src/shuffle_split.hpp
+++ b/src/main/cpp/src/shuffle_split.hpp
@@ -16,10 +16,10 @@
 
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/type_traits>
+#include <cuda/stream_ref>
 
 #include <vector>
 
@@ -142,7 +142,7 @@ struct shuffle_split_output {
  */
 shuffle_split_output shuffle_split(cudf::table_view const& input,
                                    std::vector<cudf::size_type> const& splits,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr);
 
 /**
@@ -189,7 +189,7 @@ struct shuffle_assemble_result {
 shuffle_assemble_result shuffle_assemble(shuffle_split_metadata const& metadata,
                                          cudf::device_span<uint8_t const> partitions,
                                          cudf::device_span<size_t const> partition_offsets,
-                                         rmm::cuda_stream_view stream,
+                                         cuda::stream_ref stream,
                                          rmm::device_async_resource_ref mr);
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/substring_index.cu
+++ b/src/main/cpp/src/substring_index.cu
@@ -28,8 +28,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
-
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -55,7 +54,7 @@ void compute_substring_indices(column_device_view const& d_column,
                                size_type delimiter_count,
                                size_type* start_char_pos,
                                size_type* end_char_pos,
-                               rmm::cuda_stream_view stream,
+                               cuda::stream_ref stream,
                                rmm::device_async_resource_ref)
 {
   auto strings_count = d_column.size();
@@ -112,7 +111,7 @@ template <typename DelimiterItrT>
 std::unique_ptr<column> substring_index(strings_column_view const& strings,
                                         DelimiterItrT const delimiter_itr,
                                         size_type count,
-                                        rmm::cuda_stream_view stream,
+                                        cuda::stream_ref stream,
                                         rmm::device_async_resource_ref mr)
 {
   auto strings_count = strings.size();

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -34,13 +34,13 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/launch>
 #include <cuda/std/bit>
 #include <cuda/std/chrono>
 #include <cuda/std/functional>
+#include <cuda/stream_ref>
 #include <thrust/binary_search.h>
 
 using column                   = cudf::column;
@@ -94,7 +94,7 @@ auto convert_timestamp_tz(column_view const& input,
                           table_view const& transitions,
                           size_type tz_index,
                           bool to_utc,
-                          rmm::cuda_stream_view stream,
+                          cuda::stream_ref stream,
                           rmm::device_async_resource_ref mr)
 {
   // get the fixed transitions
@@ -205,7 +205,7 @@ std::unique_ptr<column> convert_to_utc_with_multiple_timezones(
   column_view const& tz_offset,
   table_view const& transitions,
   column_view const tz_indices,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input_seconds.type().id() == cudf::type_id::INT64,
@@ -727,7 +727,7 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
                                           int64_t writer_2015_year_base_offset_us,
                                           spark_rapids_jni::orc_tz_side writer,
                                           spark_rapids_jni::orc_tz_side reader,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr,
                                           bool writer_reader_rules_differ)
 {
@@ -794,7 +794,7 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
   auto const launch_config = cuda::make_config(cuda::grid_dims(num_blocks),
                                                cuda::block_dims<CONVERT_TZ_BLOCK_SIZE>(),
                                                cuda::dynamic_shared_memory<char[]>(smem_bytes));
-  cuda::launch(stream.value(),
+  cuda::launch(stream.get(),
                launch_config,
                convert_timezones_kernel,
                input.begin<cudf::timestamp_us>(),
@@ -806,7 +806,7 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
                writer_args,
                reader_args,
                writer_reader_rules_differ);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
 
   return results;
 }
@@ -876,7 +876,7 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
 template <typename T>
 std::unique_ptr<column> convert_orc_from_utc_typed(cudf::column_view const& input,
                                                    spark_rapids_jni::orc_tz_side reader,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   auto results = cudf::make_fixed_width_column(input.type(),
@@ -909,7 +909,7 @@ std::unique_ptr<column> convert_orc_from_utc_typed(cudf::column_view const& inpu
   auto const launch_config = cuda::make_config(cuda::grid_dims(num_blocks),
                                                cuda::block_dims<CONVERT_TZ_BLOCK_SIZE>(),
                                                cuda::dynamic_shared_memory<char[]>(smem_bytes));
-  cuda::launch(stream.value(),
+  cuda::launch(stream.get(),
                launch_config,
                convert_orc_from_utc_kernel<T>,
                input.begin<T>(),
@@ -918,7 +918,7 @@ std::unique_ptr<column> convert_orc_from_utc_typed(cudf::column_view const& inpu
                input.size(),
                input.offset(),
                reader_args);
-  CUDF_CHECK_CUDA(stream.value());
+  CUDF_CHECK_CUDA(stream.get());
   return results;
 }
 
@@ -932,7 +932,7 @@ std::unique_ptr<column> convert_timestamp(column_view const& input,
                                           table_view const& transitions,
                                           size_type tz_index,
                                           bool to_utc,
-                                          rmm::cuda_stream_view stream,
+                                          cuda::stream_ref stream,
                                           rmm::device_async_resource_ref mr)
 {
   auto const type = input.type().id();
@@ -960,7 +960,7 @@ std::unique_ptr<column> convert_timestamp(column_view const& input,
 std::unique_ptr<column> convert_timestamp_to_utc(column_view const& input,
                                                  table_view const& transitions,
                                                  size_type tz_index,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   return convert_timestamp(input, transitions, tz_index, true, stream, mr);
@@ -969,7 +969,7 @@ std::unique_ptr<column> convert_timestamp_to_utc(column_view const& input,
 std::unique_ptr<column> convert_utc_timestamp_to_timezone(column_view const& input,
                                                           table_view const& transitions,
                                                           size_type tz_index,
-                                                          rmm::cuda_stream_view stream,
+                                                          cuda::stream_ref stream,
                                                           rmm::device_async_resource_ref mr)
 {
   return convert_timestamp(input, transitions, tz_index, false, stream, mr);
@@ -982,7 +982,7 @@ std::unique_ptr<column> convert_timestamp_to_utc(column_view const& input_second
                                                  column_view const& tz_offset,
                                                  table_view const& transitions,
                                                  column_view const tz_indices,
-                                                 rmm::cuda_stream_view stream,
+                                                 cuda::stream_ref stream,
                                                  rmm::device_async_resource_ref mr)
 {
   return convert_to_utc_with_multiple_timezones(input_seconds,
@@ -1001,7 +1001,7 @@ std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(
   int64_t writer_2015_year_base_offset_us,
   orc_tz_side writer,
   orc_tz_side reader,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr,
   bool writer_reader_rules_differ)
 {
@@ -1011,7 +1011,7 @@ std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(
 
 std::unique_ptr<cudf::column> convert_orc_from_utc(cudf::column_view const& input,
                                                    orc_tz_side reader,
-                                                   rmm::cuda_stream_view stream,
+                                                   cuda::stream_ref stream,
                                                    rmm::device_async_resource_ref mr)
 {
   validate_timezone_table(reader.tz_info_table);
@@ -1027,7 +1027,7 @@ std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(
   int64_t writer_2015_year_base_offset_us,
   cudf::table_view const* reader_tz_info_table,
   int32_t reader_raw_offset,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // Java passes the exact ORC 2015 writer base offset, so this path does not infer it from

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -21,8 +21,9 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <cstdint>
@@ -49,7 +50,7 @@ std::unique_ptr<cudf::column> convert_timestamp_to_utc(
   cudf::column_view const& input,
   cudf::table_view const& timezone_info,
   cudf::size_type const tz_index,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -71,7 +72,7 @@ std::unique_ptr<cudf::column> convert_utc_timestamp_to_timezone(
   cudf::column_view const& input,
   cudf::table_view const& timezone_info,
   cudf::size_type const tz_index,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -102,7 +103,7 @@ std::unique_ptr<cudf::column> convert_timestamp_to_utc(
   cudf::column_view const& tz_offset,
   cudf::table_view const& timezone_info,
   cudf::column_view const tz_indices,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -169,7 +170,7 @@ struct orc_tz_side {
   int64_t writer_2015_year_base_offset_us,
   orc_tz_side writer,
   orc_tz_side reader,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref(),
   bool writer_reader_rules_differ   = true);
 
@@ -186,7 +187,7 @@ struct orc_tz_side {
 [[nodiscard]] std::unique_ptr<cudf::column> convert_orc_from_utc(
   cudf::column_view const& input,
   orc_tz_side reader,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
@@ -217,7 +218,7 @@ struct orc_tz_side {
   int64_t writer_2015_year_base_offset_us,
   cudf::table_view const* reader_tz_info_table,
   int32_t reader_raw_offset,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/utilities.cu
+++ b/src/main/cpp/src/utilities.cu
@@ -20,12 +20,12 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/device_vector.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -38,7 +38,7 @@ bool is_basic_spark_numeric(cudf::data_type type)
 
 std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   std::vector<cudf::device_span<cudf::bitmask_type const>> const& input,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(input.size() > 0, "Empty input");

--- a/src/main/cpp/src/utilities.hpp
+++ b/src/main/cpp/src/utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/utilities.hpp
+++ b/src/main/cpp/src/utilities.hpp
@@ -22,9 +22,10 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 namespace spark_rapids_jni {
 
@@ -47,7 +48,7 @@ bool is_basic_spark_numeric(cudf::data_type type);
  */
 std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   std::vector<cudf::device_span<cudf::bitmask_type const>> const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/uuid.cu
+++ b/src/main/cpp/src/uuid.cu
@@ -126,7 +126,7 @@ __launch_bounds__(block_size) CUDF_KERNEL void generate_uuids_kernel(
 
 std::unique_ptr<cudf::column> generate_uuids(cudf::size_type row_count,
                                              long seed,
-                                             rmm::cuda_stream_view stream,
+                                             cuda::stream_ref stream,
                                              rmm::device_async_resource_ref mr)
 
 {
@@ -170,7 +170,7 @@ std::unique_ptr<cudf::column> generate_uuids(cudf::size_type row_count,
   rmm::device_uvector<char> chars(num_chars, stream, mr);
   auto grid = cudf::detail::grid_1d(num_states, block_size);
   generate_uuids_kernel<block_size>
-    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.get()>>>(
       row_count, chars.data(), states.data(), num_states);
 
   return cudf::make_strings_column(
@@ -186,7 +186,7 @@ std::unique_ptr<cudf::column> generate_uuids(cudf::size_type row_count,
 
 std::unique_ptr<cudf::column> random_uuids(int row_count,
                                            long seed,
-                                           rmm::cuda_stream_view stream,
+                                           cuda::stream_ref stream,
                                            rmm::device_async_resource_ref mr)
 
 {

--- a/src/main/cpp/src/uuid.hpp
+++ b/src/main/cpp/src/uuid.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/uuid.hpp
+++ b/src/main/cpp/src/uuid.hpp
@@ -39,7 +39,7 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> random_uuids(
   int row_count,
   long seed,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/zorder.cu
+++ b/src/main/cpp/src/zorder.cu
@@ -23,10 +23,10 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/stream_ref>
 #include <thrust/for_each.h>
 
 namespace {
@@ -136,7 +136,7 @@ __device__ uint_backed_array<uint64_t> hilbert_transposed_index(
 namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> interleave_bits(cudf::table_view const& tbl,
-                                              rmm::cuda_stream_view stream,
+                                              cuda::stream_ref stream,
                                               rmm::device_async_resource_ref mr)
 {
   auto num_columns = tbl.num_columns();
@@ -220,7 +220,7 @@ std::unique_ptr<cudf::column> interleave_bits(cudf::table_view const& tbl,
 
 std::unique_ptr<cudf::column> hilbert_index(int32_t const num_bits_per_entry,
                                             cudf::table_view const& tbl,
-                                            rmm::cuda_stream_view stream,
+                                            cuda::stream_ref stream,
                                             rmm::device_async_resource_ref mr)
 {
   auto const num_rows    = tbl.num_rows();

--- a/src/main/cpp/src/zorder.hpp
+++ b/src/main/cpp/src/zorder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/zorder.hpp
+++ b/src/main/cpp/src/zorder.hpp
@@ -19,8 +19,9 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <memory>
 
@@ -28,13 +29,13 @@ namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> interleave_bits(
   cudf::table_view const& tbl,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> hilbert_index(
   int32_t const num_bits,
   cudf::table_view const& tbl,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/hyper_log_log_plus_plus.cu
+++ b/src/main/cpp/tests/hyper_log_log_plus_plus.cu
@@ -27,8 +27,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/stream_ref>
 
 #include <hyper_log_log_plus_plus.hpp>
 #include <hyper_log_log_plus_plus_host_udf.hpp>
@@ -86,7 +87,7 @@ std::vector<int64_t const*> get_column_ptrs_from_struct_scalars(
 std::unique_ptr<cudf::column> make_struct_column_from_scalars(
   std::vector<std::unique_ptr<cudf::scalar>>& scalars,
   int num_longs_in_scalar,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   // asserts
@@ -123,7 +124,7 @@ std::unique_ptr<cudf::column> make_struct_column_from_scalars(
   auto d_output = cudf::detail::make_device_uvector(host_results_pointers, stream, mr);
 
   // concatenate struct scalars into a struct column
-  concat_struct_scalars_to_struct_column_kernel<<<1, 1, 0, stream.value()>>>(
+  concat_struct_scalars_to_struct_column_kernel<<<1, 1, 0, stream.get()>>>(
     d_col_ptrs, scalars.size(), num_longs_in_scalar, d_output);
 
   // create struct column
@@ -139,7 +140,7 @@ std::unique_ptr<cudf::column> make_struct_column_from_scalars(
  */
 std::unique_ptr<cudf::column> make_struct_column_from_scalar(std::unique_ptr<cudf::scalar>& scalar,
                                                              int num_longs_in_scalar,
-                                                             rmm::cuda_stream_view stream,
+                                                             cuda::stream_ref stream,
                                                              rmm::device_async_resource_ref mr)
 {
   std::vector<std::unique_ptr<cudf::scalar>> scalars;

--- a/src/main/cpp/tests/protobuf_helpers.cu
+++ b/src/main/cpp/tests/protobuf_helpers.cu
@@ -43,7 +43,7 @@ TEST_F(ProtobufHelpersTest, NullMaskFromPaddedValidUsesZeroLogicalRows)
                                 h_valid.data(),
                                 h_valid.size() * sizeof(h_valid[0]),
                                 cudaMemcpyDefault,
-                                stream.value()));
+                                stream.get()));
 
   auto [mask, null_count] = spark_rapids_jni::protobuf::detail::make_null_mask_from_valid(
     valid, 0, stream, cudf::get_current_device_resource_ref());
@@ -63,7 +63,7 @@ TEST_F(ProtobufHelpersTest, NullMaskFromPaddedValidIgnoresTail)
                                 h_valid.data(),
                                 h_valid.size() * sizeof(h_valid[0]),
                                 cudaMemcpyDefault,
-                                stream.value()));
+                                stream.get()));
 
   auto [mask, null_count] = spark_rapids_jni::protobuf::detail::make_null_mask_from_valid(
     valid, 2, stream, cudf::get_current_device_resource_ref());
@@ -73,8 +73,8 @@ TEST_F(ProtobufHelpersTest, NullMaskFromPaddedValidIgnoresTail)
 
   std::vector<cudf::bitmask_type> h_mask(mask.size() / sizeof(cudf::bitmask_type));
   CUDF_CUDA_TRY(
-    cudaMemcpyAsync(h_mask.data(), mask.data(), mask.size(), cudaMemcpyDefault, stream.value()));
-  stream.synchronize();
+    cudaMemcpyAsync(h_mask.data(), mask.data(), mask.size(), cudaMemcpyDefault, stream.get()));
+  stream.sync();
 
   EXPECT_TRUE(cudf::bit_is_set(h_mask.data(), 0));
   EXPECT_FALSE(cudf::bit_is_set(h_mask.data(), 1));
@@ -90,7 +90,7 @@ TEST_F(ProtobufHelpersTest, NullMaskFromAllValidRowsIsEmpty)
                                 h_valid.data(),
                                 h_valid.size() * sizeof(h_valid[0]),
                                 cudaMemcpyDefault,
-                                stream.value()));
+                                stream.get()));
 
   auto [mask, null_count] = spark_rapids_jni::protobuf::detail::make_null_mask_from_valid(
     valid, h_valid.size(), stream, cudf::get_current_device_resource_ref());

--- a/src/main/cpp/tests/shuffle_split.cu
+++ b/src/main/cpp/tests/shuffle_split.cu
@@ -49,7 +49,7 @@ spark_rapids_jni::shuffle_split_result reshape_partitions(
   cudf::device_span<uint8_t const> partitions,
   cudf::device_span<size_t const> partition_offsets,
   std::vector<int> const& remaps,
-  rmm::cuda_stream_view stream,
+  cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(remaps.size() == partition_offsets.size() - 1, "Invaid remaps vector size");


### PR DESCRIPTION
## Summary
- Migrate JNI native stream parameters from `rmm::cuda_stream_view` to `cuda::stream_ref`.
- Replace stream handle/synchronization calls with `stream.get()` and `stream.sync()` for the new API.
- Replaces the conflicted branch in #5014 on top of latest `main`.

Closes NVIDIA/cudf-spark#15685

Related to NVIDIA/cudf#23636 and NVIDIA/cudf#23770.