### PR TITLE
Fix remaining native stream_ref call sites

### DIFF
--- a/src/main/cpp/benchmarks/from_json.cu
+++ b/src/main/cpp/benchmarks/from_json.cu
@@ -361,7 +361,7 @@ void BM_from_json_to_raw_map(nvbench::state& state)
 
   auto const json_strings = generate_input(size_bytes, make_all_string_column_types(num_keys));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -379,7 +379,7 @@ void BM_from_json_to_raw_map_value_width(nvbench::state& state)
   auto const json_strings = generate_input(
     size_bytes, make_all_string_column_types(num_keys), {.value_width = value_width});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -397,7 +397,7 @@ void BM_from_json_to_raw_map_null_density(nvbench::state& state)
   auto const json_strings =
     generate_input(size_bytes, make_all_string_column_types(num_keys), {.null_pct = null_pct});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -413,7 +413,7 @@ void BM_from_json_to_raw_map_micro_size(nvbench::state& state)
 
   auto const json_strings = generate_input(size_bytes, make_all_string_column_types(num_keys));
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -438,7 +438,7 @@ void BM_from_json_to_raw_map_row_shape(nvbench::state& state)
   auto const json_strings =
     generate_input(/*size_bytes=*/0, make_all_string_column_types(num_keys), options);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -456,7 +456,7 @@ void BM_from_json_to_raw_map_key_name_len(nvbench::state& state)
   auto const json_strings = generate_input(
     size_bytes, make_all_string_column_types(num_keys), {.key_name_len = key_name_len});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map(
@@ -476,7 +476,7 @@ void BM_from_json_to_raw_map_array_values(nvbench::state& state)
 
   auto const json_strings = generate_map_of_array_input(num_rows, keys_per_row, array_len);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -500,7 +500,7 @@ void BM_from_json_to_raw_map_array_values_null_density(nvbench::state& state)
     {.element_null_pct = static_cast<double>(state.get_int64("element_null_pct")) / 100.0,
      .value_null_pct   = static_cast<double>(state.get_int64("value_null_pct")) / 100.0});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -517,7 +517,7 @@ void BM_from_json_to_raw_map_array_values_keys_per_row(nvbench::state& state)
 
   auto const json_strings = generate_map_of_array_input(num_rows, keys_per_row, array_len);
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -538,7 +538,7 @@ void BM_from_json_to_raw_map_array_values_key_name_len(nvbench::state& state)
     array_len,
     {.key_name_len = static_cast<int>(state.get_int64("key_name_len"))});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(
@@ -562,7 +562,7 @@ void BM_from_json_to_raw_map_array_values_type_mismatch(nvbench::state& state)
     array_len,
     {.mismatch_pct = static_cast<double>(state.get_int64("mismatch_pct")) / 100.0});
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.add_global_memory_reads<nvbench::int8_t>(input_char_bytes(json_strings->view()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output = spark_rapids_jni::from_json_to_raw_map_array_values(

--- a/src/main/cpp/benchmarks/from_json_to_structs.cu
+++ b/src/main/cpp/benchmarks/from_json_to_structs.cu
@@ -80,7 +80,7 @@ void BM_from_json_to_structs(nvbench::state& state)
   auto const scales       = nested_schema_scales();
   auto const precisions   = nested_schema_precisions();
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch&) {
     [[maybe_unused]] auto const output =
       spark_rapids_jni::from_json_to_structs(cudf::strings_column_view{input->view()},

--- a/src/main/cpp/benchmarks/get_json_object.cu
+++ b/src/main/cpp/benchmarks/get_json_object.cu
@@ -149,7 +149,7 @@ void BM_get_json_object(nvbench::state& state)
     instructions.emplace_back(path_instruction_type::NAMED, "0", -1);
   }
 
-  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().get()));
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     // Can also verify at https://jsonpath.com/.
     [[maybe_unused]] auto const output = spark_rapids_jni::get_json_object(

--- a/src/main/cpp/src/like.cu
+++ b/src/main/cpp/src/like.cu
@@ -61,7 +61,7 @@ struct invalid_like_pattern_fn {
 void validate_patterns(cudf::strings_column_view const& input,
                        cudf::strings_column_view const& patterns,
                        cudf::string_scalar const& escape_character,
-                       rmm::cuda_stream_view stream)
+                       cuda::stream_ref stream)
 {
   if (input.is_empty()) { return; }
 
@@ -91,7 +91,7 @@ void validate_patterns(cudf::strings_column_view const& input,
 std::unique_ptr<cudf::column> like(cudf::strings_column_view const& input,
                                    cudf::strings_column_view const& patterns,
                                    cudf::string_scalar const& escape_character,
-                                   rmm::cuda_stream_view stream,
+                                   cuda::stream_ref stream,
                                    rmm::device_async_resource_ref mr)
 {
   SRJ_FUNC_RANGE();

--- a/src/main/cpp/src/like.hpp
+++ b/src/main/cpp/src/like.hpp
@@ -21,6 +21,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <cuda/stream>
+
 #include <memory>
 
 namespace spark_rapids_jni {
@@ -35,7 +37,7 @@ std::unique_ptr<cudf::column> like(
   cudf::strings_column_view const& input,
   cudf::strings_column_view const& patterns,
   cudf::string_scalar const& escape_character,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni


### PR DESCRIPTION
Updates the remaining native call sites that still assumed cudf::get_default_stream() exposes rmm::cuda_stream_view-style APIs. This fixes Spark JNI builds against NVIDIA/cudf#23770 by using cuda::stream_ref APIs in benchmark stream setup and the missed LIKE helper.\n\nTests not run locally. The failure was reproduced in the cudf PR Spark JNI CI job: NVIDIA/cudf#23770.