### PR TITLE
Canonicalize BOOL8 values in MurmurHash32

### DIFF
--- a/src/main/cpp/src/hash/murmur_hash.cuh
+++ b/src/main/cpp/src/hash/murmur_hash.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,9 @@ struct MurmurHash3_32 {
 template <>
 murmur_hash_value_type __device__ inline MurmurHash3_32<bool>::operator()(bool const& key) const
 {
-  return compute<uint32_t>(key);
+  // BOOL8 stores false as zero and true as any non-zero byte. Canonicalize
+  // before hashing so noncanonical true values hash exactly like Spark true.
+  return compute<uint32_t>(key ? 1u : 0u);
 }
 
 template <>

--- a/src/main/cpp/tests/hash.cpp
+++ b/src/main/cpp/tests/hash.cpp
@@ -217,12 +217,11 @@ TEST_F(SparkMurmurHash3Test, NonCanonicalBool)
                                                   0);
 
   auto const output = spark_rapids_jni::murmur_hash3_32(cudf::table_view({col->view()}), 42);
-  auto const host   = cudf::test::to_host<int32_t>(output->view()).first;
 
-  ASSERT_EQ(raw.size(), host.size());
-  EXPECT_EQ(host[1], host[2]) << "byte 2 must hash the same as byte 1";
-  EXPECT_EQ(host[1], host[3]) << "byte 255 must hash the same as byte 1";
-  EXPECT_NE(host[0], host[1]) << "false and true must differ";
+  cudf::test::fixed_width_column_wrapper<bool> const canonical({false, true, true, true});
+  auto const expected = spark_rapids_jni::murmur_hash3_32(cudf::table_view({canonical}), 42);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(output->view(), expected->view());
 }
 
 TEST_F(SparkMurmurHash3Test, MultiValueWithSeeds)

--- a/src/main/cpp/tests/hash.cpp
+++ b/src/main/cpp/tests/hash.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,12 @@
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/hashing.hpp>
 
+#include <rmm/device_buffer.hpp>
+
 #include <hash/hash.hpp>
+
+#include <memory>
+#include <vector>
 
 constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
 
@@ -197,6 +202,28 @@ TYPED_TEST(HashTestFloatTyped, TestExtremes)
 }
 
 class SparkMurmurHash3Test : public cudf::test::BaseFixture {};
+
+TEST_F(SparkMurmurHash3Test, NonCanonicalBool)
+{
+  // BOOL8 treats every non-zero byte as true. fixed_width_column_wrapper<bool>
+  // canonicalizes its inputs, so construct this column from raw bytes instead.
+  auto const stream = cudf::get_default_stream();
+  std::vector<uint8_t> const raw{0, 1, 2, 255};
+  auto data      = rmm::device_buffer{raw.data(), raw.size(), stream};
+  auto const col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::BOOL8},
+                                                  static_cast<cudf::size_type>(raw.size()),
+                                                  std::move(data),
+                                                  rmm::device_buffer{},
+                                                  0);
+
+  auto const output = spark_rapids_jni::murmur_hash3_32(cudf::table_view({col->view()}), 42);
+  auto const host   = cudf::test::to_host<int32_t>(output->view()).first;
+
+  ASSERT_EQ(raw.size(), host.size());
+  EXPECT_EQ(host[1], host[2]) << "byte 2 must hash the same as byte 1";
+  EXPECT_EQ(host[1], host[3]) << "byte 255 must hash the same as byte 1";
+  EXPECT_NE(host[0], host[1]) << "false and true must differ";
+}
 
 TEST_F(SparkMurmurHash3Test, MultiValueWithSeeds)
 {


### PR DESCRIPTION
Fixes #5095.

Canonicalize BOOL8 values before Spark-compatible MurmurHash32 hashing so every non-zero stored byte hashes as boolean true (`1`) instead of exposing its raw byte value.

The regression constructs a BOOL8 column directly from raw bytes `{0, 1, 2, 255}` because `fixed_width_column_wrapper<bool>` canonicalizes inputs during test setup. It verifies that 1, 2 and 255 hash identically while false remains distinct.

Validation:
- repository pre-commit hooks pass for both changed C++/CUDA files
- `git diff --check` passes

CUDA test execution is not available on the current macOS host; the added native regression is intended for the repository's NVIDIA/CUDA CI environment.