### PR TITLE
Rename JNI artifacts for the cuDF Spark project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           cudf_ver=$(grep -A1 "repo: $clang_format_pattern" "thirdparty/cudf/.pre-commit-config.yaml" | grep "rev:" | tail -1 | sed "s/.*rev: *//");
           if [ -z "$our_ver" ] || [ -z "$cudf_ver" ] || [ "$our_ver" != "$cudf_ver" ]; then
             echo "ERROR: clang-format version mismatch or failed to extract version!";
-            echo "  spark-rapids-jni: ${our_ver:-(empty)}";
+            echo "  cudf-spark-jni: ${our_ver:-(empty)}";
             echo "  cudf:             ${cudf_ver:-(empty)}";
             echo "Please update .pre-commit-config.yaml to use the same rev as cudf";
             exit 1;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ branch=testCUDF_pr1
 date=2022-07-19T21:48:15Z
 url=https://github.com/nvidia/cudf.git
 
-  inflating: spark-rapids-jni-version-info.properties
+  inflating: cudf-spark-jni-version-info.properties
 version=22.08.0-SNAPSHOT
 user=
 revision=70adcc86a513ad6665968021c669fbca7515a188

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ This repository contains native support code for the
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/cudf-spark-jni)
 
 Note: The NVIDIA cuDF plugin for Apache Spark was formerly known as the RAPIDS Accelerator for
-Apache Spark.  The RAPIDS name will be sunset over time.  GitHub links from `spark-rapids-jni` will
-redirect to `cudf-spark-jni`.  Artifact names will remain the same for now.
+Apache Spark.  The RAPIDS name will be sunset over time.  This repository now uses the
+`cudf-spark-jni` name for its GitHub location and Maven artifact.
 
 ## Building From Source
 
 See the [build instructions in the contributing guide](CONTRIBUTING.md#building-from-source).
-

--- a/build/apply-patches
+++ b/build/apply-patches
@@ -45,7 +45,7 @@ CUDF_DIR=${CUDF_DIR:-$(realpath "$BASE_DIR/thirdparty/cudf/")}
 # is to save some state files about what happened. But a user could mess with CUDF directly
 # so we want to have ways to double check that they are indeed correct.
 
-FULLY_PATCHED_FILE="$CUDF_DIR/spark-rapids-jni.patch"
+FULLY_PATCHED_FILE="$CUDF_DIR/cudf-spark-jni.patch"
 
 pushd "$CUDF_DIR"
 

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -54,7 +54,7 @@ LOCAL_LIBCUDF_KERNEL_CACHE_DIR=${LOCAL_LIBCUDF_KERNEL_CACHE_DIR:-${LIBCUDF_KERNE
 mkdir -p "$LOCAL_CCACHE_DIR" "$LOCAL_MAVEN_REPO" "$LOCAL_LIBCUDF_KERNEL_CACHE_DIR"
 
 echo "Building docker image for CICD environment..."
-JNI_DOCKER_CICD_IMAGE="spark-rapids-jni-build:${CUDA_VERSION}-rockylinux${OS_RELEASE}"
+JNI_DOCKER_CICD_IMAGE="cudf-spark-jni-build:${CUDA_VERSION}-rockylinux${OS_RELEASE}"
 $DOCKER_CMD build $DOCKER_BUILD_EXTRA_ARGS -f $REPODIR/ci/Dockerfile \
   --build-arg CUDA_VERSION=$CUDA_VERSION \
   --build-arg OS_RELEASE=$OS_RELEASE \

--- a/build/unapply-patches
+++ b/build/unapply-patches
@@ -50,7 +50,7 @@ fi
 # is to save some state files about what happened. But a user could mess with CUDF directly
 # so we want to have ways to double check that they are indeed correct.
 
-FULLY_PATCHED_FILE="$CUDF_DIR/spark-rapids-jni.patch"
+FULLY_PATCHED_FILE="$CUDF_DIR/cudf-spark-jni.patch"
 
 pushd "$CUDF_DIR"
 

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -232,7 +232,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         sh 'bash ci/fuzz-test.sh'
                                     } catch (e) {
                                         common.printJVMCoreDumps(this)
-                                        common.uploadDebugBundle(this, 'spark-rapids-jni', 'cuda12')
+                                        common.uploadDebugBundle(this, 'cudf-spark-jni', 'cuda12')
                                         throw e
                                     }
                                 }
@@ -270,7 +270,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         sh 'bash ci/fuzz-test.sh'
                                     } catch (e) {
                                         common.printJVMCoreDumps(this)
-                                        common.uploadDebugBundle(this, 'spark-rapids-jni', 'cuda13')
+                                        common.uploadDebugBundle(this, 'cudf-spark-jni', 'cuda13')
                                         throw e
                                     }
                                 }

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -16,7 +16,7 @@
 #
 
 ###
-# Script to deploy spark-rapids-jni jar files along with other classifiers,
+# Script to deploy cudf-spark-jni jar files along with other classifiers,
 # such as cudaXXX, sources, javadoc.
 #
 # Argument(s):
@@ -92,7 +92,7 @@ fi
 DEPLOY_CMD="$DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID -DpomFile=$POM_FILE"
 echo "Deploy CMD: $DEPLOY_CMD"
 
-###### Deploy spark-rapids-jni jar with all its additions ######
+###### Deploy cudf-spark-jni jar with all its additions ######
 $DEPLOY_CMD -Dfile=$FPATH.jar \
             -DpomFile=$POM_FILE \
             -Dsources=$FPATH-sources.jar \

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.nvidia</groupId>
-  <artifactId>spark-rapids-jni</artifactId>
+  <artifactId>cudf-spark-jni</artifactId>
   <version>26.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>NVIDIA cuDF plugin JNI for Apache Spark</name>
@@ -503,7 +503,7 @@
                   <arg value="${libcudf.build.path}/libcudf.a"/>
                 </exec>
                 <exec executable="bash"
-                      output="${project.build.directory}/extra-resources/spark-rapids-jni-version-info.properties"
+                      output="${project.build.directory}/extra-resources/cudf-spark-jni-version-info.properties"
                       failonerror="true">
                   <arg value="${project.basedir}/build/build-info"/>
                   <arg value="${project.version}"/>

--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -60,7 +60,7 @@ function(ConfigureBench CMAKE_BENCH_NAME)
     install(
         TARGETS ${CMAKE_BENCH_NAME}
         COMPONENT testing
-        DESTINATION bin/benchmarks/spark-rapids-jni
+        DESTINATION bin/benchmarks/cudf-spark-jni
         EXCLUDE_FROM_ALL
     )
 endfunction(ConfigureBench)


### PR DESCRIPTION
## Description
Part fix of https://github.com/NVIDIA/cudf-spark/issues/15882

Align the published Maven coordinates and generated resources with the repository rename from `spark-rapids-jni` to `cudf-spark-jni`.

- rename the Maven artifact to `cudf-spark-jni`
- generate `cudf-spark-jni-version-info.properties` for consumers
- update deployment, Docker, patch-state, debug-bundle, and benchmark paths
- refresh documentation and diagnostics
- leave the cuDF submodule unchanged
