### PR TITLE
Fix singular protobuf message occurrence merging

### DIFF
--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -459,11 +459,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     for (auto const ni : merge_positions) {
       nested_merge_buffers[ni].emplace(std::move(*merge_bundle.fields[ni]));
     }
-    if (!merge_bundle.scan_descriptors.empty()) {
-      auto scan_bundle =
-        make_field_occurrence_scan_bundle(merge_bundle.scan_descriptors, stream, scratch_mr);
-      launch_scan_singular_message_occurrences(*d_in, scan_bundle.view(), d_error.data(), stream);
-    }
+    for_each_field_occurrence_scan_batch(
+      merge_bundle.scan_descriptors, stream, scratch_mr, [&](field_occurrence_scan_view fields) {
+        launch_scan_singular_message_occurrences(*d_in, fields, d_error.data(), stream);
+      });
   }
 
   // Store decoded columns by schema index for ordered assembly at the end.

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <array>
+#include <optional>
 #include <ranges>
 #include <set>
 #include <string>
@@ -388,6 +389,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     std::max<size_t>(static_cast<size_t>(num_rows) * num_repeated, 1), stream, scratch_mr);
   rmm::device_uvector<field_location> d_nested_locations(
     std::max<size_t>(static_cast<size_t>(num_rows) * num_nested, 1), stream, scratch_mr);
+  rmm::device_uvector<field_occurrence_count> d_nested_occurrence_info(
+    std::max<size_t>(static_cast<size_t>(num_rows) * num_nested, 1), stream, scratch_mr);
+  auto d_multiple_nested_fields =
+    cudf::detail::make_zeroed_device_uvector_async<int>(num_nested, stream, scratch_mr);
 
   if (run_count_scan) {
     std::vector<int> count_field_indices = repeated_field_indices;
@@ -418,12 +423,47 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                         num_nested,
                                         d_repeated_info.data(),
                                         num_repeated,
+                                        d_nested_occurrence_info.data(),
+                                        num_nested,
+                                        d_multiple_nested_fields.data(),
                                         descriptor_lookup};
     launch_count_repeated_fields(*d_in,
                                  fields,
                                  d_error.data(),
                                  track_permissive_null_rows ? d_row_force_null.data() : nullptr,
                                  stream);
+  }
+
+  std::vector<std::optional<singular_message_merge_buffers>> nested_merge_buffers(num_nested);
+  if (num_nested > 0) {
+    auto h_multiple_nested_fields = cudf::detail::make_pinned_vector_async<int>(num_nested, stream);
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(h_multiple_nested_fields.data(),
+                                             d_multiple_nested_fields.data(),
+                                             num_nested * sizeof(int),
+                                             stream));
+    stream.sync();
+
+    std::vector<int> merge_positions;
+    for (int ni = 0; ni < num_nested; ++ni) {
+      if (h_multiple_nested_fields[ni] != 0) { merge_positions.push_back(ni); }
+    }
+    auto merge_bundle = make_repeated_field_work_bundle(merge_positions,
+                                                        nested_field_indices,
+                                                        d_nested_occurrence_info.data(),
+                                                        num_rows,
+                                                        schema_context,
+                                                        "Top-level singular message",
+                                                        stream,
+                                                        scratch_mr,
+                                                        scratch_mr);
+    for (auto const ni : merge_positions) {
+      nested_merge_buffers[ni].emplace(std::move(*merge_bundle.fields[ni]));
+    }
+    if (!merge_bundle.scan_descriptors.empty()) {
+      auto scan_bundle =
+        make_field_occurrence_scan_bundle(merge_bundle.scan_descriptors, stream, scratch_mr);
+      launch_scan_singular_message_occurrences(*d_in, scan_bundle.view(), d_error.data(), stream);
+    }
   }
 
   // Store decoded columns by schema index for ordered assembly at the end.
@@ -446,8 +486,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                     num_scalar,
                                     h_field_lookup.empty() ? nullptr : d_field_lookup.data(),
                                     static_cast<int>(h_field_lookup.size())};
-    auto const fields =
-      field_scan_view{d_locations.data(), num_scalar, nullptr, 0, descriptor_lookup};
+    auto const fields = field_scan_view{
+      d_locations.data(), num_scalar, nullptr, 0, nullptr, 0, nullptr, descriptor_lookup};
     launch_scan_all_fields(*d_in,
                            fields,
                            d_error.data(),
@@ -693,20 +733,30 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     int parent_schema_idx           = nested_field_indices[ni];
     auto const& child_field_indices = schema_context.children(parent_schema_idx);
 
-    rmm::device_uvector<field_location> d_parent_locs(num_rows, stream, scratch_mr);
-    launch_extract_strided_locations(
-      d_nested_locations.data(), ni, num_nested, d_parent_locs.data(), num_rows, stream);
-
     // Keep row-force-null tracking for nested required-field failures, but do not let invalid
     // nested enum values null the top-level row.
-    auto nested_col =
-      build_nested_struct_column(input,
-                                 {d_parent_locs.data(), d_parent_locs.size(), nullptr},
-                                 child_field_indices,
-                                 {schema_context, nested_decode_ctx},
-                                 0,
-                                 stream,
-                                 mr);
+    std::unique_ptr<cudf::column> nested_col;
+    if (nested_merge_buffers[ni].has_value()) {
+      nested_col = build_merged_singular_struct_column(input,
+                                                       {nullptr, nullptr},
+                                                       child_field_indices,
+                                                       {schema_context, nested_decode_ctx},
+                                                       std::move(*nested_merge_buffers[ni]),
+                                                       0,
+                                                       stream,
+                                                       mr);
+    } else {
+      rmm::device_uvector<field_location> d_parent_locs(num_rows, stream, scratch_mr);
+      launch_extract_strided_locations(
+        d_nested_locations.data(), ni, num_nested, d_parent_locs.data(), num_rows, stream);
+      nested_col = build_nested_struct_column(input,
+                                              {d_parent_locs.data(), d_parent_locs.size(), nullptr},
+                                              child_field_indices,
+                                              {schema_context, nested_decode_ctx},
+                                              0,
+                                              stream,
+                                              mr);
+    }
     column_map[parent_schema_idx] = std::move(nested_col);
   }
 

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -22,6 +22,7 @@
 #include <cuda/stream>
 #include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -46,7 +47,10 @@ field_descriptor_bundle make_field_descriptors(std::vector<int> const& field_ind
     cudf::detail::make_pinned_vector_async<field_descriptor>(field_indices.size(), stream);
   for (size_t i = 0; i < field_indices.size(); ++i) {
     auto const& field = schema[field_indices[i]];
-    host[i]           = {field.field_number, field.wire_type, field.is_repeated};
+    host[i]           = {field.field_number,
+                         field.wire_type,
+                         field.is_repeated,
+                         field.output_type == cudf::type_id::STRUCT};
     if (!output_indices.empty()) { host[i].output_index = output_indices[i]; }
   }
 
@@ -470,6 +474,140 @@ std::unique_ptr<cudf::column> build_repeated_string_column(cudf::column_view con
 // Nested struct column builder
 // ============================================================================
 
+std::unique_ptr<cudf::column> build_merged_singular_struct_column(
+  protobuf_input_view input,
+  message_fragment_source_view source,
+  std::vector<int> const& child_field_indices,
+  recursive_decode_context context,
+  singular_message_merge_buffers buffers,
+  int depth,
+  cuda::stream_ref stream,
+  rmm::device_async_resource_ref mr)
+{
+  CUDF_EXPECTS(buffers.total_fragments > 1, "duplicate merge requires multiple fragments");
+  CUDF_EXPECTS(buffers.row_offsets.size() == static_cast<size_t>(input.num_rows) + 1,
+               "fragment offsets size must match row count");
+  CUDF_EXPECTS(buffers.fragments.size() == static_cast<size_t>(buffers.total_fragments),
+               "fragment count mismatch");
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+
+  auto validation_fields =
+    make_field_descriptors(child_field_indices, context.schema, stream, scratch_mr);
+  auto h_field_lookup = build_field_lookup_table(
+    validation_fields.host.data(), static_cast<int>(validation_fields.host.size()), stream);
+  auto d_field_lookup = cudf::detail::make_device_uvector_async(h_field_lookup, stream, scratch_mr);
+
+  auto invalid_rows =
+    cudf::detail::make_zeroed_device_uvector_async<bool>(input.num_rows, stream, scratch_mr);
+  message_fragment_location_provider fragment_locations{input, source, buffers.fragments.data()};
+  launch_validate_message_fragments(
+    fragment_locations,
+    {{validation_fields.device.data(),
+      static_cast<int>(validation_fields.device.size()),
+      h_field_lookup.empty() ? nullptr : d_field_lookup.data(),
+      static_cast<int>(d_field_lookup.size())}},
+    buffers.total_fragments,
+    invalid_rows.data(),
+    context.runtime.row_force_null->is_empty() ? nullptr : context.runtime.row_force_null->data(),
+    context.runtime.error->data(),
+    stream);
+
+  auto fragment_lengths = thrust::make_transform_iterator(
+    buffers.fragments.begin(),
+    [] __device__(field_occurrence const& fragment) -> int32_t { return fragment.length; });
+  auto fragment_byte_offsets = make_list_offsets_from_counts(fragment_lengths,
+                                                             buffers.total_fragments,
+                                                             "Merged singular message",
+                                                             stream,
+                                                             scratch_mr,
+                                                             scratch_mr);
+  auto const total_bytes     = fragment_byte_offsets.total_count;
+
+  rmm::device_uvector<cudf::size_type> merged_row_offsets(input.num_rows + 1, stream, scratch_mr);
+  thrust::transform(rmm::exec_policy_nosync(stream, scratch_mr),
+                    thrust::make_counting_iterator<int>(0),
+                    thrust::make_counting_iterator<int>(input.num_rows + 1),
+                    merged_row_offsets.begin(),
+                    [row_fragment_offsets = buffers.row_offsets.data(),
+                     fragment_offsets = fragment_byte_offsets.offsets.data()] __device__(int row) {
+                      return fragment_offsets[row_fragment_offsets[row]];
+                    });
+
+  rmm::device_uvector<uint8_t> merged_data(std::max<int32_t>(total_bytes, 1), stream, scratch_mr);
+  if (total_bytes > 0) {
+    auto const* invalid          = invalid_rows.data();
+    auto const* fragments        = buffers.fragments.data();
+    auto const* fragment_offsets = fragment_byte_offsets.offsets.data();
+    auto* output                 = merged_data.data();
+
+    auto src_iter = cudf::detail::make_counting_transform_iterator(
+      0,
+      cuda::proclaim_return_type<void const*>(
+        [message_data = input.message_data, fragment_locations, fragments, invalid] __device__(
+          int idx) -> void const* {
+          if (invalid[fragments[idx].row_idx]) { return nullptr; }
+          int32_t data_offset = 0;
+          auto const location = fragment_locations.get(idx, data_offset);
+          return location.offset < 0 ? nullptr
+                                     : static_cast<void const*>(message_data + data_offset);
+        }));
+    auto dst_iter = cudf::detail::make_counting_transform_iterator(
+      0, cuda::proclaim_return_type<void*>([output, fragment_offsets] __device__(int idx) -> void* {
+        return static_cast<void*>(output + fragment_offsets[idx]);
+      }));
+    auto size_iter = cudf::detail::make_counting_transform_iterator(
+      0, cuda::proclaim_return_type<size_t>([fragments, invalid] __device__(int idx) -> size_t {
+        auto const fragment = fragments[idx];
+        return invalid[fragment.row_idx] ? 0 : static_cast<size_t>(fragment.length);
+      }));
+
+    size_t temp_storage_bytes = 0;
+    CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(nullptr,
+                                             temp_storage_bytes,
+                                             src_iter,
+                                             dst_iter,
+                                             size_iter,
+                                             buffers.total_fragments,
+                                             stream.get()));
+    rmm::device_buffer temp_storage(temp_storage_bytes, stream, scratch_mr);
+    CUDF_CUDA_TRY(cub::DeviceMemcpy::Batched(temp_storage.data(),
+                                             temp_storage_bytes,
+                                             src_iter,
+                                             dst_iter,
+                                             size_iter,
+                                             buffers.total_fragments,
+                                             stream.get()));
+  }
+
+  rmm::device_uvector<field_location> merged_parent_locations(input.num_rows, stream, scratch_mr);
+  thrust::transform(
+    rmm::exec_policy_nosync(stream, scratch_mr),
+    thrust::make_counting_iterator<int>(0),
+    thrust::make_counting_iterator<int>(input.num_rows),
+    merged_parent_locations.begin(),
+    [row_fragment_offsets = buffers.row_offsets.data(),
+     row_byte_offsets     = merged_row_offsets.data(),
+     invalid              = invalid_rows.data()] __device__(int row) {
+      if (invalid[row] || row_fragment_offsets[row] == row_fragment_offsets[row + 1]) {
+        return field_location{-1, 0};
+      }
+      return field_location{0, row_byte_offsets[row + 1] - row_byte_offsets[row]};
+    });
+
+  return build_nested_struct_column(
+    {merged_data.data(),
+     static_cast<cudf::size_type>(total_bytes),
+     merged_row_offsets.data(),
+     0,
+     input.num_rows},
+    {merged_parent_locations.data(), merged_parent_locations.size(), source.top_row_indices},
+    child_field_indices,
+    context,
+    depth,
+    stream,
+    mr);
+}
+
 /**
  * Build a STRUCT column for a nested protobuf message.
  *
@@ -498,10 +636,16 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
 
   int num_child_fields = static_cast<int>(child_field_indices.size());
   std::vector<int> repeated_child_positions;
+  std::vector<int> singular_message_positions;
   repeated_child_positions.reserve(num_child_fields);
+  singular_message_positions.reserve(num_child_fields);
   for (int i = 0; i < num_child_fields; i++) {
     auto const child_idx = child_field_indices[i];
-    if (schema[child_idx].is_repeated) { repeated_child_positions.push_back(i); }
+    if (schema[child_idx].is_repeated) {
+      repeated_child_positions.push_back(i);
+    } else if (schema[child_idx].output_type == cudf::type_id::STRUCT) {
+      singular_message_positions.push_back(i);
+    }
   }
 
   auto const scratch_mr  = cudf::get_current_device_resource_ref();
@@ -510,19 +654,29 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   auto const child_location_count = static_cast<size_t>(input.num_rows) * num_child_fields;
   rmm::device_uvector<field_location> d_child_locations(
     std::max(child_location_count, size_t{1}), stream, scratch_mr);
-  rmm::device_uvector<field_occurrence_count> d_repeated_info(
-    repeated_child_positions.empty() ? 0 : child_location_count, stream, scratch_mr);
-  CUDF_EXPECTS(repeated_child_positions.empty() || d_repeated_info.size() == child_location_count,
-               "Protobuf decode internal error: nested repeated count buffer size mismatch");
-  // Repeated counts are collected in the same pass as singleton locations so each nested
-  // message is parsed only once before LIST offsets are built.
+  rmm::device_uvector<field_occurrence_count> d_occurrence_info(
+    repeated_child_positions.empty() && singular_message_positions.empty() ? 0
+                                                                           : child_location_count,
+    stream,
+    scratch_mr);
+  CUDF_EXPECTS((repeated_child_positions.empty() && singular_message_positions.empty()) ||
+                 d_occurrence_info.size() == child_location_count,
+               "Protobuf decode internal error: nested occurrence count buffer size mismatch");
+  auto d_multiple_message_fields = cudf::detail::make_zeroed_device_uvector_async<int>(
+    singular_message_positions.empty() ? 0 : num_child_fields, stream, scratch_mr);
+  auto const occurrence_stride = d_occurrence_info.is_empty() ? 0 : num_child_fields;
+  // Occurrence counts are collected with singleton locations so duplicate-message and LIST
+  // offsets do not require another count pass.
   launch_scan_nested_message_fields(
     input,
     parent,
     {d_child_locations.data(),
      num_child_fields,
-     d_repeated_info.data(),
-     repeated_child_positions.empty() ? 0 : num_child_fields,
+     d_occurrence_info.data(),
+     occurrence_stride,
+     d_occurrence_info.data(),
+     occurrence_stride,
+     d_multiple_message_fields.data(),
      {child_field_descs.device.data(), num_child_fields}},
     decode_ctx.error->data(),
     !decode_ctx.row_force_null->is_empty() ? decode_ctx.row_force_null->data() : nullptr,
@@ -538,9 +692,44 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                               decode_ctx,
                               stream);
 
+  std::vector<std::optional<singular_message_merge_buffers>> message_merge_buffers(
+    num_child_fields);
+  if (!singular_message_positions.empty()) {
+    auto h_multiple_message_fields =
+      cudf::detail::make_pinned_vector_async<int>(num_child_fields, stream);
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(h_multiple_message_fields.data(),
+                                             d_multiple_message_fields.data(),
+                                             num_child_fields * sizeof(int),
+                                             stream));
+    stream.sync();
+
+    std::vector<int> merge_positions;
+    for (auto const ci : singular_message_positions) {
+      if (h_multiple_message_fields[ci] != 0) { merge_positions.push_back(ci); }
+    }
+    auto merge_bundle = make_repeated_field_work_bundle(merge_positions,
+                                                        child_field_indices,
+                                                        d_occurrence_info.data(),
+                                                        input.num_rows,
+                                                        schema,
+                                                        "Nested singular message",
+                                                        stream,
+                                                        scratch_mr,
+                                                        scratch_mr);
+    for (auto const ci : merge_positions) {
+      message_merge_buffers[ci].emplace(std::move(*merge_bundle.fields[ci]));
+    }
+    if (!merge_bundle.scan_descriptors.empty()) {
+      auto scan_bundle =
+        make_field_occurrence_scan_bundle(merge_bundle.scan_descriptors, stream, scratch_mr);
+      launch_scan_all_field_occurrences_in_nested(
+        input, parent, scan_bundle.view(), decode_ctx.error->data(), stream);
+    }
+  }
+
   auto repeated_work = make_repeated_field_work_bundle(repeated_child_positions,
                                                        child_field_indices,
-                                                       d_repeated_info.data(),
+                                                       d_occurrence_info.data(),
                                                        input.num_rows,
                                                        schema,
                                                        "Repeated nested-field",
@@ -579,6 +768,18 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
 
     if (dt.id() == cudf::type_id::STRUCT) {
       auto const& gc_indices = schema.children(child_schema_idx);
+      if (message_merge_buffers[ci].has_value()) {
+        struct_children.push_back(
+          build_merged_singular_struct_column(input,
+                                              {parent.locations, parent.top_row_indices},
+                                              gc_indices,
+                                              context,
+                                              std::move(*message_merge_buffers[ci]),
+                                              depth + 1,
+                                              stream,
+                                              mr));
+        continue;
+      }
       rmm::device_uvector<field_location> d_gc_parent_locs(input.num_rows, stream, scratch_mr);
       launch_compute_grandchild_parent_locations(
         loc_provider, d_gc_parent_locs.data(), input.num_rows, decode_ctx.error->data(), stream);

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -719,12 +719,11 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
     for (auto const ci : merge_positions) {
       message_merge_buffers[ci].emplace(std::move(*merge_bundle.fields[ci]));
     }
-    if (!merge_bundle.scan_descriptors.empty()) {
-      auto scan_bundle =
-        make_field_occurrence_scan_bundle(merge_bundle.scan_descriptors, stream, scratch_mr);
-      launch_scan_all_field_occurrences_in_nested(
-        input, parent, scan_bundle.view(), decode_ctx.error->data(), stream);
-    }
+    for_each_field_occurrence_scan_batch(
+      merge_bundle.scan_descriptors, stream, scratch_mr, [&](field_occurrence_scan_view fields) {
+        launch_scan_all_field_occurrences_in_nested(
+          input, parent, fields, decode_ctx.error->data(), stream);
+      });
   }
 
   auto repeated_work = make_repeated_field_work_bundle(repeated_child_positions,

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -361,6 +361,24 @@ inline field_occurrence_scan_bundle make_field_occurrence_scan_bundle(
   return {std::move(descriptors), std::move(lookup)};
 }
 
+template <typename LaunchFn>
+inline void for_each_field_occurrence_scan_batch(
+  cudf::detail::host_vector<field_occurrence_scan_desc> const& host_descriptors,
+  cuda::stream_ref stream,
+  rmm::device_async_resource_ref mr,
+  LaunchFn&& launch)
+{
+  auto constexpr max_batch_size = static_cast<size_t>(MAX_REPEATED_FIELDS_PER_KERNEL);
+  for (size_t begin = 0; begin < host_descriptors.size(); begin += max_batch_size) {
+    auto const batch_size = std::min(max_batch_size, host_descriptors.size() - begin);
+    auto batch =
+      cudf::detail::make_pinned_vector_async<field_occurrence_scan_desc>(batch_size, stream);
+    std::copy_n(host_descriptors.begin() + begin, batch_size, batch.begin());
+    auto scan_bundle = make_field_occurrence_scan_bundle(batch, stream, mr);
+    launch(scan_bundle.view());
+  }
+}
+
 /**
  * Find all child field indices for a given parent index in the schema.
  * This is a commonly used pattern throughout the codebase.

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -144,6 +144,22 @@ struct repeated_field_work_bundle {
   cudf::detail::host_vector<field_occurrence_scan_desc> scan_descriptors;
 };
 
+// Buffers that gather duplicate singular-message fragments by row before recursive decoding.
+struct singular_message_merge_buffers {
+  int schema_idx;
+  int32_t total_fragments;
+  rmm::device_uvector<int32_t> row_offsets;
+  rmm::device_uvector<field_occurrence> fragments;
+
+  explicit singular_message_merge_buffers(repeated_field_work&& work)
+    : schema_idx(work.schema_idx),
+      total_fragments(work.total_count),
+      row_offsets(std::move(work.offsets)),
+      fragments(std::move(*work.occurrences))
+  {
+  }
+};
+
 struct extract_strided_count {
   field_occurrence_count const* info;
   int field_position;
@@ -511,6 +527,16 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   nested_parent_view parent,
   std::vector<int> const& child_field_indices,
   recursive_decode_context context,
+  int depth,
+  cuda::stream_ref stream,
+  rmm::device_async_resource_ref mr);
+
+std::unique_ptr<cudf::column> build_merged_singular_struct_column(
+  protobuf_input_view input,
+  message_fragment_source_view source,
+  std::vector<int> const& child_field_indices,
+  recursive_decode_context context,
+  singular_message_merge_buffers buffers,
   int depth,
   cuda::stream_ref stream,
   rmm::device_async_resource_ref mr);

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -44,6 +44,13 @@ CUDF_KERNEL void set_error_if_unset_kernel(protobuf_error* error_flag, protobuf_
   if (blockIdx.x == 0 && threadIdx.x == 0) { set_error_once(error_flag, error); }
 }
 
+__device__ inline void set_row_invalid(bool* rows, int32_t row)
+{
+  if (rows == nullptr) { return; }
+  cuda::atomic_ref<bool, cuda::thread_scope_device> ref(rows[row]);
+  ref.store(true, cuda::memory_order_relaxed);
+}
+
 enum class wire_type_mismatch_policy {
   report_error_and_abort,
   report_error_and_continue,
@@ -306,6 +313,77 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
   return true;
 }
 
+CUDF_KERNEL void validate_message_fragments_kernel(message_fragment_location_provider locations,
+                                                   message_validation_view fields,
+                                                   int num_fragments,
+                                                   bool* invalid_rows,
+                                                   bool* row_has_invalid_data,
+                                                   protobuf_error* error_flag)
+{
+  auto const idx = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (idx >= num_fragments) return;
+
+  auto const fragment = locations.fragments[idx];
+  auto const row      = fragment.row_idx;
+  auto const top_row =
+    locations.source.top_row_indices == nullptr ? row : locations.source.top_row_indices[row];
+  auto mark_row_error = [&]() {
+    set_row_invalid(invalid_rows, row);
+    set_row_invalid(row_has_invalid_data, top_row);
+  };
+
+  auto const parent =
+    locations.source.parent_locations == nullptr
+      ? field_location{0, locations.input.row_offsets[row + 1] - locations.input.row_offsets[row]}
+      : locations.source.parent_locations[row];
+  if (parent.offset < 0 || parent.length < 0 || fragment.offset < 0 || fragment.length < 0) {
+    set_error_once(error_flag, protobuf_error::BOUNDS);
+    mark_row_error();
+    return;
+  }
+
+  auto const row_start =
+    static_cast<int64_t>(locations.input.row_offsets[row]) - locations.input.base_offset;
+  auto const parent_start   = row_start + parent.offset;
+  auto const fragment_start = parent_start + fragment.offset;
+  auto const fragment_end   = fragment_start + fragment.length;
+  auto const parent_end     = parent_start + parent.length;
+  if (fragment_start < parent_start || fragment_end > parent_end ||
+      !check_message_bounds(
+        fragment_start, fragment_end, locations.input.message_data_size, error_flag)) {
+    set_error_once(error_flag, protobuf_error::BOUNDS);
+    mark_row_error();
+    return;
+  }
+
+  auto record_singular = []([[maybe_unused]] int f, [[maybe_unused]] field_location location) {
+    return true;
+  };
+  auto const* fragment_begin = locations.input.message_data + fragment_start;
+  auto const* fragment_limit = locations.input.message_data + fragment_end;
+  auto validate_repeated     = [&](int f, uint8_t const* cur, proto_wire_type wire_type) {
+    auto ignore_occurrence = []([[maybe_unused]] int32_t offset, [[maybe_unused]] int32_t length) {
+      return true;
+    };
+    return walk_repeated_element<wire_type_mismatch_policy::continue_silently>(
+      cur,
+      fragment_begin,
+      fragment_limit,
+      wire_type,
+      fields.lookup.data[f].expected_wire_type,
+      error_flag,
+      ignore_occurrence);
+  };
+
+  if (!scan_message_field_locations<wire_type_mismatch_policy::continue_silently>(
+        {fragment_begin, fragment_limit, error_flag, nullptr},
+        fields.lookup,
+        record_singular,
+        validate_repeated)) {
+    mark_row_error();
+  }
+}
+
 // ============================================================================
 // Pass 1b: Count repeated fields kernel
 // ============================================================================
@@ -335,6 +413,13 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
   for (int f = 0; f < fields.location_stride; f++) {
     field_locations[f] = {-1, 0};
   }
+  auto* field_message_info =
+    fields.singular_message_stride > 0
+      ? fields.singular_message_info + flat_index(row, fields.singular_message_stride, 0)
+      : nullptr;
+  for (int f = 0; f < fields.singular_message_stride; f++) {
+    field_message_info[f] = {0};
+  }
   auto* field_repeated_info = fields.repeated_stride > 0
                                 ? fields.repeated_info + flat_index(row, fields.repeated_stride, 0)
                                 : nullptr;
@@ -360,6 +445,8 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
   auto record_nested = [&](int f, field_location location) {
     auto const& field                   = fields.lookup.data[f];
     field_locations[field.output_index] = location;
+    auto& info                          = field_message_info[field.output_index];
+    if (++info.count == 2) { atomicExch(fields.multiple_message_fields + field.output_index, 1); }
     return true;
   };
   auto count_repeated = [&](int f, uint8_t const* cur, proto_wire_type wire_type) {
@@ -441,6 +528,7 @@ __device__ bool scan_all_field_occurrences_in_message(uint8_t const* msg_begin,
   return true;
 }
 
+template <wire_type_mismatch_policy MismatchPolicy>
 CUDF_KERNEL void scan_all_field_occurrences_kernel(cudf::column_device_view const d_in,
                                                    field_occurrence_scan_view fields,
                                                    protobuf_error* error_flag)
@@ -459,7 +547,7 @@ CUDF_KERNEL void scan_all_field_occurrences_kernel(cudf::column_device_view cons
   if (!check_message_bounds(start, end, child.size(), error_flag)) return;
 
   [[maybe_unused]] auto const scan_succeeded =
-    scan_all_field_occurrences_in_message<wire_type_mismatch_policy::report_error_and_abort>(
+    scan_all_field_occurrences_in_message<MismatchPolicy>(
       bytes + start, bytes + end, fields, error_flag, row);
 }
 
@@ -497,6 +585,15 @@ CUDF_KERNEL void scan_nested_message_fields_kernel(protobuf_input_view input,
   for (int f = 0; f < fields.repeated_stride; f++) {
     field_repeated_info[f] = {0};
   }
+  auto* field_message_info =
+    fields.singular_message_stride > 0
+      ? fields.singular_message_info + flat_index(row, fields.singular_message_stride, 0)
+      : nullptr;
+  if (field_message_info != field_repeated_info) {
+    for (int f = 0; f < fields.singular_message_stride; f++) {
+      field_message_info[f] = {0};
+    }
+  }
 
   auto const& parent_loc = parent.locations[row];
   if (parent_loc.offset < 0) return;
@@ -516,6 +613,10 @@ CUDF_KERNEL void scan_nested_message_fields_kernel(protobuf_input_view input,
 
   auto record_singular = [&](int f, field_location location) {
     field_locations[f] = location;
+    if (fields.lookup.data[f].is_message) {
+      auto& info = field_message_info[f];
+      if (++info.count == 2) { atomicExch(fields.multiple_message_fields + f, 1); }
+    }
     return true;
   };
   auto validate_repeated = [&](int f, uint8_t const* cur, proto_wire_type wt) {
@@ -775,8 +876,21 @@ void launch_scan_all_field_occurrences(cudf::column_device_view const& d_in,
   auto const num_rows = d_in.size();
   if (num_rows == 0) return;
   auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  scan_all_field_occurrences_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
-    d_in, fields, error_flag);
+  scan_all_field_occurrences_kernel<wire_type_mismatch_policy::report_error_and_abort>
+    <<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(d_in, fields, error_flag);
+  CUDF_CHECK_CUDA(stream.get());
+}
+
+void launch_scan_singular_message_occurrences(cudf::column_device_view const& d_in,
+                                              field_occurrence_scan_view fields,
+                                              protobuf_error* error_flag,
+                                              cuda::stream_ref stream)
+{
+  auto const num_rows = d_in.size();
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  scan_all_field_occurrences_kernel<wire_type_mismatch_policy::report_error_and_continue>
+    <<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(d_in, fields, error_flag);
   CUDF_CHECK_CUDA(stream.get());
 }
 
@@ -820,6 +934,22 @@ void launch_scan_all_field_occurrences_in_nested(protobuf_input_view input,
     static_cast<int>((input.num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
   scan_all_field_occurrences_in_nested_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
     input, parent, fields, error_flag);
+  CUDF_CHECK_CUDA(stream.get());
+}
+
+void launch_validate_message_fragments(message_fragment_location_provider locations,
+                                       message_validation_view fields,
+                                       int num_fragments,
+                                       bool* invalid_rows,
+                                       bool* row_has_invalid_data,
+                                       protobuf_error* error_flag,
+                                       cuda::stream_ref stream)
+{
+  if (num_fragments == 0) return;
+  auto const blocks =
+    static_cast<int>((num_fragments + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  validate_message_fragments_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.get()>>>(
+    locations, fields, num_fragments, invalid_rows, row_has_invalid_data, error_flag);
   CUDF_CHECK_CUDA(stream.get());
 }
 

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -148,6 +148,27 @@ struct nested_repeated_location_provider {
   }
 };
 
+struct message_fragment_location_provider {
+  protobuf_input_view input;
+  message_fragment_source_view source;
+  field_occurrence const* fragments;
+
+  __device__ inline field_location get(int thread_idx, int32_t& data_offset) const
+  {
+    auto const fragment      = fragments[thread_idx];
+    auto const parent_offset = source.parent_locations == nullptr
+                                 ? int32_t{0}
+                                 : source.parent_locations[fragment.row_idx].offset;
+    if (parent_offset < 0) {
+      data_offset = 0;
+      return {-1, 0};
+    }
+    data_offset =
+      input.row_offsets[fragment.row_idx] - input.base_offset + parent_offset + fragment.offset;
+    return {fragment.offset, fragment.length};
+  }
+};
+
 __device__ inline scalar_value_input resolve_scalar_value(uint8_t const* message_data,
                                                           field_location location,
                                                           int32_t data_offset)
@@ -398,6 +419,11 @@ void launch_scan_all_field_occurrences(cudf::column_device_view const& d_in,
                                        protobuf_error* error_flag,
                                        cuda::stream_ref stream);
 
+void launch_scan_singular_message_occurrences(cudf::column_device_view const& d_in,
+                                              field_occurrence_scan_view fields,
+                                              protobuf_error* error_flag,
+                                              cuda::stream_ref stream);
+
 void launch_extract_strided_locations(field_location const* nested_locations,
                                       int field_idx,
                                       int num_fields,
@@ -417,6 +443,14 @@ void launch_scan_all_field_occurrences_in_nested(protobuf_input_view input,
                                                  field_occurrence_scan_view fields,
                                                  protobuf_error* error_flag,
                                                  cuda::stream_ref stream);
+
+void launch_validate_message_fragments(message_fragment_location_provider locations,
+                                       message_validation_view fields,
+                                       int num_fragments,
+                                       bool* invalid_rows,
+                                       bool* row_has_invalid_data,
+                                       protobuf_error* error_flag,
+                                       cuda::stream_ref stream);
 
 void launch_compute_grandchild_parent_locations(nested_location_provider loc_provider,
                                                 field_location* gc_parent_locs,

--- a/src/main/cpp/src/protobuf/protobuf_types.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_types.cuh
@@ -95,6 +95,7 @@ struct field_descriptor {
   int field_number;                    // Protobuf field number
   proto_wire_type expected_wire_type;  // Expected wire type for this field
   bool is_repeated;                    // Repeated children are scanned via count/scan kernels
+  bool is_message;                     // Singular messages may need occurrence merging
   int output_index = -1;               // Matching output column, or -1 when unused
 };
 
@@ -151,6 +152,11 @@ struct protobuf_input_view {
 struct nested_parent_view {
   field_location const* locations;
   std::size_t location_count;
+  int32_t const* top_row_indices;
+};
+
+struct message_fragment_source_view {
+  field_location const* parent_locations;
   int32_t const* top_row_indices;
 };
 
@@ -226,6 +232,13 @@ struct field_scan_view {
   int location_stride;
   field_occurrence_count* repeated_info;
   int repeated_stride;
+  field_occurrence_count* singular_message_info;
+  int singular_message_stride;
+  int* multiple_message_fields;
+  lookup_view<field_descriptor> lookup;
+};
+
+struct message_validation_view {
   lookup_view<field_descriptor> lookup;
 };
 
@@ -238,6 +251,7 @@ static_assert(device_layout_compatible<field_occurrence_scan_desc>);
 static_assert(device_layout_compatible<field_occurrence_scan_view>);
 static_assert(device_layout_compatible<lookup_view<field_descriptor>>);
 static_assert(device_layout_compatible<nested_parent_view>);
+static_assert(device_layout_compatible<message_fragment_source_view>);
 static_assert(device_layout_compatible<protobuf_value_domain_view>);
 static_assert(device_layout_compatible<required_field_input_view>);
 static_assert(device_layout_compatible<scalar_value_input>);
@@ -248,6 +262,7 @@ static_assert(device_layout_compatible<batched_scalar_desc<int32_t>>);
 static_assert(device_layout_compatible<batched_scalar_input_view<int32_t>>);
 static_assert(device_layout_compatible<batched_scalar_desc<double>>);
 static_assert(device_layout_compatible<batched_scalar_input_view<double>>);
+static_assert(device_layout_compatible<message_validation_view>);
 static_assert(device_layout_compatible<enum_domain_device_view>);
 static_assert(device_layout_compatible<enum_string_lookup_device_view>);
 static_assert(device_layout_compatible<field_scan_view>);

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -2756,6 +2756,48 @@ public class ProtobufTest {
   }
 
   @Test
+  void testMoreThan32DuplicateSingularMessageFields() {
+    int numMessageFields = 33;
+    ProtobufSchemaDescriptorBuilder builder = new ProtobufSchemaDescriptorBuilder();
+    ByteArrayOutputStream row = new ByteArrayOutputStream();
+    try {
+      for (int i = 0; i < numMessageFields; i++) {
+        builder.addField(i + 1, DType.STRUCT).down()
+            .addField(1, DType.INT32)
+            .addField(2, DType.INT32)
+            .up();
+
+        byte[] firstFragment = concatBytes(tag(1, WT_VARINT), encodeVarint(i));
+        byte[] secondFragment = concatBytes(tag(2, WT_VARINT), encodeVarint(i + 100));
+        row.write(tag(i + 1, WT_LEN));
+        row.write(encodeVarint(firstFragment.length));
+        row.write(firstFragment);
+        row.write(tag(i + 1, WT_LEN));
+        row.write(encodeVarint(secondFragment.length));
+        row.write(secondFragment);
+      }
+    } catch (java.io.IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{box(row.toByteArray())}).build();
+         ColumnVector actual = Protobuf.decodeToStruct(input.getColumn(0), builder.build(), true)) {
+      assertEquals(numMessageFields, actual.getNumChildren());
+      for (int i = 0; i < numMessageFields; i++) {
+        try (ColumnVector message = actual.getChildColumnView(i).copyToColumnVector();
+             ColumnVector first = message.getChildColumnView(0).copyToColumnVector();
+             ColumnVector second = message.getChildColumnView(1).copyToColumnVector();
+             HostColumnVector hostFirst = first.copyToHost();
+             HostColumnVector hostSecond = second.copyToHost()) {
+          assertEquals(i, hostFirst.getInt(0), "Unexpected first fragment value at field " + i);
+          assertEquals(i + 100, hostSecond.getInt(0),
+              "Unexpected second fragment value at field " + i);
+        }
+      }
+    }
+  }
+
+  @Test
   void testDuplicateSingularMessageOccurrencesMergeRecursivelyInBothModes() {
     Byte[] childFirst = concat(
         box(tag(1, WT_VARINT)), box(encodeVarint(1)),
@@ -2847,20 +2889,24 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)), box(encodeVarint(7)),
         box(tag(1, WT_LEN)), encodeMessage(validFirst),
         box(tag(1, WT_LEN)), encodeMessage(validSecond));
+    Byte[] validDuplicates = concat(
+        box(tag(1, WT_LEN)), encodeMessage(validFirst),
+        box(tag(1, WT_LEN)), encodeMessage(validSecond));
     ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
         .addField(1, DType.STRUCT).down()
             .addField(1, DType.INT32)
         .up()
         .build();
 
-    try (Table input = new Table.TestBuilder().column(
-             new Byte[][]{malformedFirst, malformedLast, wrongWireBeforeDuplicates}).build();
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{
+             malformedFirst, malformedLast, wrongWireBeforeDuplicates, validDuplicates}).build();
          ColumnVector expected = ColumnVector.fromStructs(
              new StructType(true,
                  new StructType(true, new BasicType(true, DType.INT32))),
              (StructData) null,
              (StructData) null,
-             (StructData) null);
+             (StructData) null,
+             struct(struct(2)));
          ColumnVector actual = Protobuf.decodeToStruct(
              input.getColumn(0), schema, false)) {
       AssertUtils.assertStructColumnsAreEqual(expected, actual);

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -2664,6 +2664,234 @@ public class ProtobufTest {
   }
 
   @Test
+  void testDuplicateSingularMessageOccurrencesMergeInBothModes() {
+    Byte[] firstFragment = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(3, WT_VARINT)), box(encodeVarint(10)));
+    Byte[] secondFragment = concat(
+        box(tag(2, WT_VARINT)), box(encodeVarint(2)),
+        box(tag(3, WT_VARINT)), box(encodeVarint(20)));
+    Byte[] sameFieldFirst = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(9)));
+    Byte[] sameFieldSecond = concat(box(tag(1, WT_VARINT)), box(encodeVarint(2)));
+    Byte[] singleFragment = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(7)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(8)));
+    Byte[][] rows = new Byte[][]{
+        concat(
+            box(tag(1, WT_LEN)), encodeMessage(firstFragment),
+            box(tag(1, WT_LEN)), encodeMessage(secondFragment)),
+        concat(
+            box(tag(1, WT_LEN)), encodeMessage(sameFieldFirst),
+            box(tag(1, WT_LEN)), encodeMessage(sameFieldSecond)),
+        concat(box(tag(1, WT_LEN)), encodeMessage(singleFragment)),
+        new Byte[]{},
+        null};
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).down()
+            .addField(1, DType.INT32).required()
+            .addField(2, DType.INT32).required()
+            .addField(3, DType.INT32).repeated()
+        .up()
+        .build();
+
+    StructType childType = new StructType(true,
+        new BasicType(true, DType.INT32),
+        new BasicType(true, DType.INT32),
+        new ListType(true, new BasicType(true, DType.INT32)));
+    try (Table input = new Table.TestBuilder().column(rows).build();
+         ColumnVector expected = ColumnVector.fromStructs(
+             new StructType(true, childType),
+             struct(struct(1, 2, Arrays.asList(10, 20))),
+             struct(struct(2, 9, Collections.emptyList())),
+             struct(struct(7, 8, Collections.emptyList())),
+             struct((Object) null),
+             (StructData) null);
+         ColumnVector actualPermissive = Protobuf.decodeToStruct(
+             input.getColumn(0), schema, false);
+         ColumnVector actualFailfast = Protobuf.decodeToStruct(
+             input.getColumn(0), schema, true)) {
+      AssertUtils.assertStructColumnsAreEqual(expected, actualPermissive);
+      AssertUtils.assertStructColumnsAreEqual(expected, actualFailfast);
+    }
+  }
+
+  @Test
+  void testDuplicateSingularMessageSlowPathPreservesPresenceAndNullsInBothModes() {
+    Byte[] value1 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));
+    Byte[] value2 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(2)));
+    Byte[][] rows = new Byte[][]{
+        concat(
+            box(tag(1, WT_LEN)), encodeMessage(value1),
+            box(tag(1, WT_LEN)), encodeMessage(value2)),
+        concat(box(tag(1, WT_LEN)), encodeMessage(new Byte[]{})),
+        concat(
+            box(tag(1, WT_LEN)), encodeMessage(new Byte[]{}),
+            box(tag(1, WT_LEN)), encodeMessage(new Byte[]{})),
+        new Byte[]{},
+        null};
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).down()
+            .addField(1, DType.INT32)
+        .up()
+        .build();
+    StructType childType = new StructType(true, new BasicType(true, DType.INT32));
+
+    try (Table input = new Table.TestBuilder().column(rows).build();
+         ColumnVector expected = ColumnVector.fromStructs(
+             new StructType(true, childType),
+             struct(struct(2)),
+             struct(struct((Object) null)),
+             struct(struct((Object) null)),
+             struct((Object) null),
+             (StructData) null);
+         ColumnVector actualPermissive = Protobuf.decodeToStruct(
+             input.getColumn(0), schema, false);
+         ColumnVector actualFailfast = Protobuf.decodeToStruct(
+             input.getColumn(0), schema, true)) {
+      AssertUtils.assertStructColumnsAreEqual(expected, actualPermissive);
+      AssertUtils.assertStructColumnsAreEqual(expected, actualFailfast);
+    }
+  }
+
+  @Test
+  void testDuplicateSingularMessageOccurrencesMergeRecursivelyInBothModes() {
+    Byte[] childFirst = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(3, WT_VARINT)), box(encodeVarint(10)));
+    Byte[] childSecond = concat(
+        box(tag(2, WT_VARINT)), box(encodeVarint(2)),
+        box(tag(3, WT_VARINT)), box(encodeVarint(20)));
+    Byte[] parentFirst = concat(box(tag(1, WT_LEN)), encodeMessage(childFirst));
+    Byte[] parentSecond = concat(box(tag(1, WT_LEN)), encodeMessage(childSecond));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), encodeMessage(parentFirst),
+        box(tag(1, WT_LEN)), encodeMessage(parentSecond));
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).down()
+            .addField(1, DType.STRUCT).down()
+                .addField(1, DType.INT32)
+                .addField(2, DType.INT32)
+                .addField(3, DType.INT32).repeated()
+            .up()
+        .up()
+        .build();
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedChild = ColumnVector.fromStructs(
+             new StructType(true,
+                 new BasicType(true, DType.INT32),
+                 new BasicType(true, DType.INT32),
+                 new ListType(true, new BasicType(true, DType.INT32))),
+             struct(1, 2, Arrays.asList(10, 20)));
+         ColumnVector expectedParent = ColumnVector.makeStruct(expectedChild);
+         ColumnVector expected = ColumnVector.makeStruct(expectedParent);
+         ColumnVector actualPermissive = Protobuf.decodeToStruct(
+             input.getColumn(0), schema, false);
+         ColumnVector actualFailfast = Protobuf.decodeToStruct(
+             input.getColumn(0), schema, true)) {
+      AssertUtils.assertStructColumnsAreEqual(expected, actualPermissive);
+      AssertUtils.assertStructColumnsAreEqual(expected, actualFailfast);
+    }
+  }
+
+  @Test
+  void testSlicedInputPreservesDuplicateSingularMessageMerge() {
+    Byte[] firstFragment = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));
+    Byte[] secondFragment = concat(box(tag(2, WT_VARINT)), box(encodeVarint(2)));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), encodeMessage(firstFragment),
+        box(tag(1, WT_LEN)), encodeMessage(secondFragment));
+    Byte[] sentinel = concat(box(tag(99, WT_VARINT)), box(encodeVarint(7)));
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).down()
+            .addField(1, DType.INT32)
+            .addField(2, DType.INT32)
+        .up()
+        .build();
+
+    try (Table input = new Table.TestBuilder()
+             .column(new Byte[][]{sentinel, row, sentinel})
+             .build();
+         ColumnVector expectedChild = ColumnVector.fromStructs(
+             new StructType(true,
+                 new BasicType(true, DType.INT32),
+                 new BasicType(true, DType.INT32)),
+             struct(1, 2));
+         ColumnVector expected = ColumnVector.makeStruct(expectedChild);
+         CloseableArray<ColumnView> views =
+             CloseableArray.wrap(input.getColumn(0).splitAsViews(1, 2));
+         ColumnVector actualPermissive = Protobuf.decodeToStruct(views.get(1), schema, false);
+         ColumnVector actualFailfast = Protobuf.decodeToStruct(views.get(1), schema, true)) {
+      AssertUtils.assertStructColumnsAreEqual(expected, actualPermissive);
+      AssertUtils.assertStructColumnsAreEqual(expected, actualFailfast);
+    }
+  }
+
+  @Test
+  void testMalformedSingularMessageFragmentBoundary_Permissive() {
+    Byte[] truncatedVarint = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte) 0x80});
+    Byte[] validUnknownFixed64 = concat(
+        box(tag(3, WT_64BIT)),
+        box(encodeFixed64(0x0108010801080108L)));
+    Byte[] malformedFirst = concat(
+        box(tag(1, WT_LEN)), encodeMessage(truncatedVarint),
+        box(tag(1, WT_LEN)), encodeMessage(validUnknownFixed64));
+    Byte[] malformedLast = concat(
+        box(tag(1, WT_LEN)), encodeMessage(validUnknownFixed64),
+        box(tag(1, WT_LEN)), encodeMessage(truncatedVarint));
+    Byte[] validFirst = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));
+    Byte[] validSecond = concat(box(tag(1, WT_VARINT)), box(encodeVarint(2)));
+    Byte[] wrongWireBeforeDuplicates = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(7)),
+        box(tag(1, WT_LEN)), encodeMessage(validFirst),
+        box(tag(1, WT_LEN)), encodeMessage(validSecond));
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).down()
+            .addField(1, DType.INT32)
+        .up()
+        .build();
+
+    try (Table input = new Table.TestBuilder().column(
+             new Byte[][]{malformedFirst, malformedLast, wrongWireBeforeDuplicates}).build();
+         ColumnVector expected = ColumnVector.fromStructs(
+             new StructType(true,
+                 new StructType(true, new BasicType(true, DType.INT32))),
+             (StructData) null,
+             (StructData) null,
+             (StructData) null);
+         ColumnVector actual = Protobuf.decodeToStruct(
+             input.getColumn(0), schema, false)) {
+      AssertUtils.assertStructColumnsAreEqual(expected, actual);
+    }
+  }
+
+  @Test
+  void testMalformedSingularMessageFragmentBoundary_Failfast() {
+    Byte[] truncatedVarint = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte) 0x80});
+    Byte[] validUnknownFixed64 = concat(
+        box(tag(3, WT_64BIT)),
+        box(encodeFixed64(0x0108010801080108L)));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), encodeMessage(validUnknownFixed64),
+        box(tag(1, WT_LEN)), encodeMessage(truncatedVarint));
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).down()
+            .addField(1, DType.INT32)
+        .up()
+        .build();
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector ignored = Protobuf.decodeToStruct(
+            input.getColumn(0), schema, true)) {
+        }
+      });
+    }
+  }
+
+  @Test
   void testNestedMessageMultipleScalarChildren() {
     // message Inner { int32 a = 1; int64 b = 2; bool c = 3; float d = 4; }
     // message Outer { Inner inner = 1; }


### PR DESCRIPTION
Fixes #4983.

## Summary

Protobuf merges repeated occurrences of a singular embedded message instead of applying last-one-wins to the message as a whole. This change brings the JNI decoder in line with protobuf-java for the singular-message paths supported on `main`.

## Changes

- Count and gather all occurrences when a singular message appears more than once in a row.
- Validate each message fragment independently before concatenating it, so malformed data cannot consume bytes from the next fragment.
- Decode the merged payload through the existing recursive message path, preserving last-one-wins for singular scalar children, append semantics for repeated children, recursive singular-message merging, and required-field validation after the merge.
- Preserve zero-length message presence, null rows, permissive/fail-fast behavior, and sliced-input offsets.
- Add focused regression coverage for top-level and recursively nested messages, repeated children, required fields split across fragments, empty fragments, sliced inputs, and malformed fragment boundaries.

## Testing

- `pre-commit` hooks for all changed files
- `mvn -q compiler:testCompile -DskipTests`
- JNI build and relevant protobuf tests passed locally
