### PR TITLE
Add row-wise LIKE support

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -277,6 +277,7 @@ add_library(
   src/json_utils.cu
   src/join_primitives.cu
   src/list_slice.cu
+  src/like.cu
   src/map.cu
   src/map_utils.cu
   src/map_zip_with_utils.cu

--- a/src/main/cpp/src/StringUtilsJni.cpp
+++ b/src/main/cpp/src/StringUtilsJni.cpp
@@ -60,8 +60,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_StringUtils_like(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto const input = std::bit_cast<cudf::column_view const*>(input_handle);
-    auto const patterns = std::bit_cast<cudf::column_view const*>(patterns_handle);
+    auto const input       = std::bit_cast<cudf::column_view const*>(input_handle);
+    auto const patterns    = std::bit_cast<cudf::column_view const*>(patterns_handle);
     auto const escape_char = std::bit_cast<cudf::string_scalar const*>(escape_char_handle);
     return cudf::jni::release_as_jlong(spark_rapids_jni::like(
       cudf::strings_column_view{*input}, cudf::strings_column_view{*patterns}, *escape_char));

--- a/src/main/cpp/src/StringUtilsJni.cpp
+++ b/src/main/cpp/src/StringUtilsJni.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "cudf_jni_apis.hpp"
+#include "exception_with_row_index.hpp"
+#include "like.hpp"
 #include "reverse_strings.hpp"
 #include "uuid.hpp"
 
@@ -47,5 +49,23 @@ Java_com_nvidia_spark_rapids_jni_StringUtils_reverseStrings(JNIEnv* env, jclass,
       spark_rapids_jni::reverse_strings(cudf::strings_column_view{*input}));
   }
   JNI_CATCH(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_StringUtils_like(
+  JNIEnv* env, jclass, jlong input_handle, jlong patterns_handle, jlong escape_char_handle)
+{
+  JNI_NULL_CHECK(env, input_handle, "input column is null", 0);
+  JNI_NULL_CHECK(env, patterns_handle, "patterns column is null", 0);
+  JNI_NULL_CHECK(env, escape_char_handle, "escape character is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const input = std::bit_cast<cudf::column_view const*>(input_handle);
+    auto const patterns = std::bit_cast<cudf::column_view const*>(patterns_handle);
+    auto const escape_char = std::bit_cast<cudf::string_scalar const*>(escape_char_handle);
+    return cudf::jni::release_as_jlong(spark_rapids_jni::like(
+      cudf::strings_column_view{*input}, cudf::strings_column_view{*patterns}, *escape_char));
+  }
+  CATCH_EXCEPTION_WITH_ROW_INDEX(env, 0);
 }
 }

--- a/src/main/cpp/src/like.cu
+++ b/src/main/cpp/src/like.cu
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exception_with_row_index.hpp"
+#include "like.hpp"
+#include "nvtx_ranges.hpp"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/strings/contains.hpp>
+#include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/find.h>
+#include <thrust/iterator/counting_iterator.h>
+
+namespace spark_rapids_jni {
+namespace detail {
+namespace {
+
+struct invalid_like_pattern_fn {
+  cudf::column_device_view const input;
+  cudf::column_device_view const patterns;
+  cudf::string_view const escape;
+
+  __device__ bool operator()(cudf::size_type row) const
+  {
+    if (input.is_null(row)) { return false; }
+
+    auto const pattern = patterns.element<cudf::string_view>(row);
+    auto const escape_code_point = *escape.begin();
+    auto it = pattern.begin();
+    auto const end = pattern.end();
+    while (it != end) {
+      if (*it == escape_code_point) {
+        ++it;
+        if (it == end) { return true; }
+        auto const escaped = *it;
+        if (escaped != escape_code_point && escaped != '_' && escaped != '%') { return true; }
+      }
+      ++it;
+    }
+    return false;
+  }
+};
+
+void validate_patterns(cudf::strings_column_view const& input,
+                       cudf::strings_column_view const& patterns,
+                       cudf::string_scalar const& escape_character,
+                       rmm::cuda_stream_view stream)
+{
+  if (input.is_empty()) { return; }
+
+  CUDF_EXPECTS(input.size() == patterns.size(),
+               "Number of patterns must match the input size");
+  CUDF_EXPECTS(!patterns.has_nulls(), "Parameter patterns must not contain nulls");
+  CUDF_EXPECTS(escape_character.is_valid(stream), "Escape character must be valid");
+  auto const escape = escape_character.value(stream);
+  CUDF_EXPECTS(escape.size_bytes() == 1, "Escape character must contain exactly one ASCII byte");
+
+  auto const d_input = cudf::column_device_view::create(
+    input.parent(), stream, cudf::get_current_device_resource_ref());
+  auto const d_patterns = cudf::column_device_view::create(
+    patterns.parent(), stream, cudf::get_current_device_resource_ref());
+  auto const begin = thrust::make_counting_iterator<cudf::size_type>(0);
+  auto const end = begin + input.size();
+  auto const invalid = thrust::find_if(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    begin,
+    end,
+    invalid_like_pattern_fn{*d_input, *d_patterns, escape});
+  if (invalid != end) { throw spark_rapids_jni::exception_with_row_index(*invalid); }
+}
+
+}  // namespace
+}  // namespace detail
+
+std::unique_ptr<cudf::column> like(cudf::strings_column_view const& input,
+                                   cudf::strings_column_view const& patterns,
+                                   cudf::string_scalar const& escape_character,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::device_async_resource_ref mr)
+{
+  SRJ_FUNC_RANGE();
+  detail::validate_patterns(input, patterns, escape_character, stream);
+  return cudf::strings::like(input, patterns, escape_character, stream, mr);
+}
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/like.cu
+++ b/src/main/cpp/src/like.cu
@@ -41,10 +41,10 @@ struct invalid_like_pattern_fn {
   {
     if (input.is_null(row)) { return false; }
 
-    auto const pattern = patterns.element<cudf::string_view>(row);
+    auto const pattern           = patterns.element<cudf::string_view>(row);
     auto const escape_code_point = *escape.begin();
-    auto it = pattern.begin();
-    auto const end = pattern.end();
+    auto it                      = pattern.begin();
+    auto const end               = pattern.end();
     while (it != end) {
       if (*it == escape_code_point) {
         ++it;
@@ -65,8 +65,7 @@ void validate_patterns(cudf::strings_column_view const& input,
 {
   if (input.is_empty()) { return; }
 
-  CUDF_EXPECTS(input.size() == patterns.size(),
-               "Number of patterns must match the input size");
+  CUDF_EXPECTS(input.size() == patterns.size(), "Number of patterns must match the input size");
   CUDF_EXPECTS(!patterns.has_nulls(), "Parameter patterns must not contain nulls");
   CUDF_EXPECTS(escape_character.is_valid(stream), "Escape character must be valid");
   auto const escape = escape_character.value(stream);
@@ -77,12 +76,12 @@ void validate_patterns(cudf::strings_column_view const& input,
   auto const d_patterns = cudf::column_device_view::create(
     patterns.parent(), stream, cudf::get_current_device_resource_ref());
   auto const begin = thrust::make_counting_iterator<cudf::size_type>(0);
-  auto const end = begin + input.size();
-  auto const invalid = thrust::find_if(
-    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-    begin,
-    end,
-    invalid_like_pattern_fn{*d_input, *d_patterns, escape});
+  auto const end   = begin + input.size();
+  auto const invalid =
+    thrust::find_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    begin,
+                    end,
+                    invalid_like_pattern_fn{*d_input, *d_patterns, escape});
   if (invalid != end) { throw spark_rapids_jni::exception_with_row_index(*invalid); }
 }
 

--- a/src/main/cpp/src/like.hpp
+++ b/src/main/cpp/src/like.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <memory>
+
+namespace spark_rapids_jni {
+
+/**
+ * @brief Match each input string against the corresponding LIKE pattern.
+ *
+ * Patterns must not contain nulls. Invalid escape sequences on rows with a non-null input throw
+ * exception_with_row_index for the first invalid row.
+ */
+std::unique_ptr<cudf::column> like(
+  cudf::strings_column_view const& input,
+  cudf::strings_column_view const& patterns,
+  cudf::string_scalar const& escape_character,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+}  // namespace spark_rapids_jni

--- a/src/main/java/com/nvidia/spark/rapids/jni/StringUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/StringUtils.java
@@ -16,11 +16,14 @@
 
 package com.nvidia.spark.rapids.jni;
 
+import ai.rapids.cudf.BinaryOp;
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.ColumnView;
 import ai.rapids.cudf.Cuda;
 import ai.rapids.cudf.CudfException;
+import ai.rapids.cudf.DType;
 import ai.rapids.cudf.NativeDepsLoader;
+import ai.rapids.cudf.Scalar;
 import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
@@ -108,7 +111,38 @@ public class StringUtils {
     return new ColumnVector(reverseStrings(input.getNativeView()));
   }
 
+  /**
+   * Match each input string against the LIKE pattern at the corresponding row.
+   *
+   * <p>The escape character applies to every pattern. A null input or pattern produces a null
+   * result. Invalid escape sequences in non-null patterns throw {@link ExceptionWithRowIndex} for
+   * the first row where both the input and pattern are non-null.</p>
+   *
+   * @param input strings to match
+   * @param patterns row-aligned LIKE patterns
+   * @param escapeChar scalar string containing the escape character
+   * @return a BOOL8 column containing the row-aligned match results
+   */
+  public static ColumnVector like(ColumnView input, ColumnView patterns, Scalar escapeChar) {
+    assert input.getType().equals(DType.STRING) : "input column must be a String";
+    assert patterns.getType().equals(DType.STRING) : "patterns column must be a String";
+    assert input.getRowCount() == patterns.getRowCount()
+        : "input and patterns must have the same number of rows";
+    assert escapeChar != null : "escapeChar must not be null";
+    assert escapeChar.getType().equals(DType.STRING) : "escapeChar must be a string scalar";
+
+    try (Scalar empty = Scalar.fromString("");
+         ColumnVector normalizedPatterns = patterns.replaceNulls(empty);
+         ColumnVector result = new ColumnVector(like(
+             input.getNativeView(), normalizedPatterns.getNativeView(), escapeChar.getScalarHandle()))) {
+      return result.mergeAndSetValidity(BinaryOp.BITWISE_AND, input, patterns);
+    }
+  }
+
   private static native long randomUUIDs(int rowCount, long seed);
 
   private static native long reverseStrings(long inputHandle) throws CudfException;
+
+  private static native long like(long inputHandle, long patternsHandle, long escapeCharHandle)
+      throws CudfException, ExceptionWithRowIndex;
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/StringUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/StringUtilsTest.java
@@ -134,4 +134,51 @@ public class StringUtilsTest {
       assertColumnsAreEqual(expected, result);
     }
   }
+
+  @Test
+  void testLikeWithColumnPatterns() {
+    try (ColumnVector input = ColumnVector.fromStrings(
+            "azaa", "ababaabba", "aaxa", "abc_def", "abc1def", "", "éclair", null, "x");
+         ColumnVector patterns = ColumnVector.fromStrings(
+            "%a", "a%b%", "a__a", "abc\\_d%", "abc\\_d%", "", "é%", "%", null);
+         Scalar escape = Scalar.fromString("\\");
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(
+            true, true, true, true, false, true, true, null, null);
+         ColumnVector result = StringUtils.like(input, patterns, escape)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void testLikeWithCustomEscape() {
+    try (ColumnVector input = ColumnVector.fromStrings("abc_def", "abc1def", "20%", "20x");
+         ColumnVector patterns = ColumnVector.fromStrings("abc#_d%", "abc#_d%", "20#%", "20#%");
+         Scalar escape = Scalar.fromString("#");
+         ColumnVector expected = ColumnVector.fromBoxedBooleans(true, false, true, false);
+         ColumnVector result = StringUtils.like(input, patterns, escape)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void testLikeInvalidPatternReportsFirstActiveRow() {
+    try (ColumnVector input = ColumnVector.fromStrings(null, "abc", "def");
+         ColumnVector patterns = ColumnVector.fromStrings("bad\\x", "bad\\x", "trailing\\");
+         Scalar escape = Scalar.fromString("\\")) {
+      ExceptionWithRowIndex error = assertThrows(
+          ExceptionWithRowIndex.class, () -> StringUtils.like(input, patterns, escape).close());
+      assertEquals(1, error.getRowIndex());
+    }
+  }
+
+  @Test
+  void testLikeEmptyColumns() {
+    try (ColumnVector input = ColumnVector.fromStrings();
+         ColumnVector patterns = ColumnVector.fromStrings();
+         Scalar escape = Scalar.fromString("\\");
+         ColumnVector expected = ColumnVector.fromBoxedBooleans();
+         ColumnVector result = StringUtils.like(input, patterns, escape)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

Supports NVIDIA/cudf-spark#65.

## Description

Add a JNI wrapper for libcudf's row-wise `LIKE` API. The wrapper:

- preserves nulls from both the input and pattern columns;
- validates Spark-compatible escape sequences and reports the first active invalid row with `ExceptionWithRowIndex`;
- accepts a shared ASCII escape scalar and delegates matching to libcudf; and
- exposes the operation through `StringUtils.like` for the Spark plugin.

## Testing

- Clean native build/install:
  `env DOCKER_RUN_EXTRA_ARGS= build/build-in-docker -DskipTests -DCPP_PARALLEL_LEVEL=64 -DCMAKE_CUDA_ARCHITECTURES=native install`
- Targeted GPU tests:
  `env DOCKER_RUN_EXTRA_ARGS= build/build-in-docker -DCPP_PARALLEL_LEVEL=64 -DCMAKE_CUDA_ARCHITECTURES=native -Dtest=StringUtilsTest test`
- 24 tests passed across `StringUtilsTest`, `NativeDepsLoaderTest`, `ColumnViewNonEmptyNullsTest`, and `CudaFatalTest`.

This change was developed with assistance from OpenAI Codex and reviewed by the author.
