### PR TITLE
Use `cuda::device_buffer<std::byte>` for null masks

### DIFF
--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -547,7 +547,9 @@ std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile cons
   auto [result_bitmask, null_count] =
     profile.get_null_probability().has_value()
       ? cudf::bools_to_mask(cudf::device_span<bool const>(null_mask), stream)
-      : std::pair{std::make_unique<rmm::device_buffer>(), 0};
+      : std::pair{std::make_unique<cuda::device_buffer<std::byte>>(
+                    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED)),
+                  0};
 
   return cudf::make_strings_column(num_rows,
                                    std::move(offsets),
@@ -652,7 +654,9 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
   auto [result_bitmask, null_count] =
     profile.get_null_probability().has_value()
       ? cudf::bools_to_mask(cudf::device_span<bool const>(null_mask))
-      : std::pair{std::make_unique<rmm::device_buffer>(), 0};
+      : std::pair{std::make_unique<cuda::device_buffer<std::byte>>(
+                    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED)),
+                  0};
 
   return std::make_unique<cudf::column>(
     dtype, num_rows, data.release(), std::move(*result_bitmask.release()), null_count);
@@ -731,7 +735,9 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
           return cudf::bools_to_mask(cudf::device_span<bool const>(valids),
                                      cudf::get_default_stream());
         }
-        return std::pair{std::make_unique<rmm::device_buffer>(), 0};
+        return std::pair{std::make_unique<cuda::device_buffer<std::byte>>(
+                           cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED)),
+                         0};
       }();
 
       // Adopt remaining children as evenly as possible
@@ -816,15 +822,19 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
     thrust::device_pointer_cast(offsets.end())[-1] =
       current_child_column->size();  // Always include all elements
 
-    auto offsets_column = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
-                                                         current_num_rows + 1,
-                                                         offsets.release(),
-                                                         rmm::device_buffer{},
-                                                         0);
+    auto offsets_column =
+      std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                     current_num_rows + 1,
+                                     offsets.release(),
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                     0);
 
-    auto [null_mask, null_count] = profile.get_null_probability().has_value()
-                                     ? cudf::bools_to_mask(cudf::device_span<bool const>(valids))
-                                     : std::pair{std::make_unique<rmm::device_buffer>(), 0};
+    auto [null_mask, null_count] =
+      profile.get_null_probability().has_value()
+        ? cudf::bools_to_mask(cudf::device_span<bool const>(valids))
+        : std::pair{std::make_unique<cuda::device_buffer<std::byte>>(
+                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED)),
+                    0};
 
     list_column = cudf::make_lists_column(current_num_rows,
                                           std::move(offsets_column),
@@ -900,8 +910,12 @@ std::unique_ptr<cudf::column> create_distinct_rows_column<cudf::list_view>(
   auto child_column      = cudf::sequence(num_rows, *zero);
   for (int lvl = dist_params.max_depth; lvl > 0; --lvl) {
     auto offsets_column = cudf::sequence(num_rows + 1, *zero);
-    auto list_column    = cudf::make_lists_column(
-      num_rows, std::move(offsets_column), std::move(child_column), 0, rmm::device_buffer{});
+    auto list_column =
+      cudf::make_lists_column(num_rows,
+                              std::move(offsets_column),
+                              std::move(child_column),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
     if (auto const cv = list_column->view();
         cudf::has_nonempty_nulls(cv, cudf::get_default_stream())) {
       list_column = cudf::purge_nonempty_nulls(
@@ -931,8 +945,8 @@ std::unique_ptr<cudf::column> create_distinct_rows_column<cudf::struct_view>(
   children.push_back(cudf::sequence(num_rows, *cudf::make_fixed_width_scalar<int32_t>(0)));
   for (int lvl = dist_params.max_depth; lvl > 1; --lvl) {
     std::vector<std::unique_ptr<cudf::column>> parents;
-    parents.push_back(
-      cudf::create_structs_hierarchy(num_rows, std::move(children), 0, rmm::device_buffer{}));
+    parents.push_back(cudf::create_structs_hierarchy(
+      num_rows, std::move(children), 0, cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED)));
     std::swap(parents, children);
   }
   auto const null_count = col->null_count();
@@ -1096,10 +1110,12 @@ std::unique_ptr<cudf::column> create_string_column(cudf::size_type num_rows,
   return std::move(table->release().front());
 }
 
-std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
+std::pair<cuda::device_buffer<std::byte>, cudf::size_type> create_random_null_mask(
   cudf::size_type size, std::optional<double> null_probability, unsigned seed)
 {
-  if (not null_probability.has_value()) { return {rmm::device_buffer{}, 0}; }
+  if (not null_probability.has_value()) {
+    return {cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0};
+  }
   CUDF_EXPECTS(*null_probability >= 0.0 and *null_probability <= 1.0,
                "Null probability must be within the range [0.0, 1.0]");
   if (*null_probability == 0.0f) {

--- a/src/main/cpp/benchmarks/common/generate_input.hpp
+++ b/src/main/cpp/benchmarks/common/generate_input.hpp
@@ -771,5 +771,5 @@ std::vector<cudf::type_id> mix_dtypes(std::pair<cudf::type_id, cudf::type_id> co
  * @param seed Optional, seed for the pseudo-random engine
  * @return null mask device buffer with random null mask data and null count
  */
-std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
+std::pair<cuda::device_buffer<std::byte>, cudf::size_type> create_random_null_mask(
   cudf::size_type size, std::optional<double> null_probability = std::nullopt, unsigned seed = 1);

--- a/src/main/cpp/benchmarks/from_json.cu
+++ b/src/main/cpp/benchmarks/from_json.cu
@@ -346,9 +346,13 @@ std::unique_ptr<cudf::column> generate_map_of_array_input(std::size_t num_rows,
                      row_count,
                      fn);
 
-  auto offsets_col = std::make_unique<cudf::column>(std::move(offsets), rmm::device_buffer{}, 0);
-  return cudf::make_strings_column(
-    row_count, std::move(offsets_col), chars.release(), 0, rmm::device_buffer{});
+  auto offsets_col = std::make_unique<cudf::column>(
+    std::move(offsets), cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
+  return cudf::make_strings_column(row_count,
+                                   std::move(offsets_col),
+                                   chars.release(),
+                                   0,
+                                   cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 }  // namespace

--- a/src/main/cpp/benchmarks/parse_uri.cpp
+++ b/src/main/cpp/benchmarks/parse_uri.cpp
@@ -117,7 +117,8 @@ static void bench_parse_uri(nvbench::state& state)
       cudf::type_id::INT32, distribution_id::UNIFORM, 1, data_view.size() - 1);
   auto gather_table =
     create_random_table({cudf::type_id::INT32}, row_count{n_rows}, gather_profile);
-  gather_table->get_column(0).set_null_mask(rmm::device_buffer{}, 0);
+  gather_table->get_column(0).set_null_mask(
+    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
 
   // Create scatter map by placing 0-index values throughout the gather-map
   auto scatter_data = cudf::sequence(

--- a/src/main/cpp/src/bloom_filter.cu
+++ b/src/main/cpp/src/bloom_filter.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -324,8 +324,11 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(int version,
     static_cast<uint8_t*>(buf.data()) + hdr_size, 0, bloom_filter_size, stream.get()));
 
   return std::make_unique<cudf::list_scalar>(
-    cudf::column(
-      cudf::data_type{cudf::type_id::UINT8}, buf_size, std::move(buf), rmm::device_buffer{}, 0),
+    cudf::column(cudf::data_type{cudf::type_id::UINT8},
+                 buf_size,
+                 std::move(buf),
+                 cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                 0),
     true,
     stream,
     mr);
@@ -441,8 +444,11 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_merge(cudf::column_view const& b
 
   // create the 1-row list column and move it into a scalar.
   return std::make_unique<cudf::list_scalar>(
-    cudf::column(
-      cudf::data_type{cudf::type_id::UINT8}, buf_size, std::move(buf), rmm::device_buffer{}, 0),
+    cudf::column(cudf::data_type{cudf::type_id::UINT8},
+                 buf_size,
+                 std::move(buf),
+                 cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                 0),
     true,
     stream,
     mr);

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -664,20 +664,23 @@ struct string_to_integer_impl {
                                      rmm::device_async_resource_ref mr)
   {
     if (string_col.size() == 0) {
-      return std::make_unique<column>(
-        data_type{type_to_id<T>()}, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
+      return std::make_unique<column>(data_type{type_to_id<T>()},
+                                      0,
+                                      rmm::device_buffer{},
+                                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                      0);
     }
 
     rmm::device_uvector<T> data(string_col.size(), stream, mr);
-    auto const num_words = bitmask_allocation_size_bytes(string_col.size()) / sizeof(bitmask_type);
-    rmm::device_uvector<bitmask_type> null_mask(num_words, stream, mr);
+    auto null_mask =
+      cudf::create_null_mask(string_col.size(), cudf::mask_state::UNINITIALIZED, stream, mr);
 
     dim3 const blocks(util::div_rounding_up_unsafe(string_col.size(), detail::NUM_THREADS));
     dim3 const threads{detail::NUM_THREADS};
 
     detail::string_to_integer_kernel<<<blocks, threads, 0, stream.get()>>>(
       data.data(),
-      null_mask.data(),
+      reinterpret_cast<bitmask_type*>(null_mask.data()),
       string_col.chars_begin(stream),
       string_col.offsets().data<size_type>(),
       string_col.null_mask(),
@@ -685,12 +688,13 @@ struct string_to_integer_impl {
       ansi_mode,
       strip);
 
-    auto null_count = cudf::null_count(null_mask.data(), 0, string_col.size(), stream);
+    auto null_count = cudf::null_count(
+      reinterpret_cast<bitmask_type*>(null_mask.data()), 0, string_col.size(), stream);
 
     auto col = std::make_unique<column>(data_type{type_to_id<T>()},
                                         string_col.size(),
                                         data.release(),
-                                        null_mask.release(),
+                                        std::move(null_mask),
                                         null_count);
 
     if (ansi_mode) { validate_ansi_column(col->view(), string_col, stream); }
@@ -738,15 +742,15 @@ struct string_to_decimal_impl {
     using Type = device_storage_type_t<T>;
 
     rmm::device_uvector<Type> data(string_col.size(), stream, mr);
-    auto const num_words = bitmask_allocation_size_bytes(string_col.size()) / sizeof(bitmask_type);
-    rmm::device_uvector<bitmask_type> null_mask(num_words, stream, mr);
+    auto null_mask =
+      cudf::create_null_mask(string_col.size(), cudf::mask_state::UNINITIALIZED, stream, mr);
 
     dim3 const blocks(util::div_rounding_up_unsafe(string_col.size(), detail::NUM_THREADS));
     dim3 const threads{detail::NUM_THREADS};
 
     detail::string_to_decimal_kernel<<<blocks, threads, 0, stream.get()>>>(
       data.data(),
-      null_mask.data(),
+      reinterpret_cast<bitmask_type*>(null_mask.data()),
       string_col.chars_begin(stream),
       string_col.offsets().data<size_type>(),
       string_col.null_mask(),
@@ -755,10 +759,11 @@ struct string_to_decimal_impl {
       precision,
       strip);
 
-    auto null_count = cudf::null_count(null_mask.data(), 0, string_col.size(), stream);
+    auto null_count = cudf::null_count(
+      reinterpret_cast<bitmask_type*>(null_mask.data()), 0, string_col.size(), stream);
 
     auto col = std::make_unique<column>(
-      dtype, string_col.size(), data.release(), null_mask.release(), null_count);
+      dtype, string_col.size(), data.release(), std::move(null_mask), null_count);
 
     if (ansi_mode) { validate_ansi_column(col->view(), string_col, stream); }
 
@@ -839,7 +844,8 @@ std::unique_ptr<column> string_to_decimal(int32_t precision,
   }();
 
   if (string_col.size() == 0) {
-    return std::make_unique<column>(dtype, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
+    return std::make_unique<column>(
+      dtype, 0, rmm::device_buffer{}, cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
   }
 
   return type_dispatcher(dtype,

--- a/src/main/cpp/src/cast_string_to_datetime.cu
+++ b/src/main/cpp/src/cast_string_to_datetime.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -947,7 +947,7 @@ std::unique_ptr<cudf::column> parse_ts_strings(cudf::strings_column_view const& 
   return make_structs_column(num_rows,
                              std::move(output_columns),
                              /* null_count */ 0,
-                             rmm::device_buffer(),
+                             cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
                              stream,
                              mr);
 }
@@ -1088,12 +1088,13 @@ std::unique_ptr<cudf::column> parse_to_date(cudf::strings_column_view const& inp
 
   auto const d_input = cudf::column_device_view::create(
     input.parent(), stream, cudf::get_current_device_resource_ref());
-  auto result = cudf::make_timestamp_column(cudf::data_type{cudf::type_to_id<cudf::timestamp_D>()},
-                                            input.size(),
-                                            rmm::device_buffer{},
-                                            0,
-                                            stream,
-                                            mr);
+  auto result =
+    cudf::make_timestamp_column(cudf::data_type{cudf::type_to_id<cudf::timestamp_D>()},
+                                input.size(),
+                                cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                0,
+                                stream,
+                                mr);
   auto validity =
     rmm::device_uvector<bool>(num_rows, stream, cudf::get_current_device_resource_ref());
 

--- a/src/main/cpp/src/datetime_truncate.cu
+++ b/src/main/cpp/src/datetime_truncate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -308,9 +308,10 @@ std::unique_ptr<cudf::column> truncate_datetime(cudf::column_view const& datetim
 
   auto [null_mask, null_count] =
     cudf::bools_to_mask(cudf::device_span<bool const>(validity), stream, mr);
-  output->set_null_mask(
-    null_count > 0 ? std::move(*null_mask.release()) : rmm::device_buffer{0, stream, mr},
-    null_count);
+  output->set_null_mask(null_count > 0
+                          ? std::move(*null_mask.release())
+                          : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr),
+                        null_count);
   return output;
 }
 

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -980,11 +980,12 @@ std::unique_ptr<cudf::table> multiply_decimal128(cudf::column_view const& a,
     cudf::bitmask_and(cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
-  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
-                                                  num_rows,
-                                                  rmm::device_buffer(result_null_mask, stream),
-                                                  result_null_count,
-                                                  stream));
+  columns.push_back(cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::BOOL8},
+    num_rows,
+    cuda::device_buffer<std::byte>{stream, result_null_mask.memory_resource(), result_null_mask},
+    result_null_count,
+    stream));
   columns.push_back(
     cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::DECIMAL128, product_scale},
                                   num_rows,
@@ -1015,11 +1016,12 @@ std::unique_ptr<cudf::table> divide_decimal128(cudf::column_view const& a,
     cudf::bitmask_and(cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
-  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
-                                                  num_rows,
-                                                  rmm::device_buffer(result_null_mask, stream),
-                                                  result_null_count,
-                                                  stream));
+  columns.push_back(cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::BOOL8},
+    num_rows,
+    cuda::device_buffer<std::byte>{stream, result_null_mask.memory_resource(), result_null_mask},
+    result_null_count,
+    stream));
   columns.push_back(
     cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::DECIMAL128, quotient_scale},
                                   num_rows,
@@ -1049,11 +1051,12 @@ std::unique_ptr<cudf::table> integer_divide_decimal128(cudf::column_view const& 
     cudf::bitmask_and(cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
-  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
-                                                  num_rows,
-                                                  rmm::device_buffer(result_null_mask, stream),
-                                                  result_null_count,
-                                                  stream));
+  columns.push_back(cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::BOOL8},
+    num_rows,
+    cuda::device_buffer<std::byte>{stream, result_null_mask.memory_resource(), result_null_mask},
+    result_null_count,
+    stream));
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::INT64},
                                                   num_rows,
                                                   std::move(result_null_mask),
@@ -1082,11 +1085,12 @@ std::unique_ptr<cudf::table> remainder_decimal128(cudf::column_view const& a,
     cudf::bitmask_and(cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
-  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
-                                                  num_rows,
-                                                  rmm::device_buffer(result_null_mask, stream),
-                                                  result_null_count,
-                                                  stream));
+  columns.push_back(cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::BOOL8},
+    num_rows,
+    cuda::device_buffer<std::byte>{stream, result_null_mask.memory_resource(), result_null_mask},
+    result_null_count,
+    stream));
   columns.push_back(
     cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::DECIMAL128, remainder_scale},
                                   num_rows,
@@ -1115,11 +1119,12 @@ std::unique_ptr<cudf::table> add_decimal128(cudf::column_view const& a,
     cudf::bitmask_and(cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
-  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
-                                                  num_rows,
-                                                  rmm::device_buffer(result_null_mask, stream),
-                                                  result_null_count,
-                                                  stream));
+  columns.push_back(cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::BOOL8},
+    num_rows,
+    cuda::device_buffer<std::byte>{stream, result_null_mask.memory_resource(), result_null_mask},
+    result_null_count,
+    stream));
   columns.push_back(
     cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::DECIMAL128, target_scale},
                                   num_rows,
@@ -1148,11 +1153,12 @@ std::unique_ptr<cudf::table> sub_decimal128(cudf::column_view const& a,
     cudf::bitmask_and(cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
-  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
-                                                  num_rows,
-                                                  rmm::device_buffer(result_null_mask, stream),
-                                                  result_null_count,
-                                                  stream));
+  columns.push_back(cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::BOOL8},
+    num_rows,
+    cuda::device_buffer<std::byte>{stream, result_null_mask.memory_resource(), result_null_mask},
+    result_null_count,
+    stream));
   columns.push_back(
     cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::DECIMAL128, target_scale},
                                   num_rows,

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,10 +157,18 @@ std::unique_ptr<cudf::column> make_empty_map_from_value(std::unique_ptr<cudf::co
   std::vector<std::unique_ptr<cudf::column>> out_keys_vals;
   out_keys_vals.emplace_back(std::move(keys));
   out_keys_vals.emplace_back(std::move(value_child));
-  auto child =
-    cudf::make_structs_column(0, std::move(out_keys_vals), 0, rmm::device_buffer{}, stream, mr);
+  auto child   = cudf::make_structs_column(0,
+                                         std::move(out_keys_vals),
+                                         0,
+                                         cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                         stream,
+                                         mr);
   auto offsets = cudf::make_empty_column(cudf::data_type(cudf::type_id::INT32));
-  return cudf::make_lists_column(0, std::move(offsets), std::move(child), 0, rmm::device_buffer{});
+  return cudf::make_lists_column(0,
+                                 std::move(offsets),
+                                 std::move(child),
+                                 0,
+                                 cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 std::unique_ptr<cudf::column> make_empty_map(cuda::stream_ref stream,
@@ -744,8 +752,11 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
 
   auto [offsets, chars] = cudf::strings::detail::make_strings_children(
     substring_fn{input_json, extracted_ranges}, num_extract, stream, mr);
-  return cudf::make_strings_column(
-    num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
+  return cudf::make_strings_column(num_extract,
+                                   std::move(offsets),
+                                   chars.release(),
+                                   0,
+                                   cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 // Compute the offsets for the final lists of Struct<String,String>.
@@ -813,7 +824,8 @@ std::unique_ptr<cudf::column> compute_list_offsets(
 #ifdef DEBUG_FROM_JSON
   print_debug(list_offsets, "Output list offsets", ", ", stream);
 #endif
-  return std::make_unique<cudf::column>(std::move(list_offsets), rmm::device_buffer{}, 0);
+  return std::make_unique<cudf::column>(
+    std::move(list_offsets), cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
 }
 
 // If a JSON line is invalid, the tokens corresponding to that line are output as
@@ -851,7 +863,7 @@ struct is_line_begin {
   }
 };
 
-std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
+std::pair<cuda::device_buffer<std::byte>, cudf::size_type> create_null_mask(
   cudf::size_type num_rows,
   std::unique_ptr<cudf::column> const& should_be_nullified,
   cudf::device_span<PdaTokenT const> tokens,
@@ -931,7 +943,9 @@ std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
   auto const valid_it          = should_be_nullified->view().begin<bool>();
   auto [null_mask, null_count] = cudf::detail::valid_if(
     valid_it, valid_it + should_be_nullified->size(), thrust::logical_not<bool>{}, stream, mr);
-  return {null_count > 0 ? std::move(null_mask) : rmm::device_buffer{0, stream, mr}, null_count};
+  return {null_count > 0 ? std::move(null_mask)
+                         : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr),
+          null_count};
 }
 
 // Array-value path: parse `Map[String, Array[String]]` JSON into
@@ -1060,8 +1074,13 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
   std::vector<std::unique_ptr<cudf::column>> out_keys_vals;
   out_keys_vals.emplace_back(std::move(extracted_keys));
   out_keys_vals.emplace_back(std::move(extracted_values));
-  auto structs_col = cudf::make_structs_column(
-    num_pairs, std::move(out_keys_vals), 0, rmm::device_buffer{}, stream, mr);
+  auto structs_col =
+    cudf::make_structs_column(num_pairs,
+                              std::move(out_keys_vals),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                              stream,
+                              mr);
 
   // Do not use `cudf::make_lists_column` since we do not need to call `purge_nonempty_nulls`
   // on the children columns as they do not have non-empty nulls.
@@ -1259,8 +1278,8 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   // its element child has no non-empty nulls.
   auto [inner_mask, inner_null_count] =
     cudf::bools_to_mask(cudf::device_span<bool const>(inner_valid), stream, mr);
-  auto inner_offsets_col =
-    std::make_unique<cudf::column>(std::move(inner_offsets), rmm::device_buffer{}, 0);
+  auto inner_offsets_col = std::make_unique<cudf::column>(
+    std::move(inner_offsets), cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
   std::vector<std::unique_ptr<cudf::column>> inner_list_children;
   inner_list_children.emplace_back(std::move(inner_offsets_col));
   inner_list_children.emplace_back(std::move(extracted_elements));
@@ -1268,7 +1287,8 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
     cudf::data_type{cudf::type_id::LIST},
     num_values,
     rmm::device_buffer{},
-    inner_null_count > 0 ? std::move(*inner_mask) : rmm::device_buffer{},
+    inner_null_count > 0 ? std::move(*inner_mask)
+                         : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
     inner_null_count > 0 ? inner_null_count : 0,
     std::move(inner_list_children));
 
@@ -1276,8 +1296,13 @@ std::unique_ptr<cudf::column> from_json_to_raw_map_array_values(
   std::vector<std::unique_ptr<cudf::column>> out_keys_vals;
   out_keys_vals.emplace_back(std::move(extracted_keys));
   out_keys_vals.emplace_back(std::move(inner_list));
-  auto structs_col = cudf::make_structs_column(
-    num_values, std::move(out_keys_vals), 0, rmm::device_buffer{}, stream, mr);
+  auto structs_col =
+    cudf::make_structs_column(num_values,
+                              std::move(out_keys_vals),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                              stream,
+                              mr);
 
   // Assemble the outer list (row offsets + struct child).
   std::vector<std::unique_ptr<cudf::column>> list_children;

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ std::unique_ptr<cudf::column> make_empty_column_from_schema(
       cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32}),
       make_empty_column_from_schema(schema.child_types.front().second, stream, mr),
       0,
-      {});
+      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   }
 
   if (schema.type.id() == cudf::type_id::STRUCT) {
@@ -183,7 +183,12 @@ std::unique_ptr<cudf::column> make_empty_column_from_schema(
       schema.child_types.end(),
       std::back_inserter(children),
       [&](auto const& child) { return make_empty_column_from_schema(child.second, stream, mr); });
-    return cudf::make_structs_column(0, std::move(children), 0, {}, stream, mr);
+    return cudf::make_structs_column(0,
+                                     std::move(children),
+                                     0,
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                     stream,
+                                     mr);
   }
 
   return cudf::make_empty_column(schema.type);
@@ -199,10 +204,11 @@ void nullify_rows(cudf::column& input,
   auto const input_view = input.view();
   auto null_mask =
     input_view.nullable()
-      ? rmm::device_buffer{}
+      ? cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED)
       : cudf::create_null_mask(input_view.size(), cudf::mask_state::ALL_VALID, stream, mr);
-  auto const mask_ptr = input_view.nullable() ? input.mutable_view().null_mask()
-                                              : static_cast<cudf::bitmask_type*>(null_mask.data());
+  auto const mask_ptr = input_view.nullable()
+                          ? input.mutable_view().null_mask()
+                          : reinterpret_cast<cudf::bitmask_type*>(null_mask.data());
 
   // Diagnostic row indices are sorted and unique, so updates to one mask word are adjacent.
   std::vector<mask_word_update> word_updates;
@@ -264,7 +270,7 @@ void nullify_rows(cudf::column& input,
   std::unique_ptr<cudf::column> offsets_column,
   std::unique_ptr<cudf::column> child_column,
   cudf::size_type null_count,
-  rmm::device_buffer&& null_mask,
+  cuda::device_buffer<std::byte>&& null_mask,
   bool did_nullify_schema_mismatch_rows,
   cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
@@ -290,7 +296,7 @@ void nullify_rows(cudf::column& input,
   cudf::size_type num_rows,
   std::vector<std::unique_ptr<cudf::column>>&& children,
   cudf::size_type null_count,
-  rmm::device_buffer&& null_mask,
+  cuda::device_buffer<std::byte>&& null_mask,
   bool did_nullify_schema_mismatch_rows,
   cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
@@ -359,7 +365,9 @@ std::unique_ptr<cudf::column> cast_strings_to_booleans(cudf::column_view const& 
 
   auto [null_mask, null_count] =
     cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
-  output->set_null_mask(null_count > 0 ? std::move(null_mask) : rmm::device_buffer{0, stream, mr},
+  output->set_null_mask(null_count > 0
+                          ? std::move(null_mask)
+                          : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr),
                         null_count);
 
   return output;
@@ -420,7 +428,7 @@ std::unique_ptr<cudf::column> cast_strings_to_integers(cudf::column_view const& 
       : cudf::column_view{cudf::data_type{cudf::type_id::STRING},
                           input_sv.size(),
                           input_sv.chars_begin(stream),
-                          static_cast<cudf::bitmask_type const*>(null_mask.data()),
+                          reinterpret_cast<cudf::bitmask_type const*>(null_mask.data()),
                           null_count,
                           input_sv.offset(),
                           std::vector<cudf::column_view>{input_sv.offsets()}};
@@ -677,7 +685,11 @@ std::unique_ptr<cudf::column> cast_strings_to_decimals(cudf::column_view const& 
 
   // Don't care about the null mask, as nulls imply empty strings, which will also result in nulls.
   auto const unquoted_strings =
-    cudf::make_strings_column(string_count, std::move(offsets_column), chars_data.release(), 0, {});
+    cudf::make_strings_column(string_count,
+                              std::move(offsets_column),
+                              chars_data.release(),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   return spark_rapids_jni::string_to_decimal(precision,
                                              output_type.scale(),
@@ -745,11 +757,12 @@ std::pair<std::unique_ptr<cudf::column>, bool> try_remove_quotes(
     offsets_column->view(), bytes, string_pairs.begin(), string_count, stream, mr);
 
   if (nullify_if_not_quoted) {
-    auto output = cudf::make_strings_column(string_count,
-                                            std::move(offsets_column),
-                                            chars_data.release(),
-                                            0,
-                                            rmm::device_buffer{0, stream, mr});
+    auto output = cudf::make_strings_column(
+      string_count,
+      std::move(offsets_column),
+      chars_data.release(),
+      0,
+      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr));
 
     auto [null_mask, null_count] = cudf::detail::valid_if(
       string_pairs.begin(),
@@ -1072,7 +1085,8 @@ std::unique_ptr<cudf::column> from_json_to_structs(cudf::strings_column_view con
     input.size(),
     std::move(converted_cols),
     null_count,
-    null_count > 0 ? std::move(null_mask) : rmm::device_buffer{0, stream, mr},
+    null_count > 0 ? std::move(null_mask)
+                   : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr),
     /*did_nullify_schema_mismatch_rows=*/false,
     stream,
     mr);

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1081,7 +1081,8 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
   }
   // From here, we had out-of-bound write. Although this is very rare, it may still happen.
 
-  std::vector<std::pair<rmm::device_buffer, cudf::size_type>> out_null_masks_and_null_counts;
+  std::vector<std::pair<cuda::device_buffer<std::byte>, cudf::size_type>>
+    out_null_masks_and_null_counts;
   std::vector<std::pair<std::unique_ptr<cudf::column>, int64_t>> out_offsets_and_sizes;
   std::vector<rmm::device_uvector<char>> out_char_buffers;
   std::vector<std::size_t> oob_indices;

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ struct percentile_dispatcher {
   //  2. Null mask to apply for the final output column containing percentile values, and
   //  3. Null count corresponding to that null mask.
   using output_type =
-    std::tuple<std::unique_ptr<cudf::column>, rmm::device_buffer, cudf::size_type>;
+    std::tuple<std::unique_ptr<cudf::column>, cuda::device_buffer<std::byte>, cudf::size_type>;
 
   template <typename T, typename... Args>
   std::enable_if_t<!is_supported<T>(), output_type> operator()(Args&&...) const
@@ -221,7 +221,7 @@ struct percentile_dispatcher {
       return {std::move(percentiles), std::move(*null_mask.release()), null_count};
     }
 
-    return {std::move(percentiles), rmm::device_buffer{}, 0};
+    return {std::move(percentiles), cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0};
   }
 };
 
@@ -252,7 +252,7 @@ void check_input(cudf::column_view const& input, std::vector<double> const& perc
 
 // Wrap the input column in a lists column, to satisfy the requirement type in Spark.
 std::unique_ptr<cudf::column> wrap_in_list(std::unique_ptr<cudf::column>&& input,
-                                           rmm::device_buffer&& null_mask,
+                                           cuda::device_buffer<std::byte>&& null_mask,
                                            cudf::size_type null_count,
                                            cudf::size_type num_histograms,
                                            cudf::size_type num_percentages,
@@ -294,7 +294,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
                                      cudf::make_empty_column(cudf::type_to_id<cudf::size_type>()),
                                      cudf::reduction::detail::make_empty_histogram_like(values),
                                      0,
-                                     {});
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
     } else {
       return cudf::reduction::detail::make_empty_histogram_like(values);
     }
@@ -327,7 +327,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
                "The input frequencies must not contain negative values.",
                std::invalid_argument);
 
-  auto const make_structs_histogram = [&](rmm::device_buffer&& null_mask,
+  auto const make_structs_histogram = [&](cuda::device_buffer<std::byte>&& null_mask,
                                           cudf::size_type null_count) {
     // Copy values and frequencies into a new structs column.
     std::vector<std::unique_ptr<cudf::column>> values_and_frequencies;
@@ -345,7 +345,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
           std::vector<cudf::bitmask_type const*>{
             // Don't use values.null_mask(), to make sure no slicing.
             values_and_frequencies.front()->view().null_mask(),
-            static_cast<cudf::bitmask_type const*>(null_mask.data())},
+            reinterpret_cast<cudf::bitmask_type const*>(null_mask.data())},
           std::vector<cudf::size_type>{0, 0},
           values.size(),
           stream,
@@ -369,8 +369,12 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
         });
     }
 
-    return cudf::make_structs_column(
-      values.size(), std::move(values_and_frequencies), 0, rmm::device_buffer{}, stream, mr);
+    return cudf::make_structs_column(values.size(),
+                                     std::move(values_and_frequencies),
+                                     0,
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                     stream,
+                                     mr);
   };
 
   auto const make_lists_histograms = [&](cudf::size_type num_elements,
@@ -379,12 +383,16 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
     auto const sizes_itr = cuda::make_constant_iterator(1);
     auto offsets         = std::get<0>(
       cudf::detail::make_offsets_child_column(sizes_itr, sizes_itr + num_elements, stream, mr));
-    return cudf::make_lists_column(
-      num_elements, std::move(offsets), std::move(structs_histogram), 0, rmm::device_buffer{});
+    return cudf::make_lists_column(num_elements,
+                                   std::move(offsets),
+                                   std::move(structs_histogram),
+                                   0,
+                                   cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   };
 
   if (output_as_lists) {
-    auto child            = make_structs_histogram(rmm::device_buffer{}, 0);
+    auto child =
+      make_structs_histogram(cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
     auto lists_histograms = make_lists_histograms(values.size(), std::move(child));
 
     if (!h_checks.back()) {  // all frequencies are positive
@@ -400,11 +408,11 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
       cudf::bools_to_mask(cudf::device_span<bool const>(check_valid), stream, default_mr);
     lists_histograms->set_null_mask(std::move(*null_mask.release()), null_count);
     lists_histograms = cudf::purge_nonempty_nulls(lists_histograms->view(), stream, mr);
-    lists_histograms->set_null_mask(rmm::device_buffer{}, 0);
+    lists_histograms->set_null_mask(cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
     return lists_histograms;
   } else {                   // output_as_lists==false
     if (!h_checks.back()) {  // all frequencies are positive
-      return make_structs_histogram(rmm::device_buffer{}, 0);
+      return make_structs_histogram(cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0);
     }
 
     // We nullify the values corresponding to zero frequencies.

--- a/src/main/cpp/src/hyper_log_log_plus_plus.cu
+++ b/src/main/cpp/src/hyper_log_log_plus_plus.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -464,11 +464,12 @@ std::unique_ptr<cudf::column> group_hllpp(cudf::column_view const& input,
     std::vector<int64_t*>(host_results_pointer_iter, host_results_pointer_iter + children.size());
   auto d_results = cudf::detail::make_device_uvector(host_results_pointers, stream, default_mr);
 
-  auto result = cudf::make_structs_column(num_groups,
-                                          std::move(children),
-                                          0,                     // null count
-                                          rmm::device_buffer{},  // null mask
-                                          stream);
+  auto result = cudf::make_structs_column(
+    num_groups,
+    std::move(children),
+    0,                                                         // null count
+    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),  // null mask
+    stream);
 
   // 5. compact sketches
   auto num_phase3_threads = num_groups * num_long_cols;
@@ -663,7 +664,8 @@ std::unique_ptr<cudf::column> group_merge_hllpp(
   compact_kernel<block_size><<<num_phase3_blocks, block_size, 0, stream.get()>>>(
     num_groups, num_registers_per_sketch, d_sketches_output, registers_output_cache);
 
-  return make_structs_column(num_groups, std::move(results), 0, rmm::device_buffer{});
+  return make_structs_column(
+    num_groups, std::move(results), 0, cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 /**

--- a/src/main/cpp/src/hyper_log_log_plus_plus_host_udf.cu
+++ b/src/main/cpp/src/hyper_log_log_plus_plus_host_udf.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,12 +63,13 @@ struct hllpp_groupby_udf : cudf::groupby_host_udf {
       0, [&](int i) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT64}); });
     auto children =
       std::vector<std::unique_ptr<cudf::column>>(results_iter, results_iter + num_long_cols);
-    return cudf::make_structs_column(0,
-                                     std::move(children),
-                                     0,                     // null count
-                                     rmm::device_buffer{},  // null mask
-                                     stream,
-                                     mr);
+    return cudf::make_structs_column(
+      0,
+      std::move(children),
+      0,                                                         // null count
+      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),  // null mask
+      stream,
+      mr);
   }
 
   [[nodiscard]] bool is_equal(cudf::host_udf_base const& other) const override

--- a/src/main/cpp/src/iceberg/iceberg_truncate.cu
+++ b/src/main/cpp/src/iceberg/iceberg_truncate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,12 +226,12 @@ std::unique_ptr<cudf::column> truncate_binary_impl(cudf::column_view const& inpu
     mr);
   auto new_chars_size = new_chars.size();
 
-  auto new_child =
-    std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},  // Data type
-                                   new_chars_size,                         // Number of elements
-                                   new_chars.release(),   // Transfer ownership of the buffer
-                                   rmm::device_buffer{},  // no nulls in child
-                                   0);
+  auto new_child = std::make_unique<cudf::column>(
+    cudf::data_type{cudf::type_id::UINT8},                     // Data type
+    new_chars_size,                                            // Number of elements
+    new_chars.release(),                                       // Transfer ownership of the buffer
+    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),  // no nulls in child
+    0);
 
   return cudf::make_lists_column(num_rows,
                                  std::move(new_offsets),

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,8 +125,9 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
   if (input.is_empty()) {
     return {std::make_unique<rmm::device_buffer>(0, stream, mr),
             '\n',
-            std::make_unique<cudf::column>(
-              rmm::device_uvector<bool>{0, stream, mr}, rmm::device_buffer{}, 0)};
+            std::make_unique<cudf::column>(rmm::device_uvector<bool>{0, stream, mr},
+                                           cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                           0)};
   }
 
   auto const default_mr  = rmm::mr::get_current_device_resource_ref();
@@ -281,7 +282,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
       : cudf::column_view{cudf::data_type{cudf::type_id::STRING},
                           input.size(),
                           input.chars_begin(stream),
-                          static_cast<cudf::bitmask_type const*>(null_mask->data()),
+                          reinterpret_cast<cudf::bitmask_type const*>(null_mask->data()),
                           null_count,
                           input.offset(),
                           std::vector<cudf::column_view>{input.offsets()}};
@@ -293,9 +294,11 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
     stream,
     mr);
 
-  return {std::move(concat_strings->release().data),
-          delimiter,
-          std::make_unique<cudf::column>(std::move(should_be_nullified), rmm::device_buffer{}, 0)};
+  return {
+    std::move(concat_strings->release().data),
+    delimiter,
+    std::make_unique<cudf::column>(
+      std::move(should_be_nullified), cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0)};
 }
 
 }  // namespace detail

--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -339,11 +339,12 @@ std::unique_ptr<cudf::column> map_from_entries(cudf::column_view const& input,
   auto gathered_struct       = std::move(gathered_table->release()[0]);
 
   // 2d. Output offsets column directly from out_offsets.
-  auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
-                                                    num_rows + 1,
-                                                    out_offsets.release(),
-                                                    rmm::device_buffer{},
-                                                    0);
+  auto offsets_col =
+    std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                   num_rows + 1,
+                                   out_offsets.release(),
+                                   cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                   0);
 
   // 2e. Assemble the LIST<STRUCT> result with the new null mask.  The public
   // make_lists_column overload only wraps the supplied buffers — no device work — so the

--- a/src/main/cpp/src/map_zip_with_utils.cu
+++ b/src/main/cpp/src/map_zip_with_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,21 +364,23 @@ std::unique_ptr<cudf::column> map_zip(
 
   // Find the indices of each key in the first map
   // This tells us where each key appears in the first map, or if it doesn't exist
-  auto map1_indices      = indices_of(search_keys_list, cudf::lists_column_view(map1_keys), stream);
-  auto map1_indices_list = make_lists_column(search_keys_list.size(),
-                                             std::make_unique<column>(search_keys_list.offsets()),
-                                             std::move(map1_indices),
-                                             0,
-                                             rmm::device_buffer{0, stream});
+  auto map1_indices = indices_of(search_keys_list, cudf::lists_column_view(map1_keys), stream);
+  auto map1_indices_list =
+    make_lists_column(search_keys_list.size(),
+                      std::make_unique<column>(search_keys_list.offsets()),
+                      std::move(map1_indices),
+                      0,
+                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream));
 
   // Find the indices of each key in the second map
   // This tells us where each key appears in the second map, or if it doesn't exist
-  auto map2_indices      = indices_of(search_keys_list, cudf::lists_column_view(map2_keys), stream);
-  auto map2_indices_list = make_lists_column(search_keys_list.size(),
-                                             std::make_unique<column>(search_keys_list.offsets()),
-                                             std::move(map2_indices),
-                                             0,
-                                             rmm::device_buffer{0, stream});
+  auto map2_indices = indices_of(search_keys_list, cudf::lists_column_view(map2_keys), stream);
+  auto map2_indices_list =
+    make_lists_column(search_keys_list.size(),
+                      std::make_unique<column>(search_keys_list.offsets()),
+                      std::move(map2_indices),
+                      0,
+                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream));
 
   // Gather the values from map1 and map2 using the calculated indices
   // This extracts the values corresponding to each key in the union
@@ -398,23 +400,25 @@ std::unique_ptr<cudf::column> map_zip(
   value_pair_children.push_back(
     std::move(std::make_unique<column>(cudf::lists_column_view(*map2_values_list_gather).child())));
 
-  auto value_pair = make_structs_column(cudf::lists_column_view(*search_keys).child().size(),
-                                        std::move(value_pair_children),
-                                        0,
-                                        rmm::device_buffer{0, stream, mr},
-                                        stream,
-                                        mr);
+  auto value_pair =
+    make_structs_column(cudf::lists_column_view(*search_keys).child().size(),
+                        std::move(value_pair_children),
+                        0,
+                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr),
+                        stream,
+                        mr);
   std::vector<std::unique_ptr<column>> map_structs_children;
   map_structs_children.push_back(
     std::move(std::make_unique<column>(cudf::lists_column_view(*search_keys).child())));
   map_structs_children.push_back(std::move(value_pair));
 
-  auto map_structs = make_structs_column(cudf::lists_column_view(*search_keys).child().size(),
-                                         std::move(map_structs_children),
-                                         0,
-                                         rmm::device_buffer{0, stream, mr},
-                                         stream,
-                                         mr);
+  auto map_structs =
+    make_structs_column(cudf::lists_column_view(*search_keys).child().size(),
+                        std::move(map_structs_children),
+                        0,
+                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr),
+                        stream,
+                        mr);
   auto [result_mask, null_count] =
     cudf::bitmask_and(cudf::table_view({col1.parent(), col2.parent()}), stream, mr);
   return make_lists_column(search_keys_list.size(),

--- a/src/main/cpp/src/number_converter.cu
+++ b/src/main/cpp/src/number_converter.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,12 +400,13 @@ std::unique_ptr<cudf::column> convert_impl(cudf::size_type num_rows,
   auto [null_mask, null_count] =
     cudf::bools_to_mask(cudf::device_span<bool const>(out_mask), stream, mr);
 
-  return cudf::make_strings_column(
-    num_rows,
-    std::move(offsets),
-    chars.release(),
-    null_count,
-    null_count ? std::move(*null_mask.release()) : rmm::device_buffer{});
+  return cudf::make_strings_column(num_rows,
+                                   std::move(offsets),
+                                   chars.release(),
+                                   null_count,
+                                   null_count
+                                     ? std::move(*null_mask.release())
+                                     : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 /**

--- a/src/main/cpp/src/parse_timestamp_with_format.cu
+++ b/src/main/cpp/src/parse_timestamp_with_format.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -396,12 +396,13 @@ std::unique_ptr<cudf::column> parse_timestamp_strings_with_format(
   }
 
   auto const d_input = cudf::column_device_view::create(input.parent(), stream, temp_mr);
-  auto result = cudf::make_timestamp_column(cudf::data_type{cudf::type_to_id<cudf::timestamp_us>()},
-                                            num_rows,
-                                            rmm::device_buffer{},
-                                            0,
-                                            stream,
-                                            mr);
+  auto result =
+    cudf::make_timestamp_column(cudf::data_type{cudf::type_to_id<cudf::timestamp_us>()},
+                                num_rows,
+                                cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                0,
+                                stream,
+                                mr);
   // Every code path in parse_with_format_fn::operator() writes validity[idx], so leaving the
   // buffer uninitialized is safe.
   auto validity = rmm::device_uvector<bool>(num_rows, stream, temp_mr);

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -912,7 +912,7 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
   auto src_offsets = rmm::device_uvector<size_type>(strings_count, stream);
 
   // copy null mask
-  rmm::device_buffer null_mask =
+  cuda::device_buffer<std::byte> null_mask =
     input.parent().nullable()
       ? cudf::copy_bitmask(input.parent(), stream, mr)
       : cudf::create_null_mask(input.size(), mask_state::ALL_VALID, stream, mr);
@@ -926,7 +926,7 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
     input.chars_begin(stream),
     offsets_mutable_view.begin<size_type>(),
     src_offsets.data(),
-    static_cast<bitmask_type*>(null_mask.data()),
+    reinterpret_cast<bitmask_type*>(null_mask.data()),
     d_matches ? cuda::std::optional<column_device_view const>{*d_matches} : cuda::std::nullopt);
 
   // use scan to transform number of bytes into offsets
@@ -954,7 +954,7 @@ std::unique_ptr<column> parse_uri(strings_column_view const& input,
     static_cast<char*>(d_out_chars.data()));
 
   auto null_count =
-    cudf::null_count(static_cast<bitmask_type*>(null_mask.data()), 0, strings_count);
+    cudf::null_count(reinterpret_cast<bitmask_type*>(null_mask.data()), 0, strings_count);
 
   return make_strings_column(strings_count,
                              std::move(offsets_column),
@@ -996,7 +996,8 @@ void validate_input_uris(strings_column_view const& input, cuda::stream_ref stre
   // Create validation column for throw_row_error_if_any
   auto validation_column = std::make_unique<column>(
     std::move(validity_flags),
-    null_count > 0 ? std::move(*validation_mask.release()) : rmm::device_buffer{0, stream},
+    null_count > 0 ? std::move(*validation_mask.release())
+                   : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream),
     null_count);
   throw_row_error_if_any(input.parent(), validation_column->view(), stream);
 }

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,8 +323,12 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       }
       empty_children.push_back(std::move(empty_child));
     }
-    return cudf::make_structs_column(
-      0, std::move(empty_children), 0, rmm::device_buffer{}, stream, mr);
+    return cudf::make_structs_column(0,
+                                     std::move(empty_children),
+                                     0,
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                     stream,
+                                     mr);
   }
 
   // Extract shared input data pointers (used by scalar, repeated, and nested sections)
@@ -735,7 +739,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   // Build final struct null mask by combining input nulls with PERMISSIVE-mode row invalidation.
   cudf::size_type struct_null_count = 0;
-  rmm::device_buffer struct_mask{0, stream, mr};
+  auto struct_mask = cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr);
   auto const input_null_count = binary_input.null_count();
 
   if (track_permissive_null_rows || input_null_count > 0) {

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,11 +56,11 @@ field_descriptor_bundle make_field_descriptors(std::vector<int> const& field_ind
 
 namespace {
 
-inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_parent_locations(
-  field_location const* parent_locs,
-  int num_rows,
-  cuda::stream_ref stream,
-  rmm::device_async_resource_ref mr)
+inline std::pair<cuda::device_buffer<std::byte>, cudf::size_type>
+make_null_mask_from_parent_locations(field_location const* parent_locs,
+                                     int num_rows,
+                                     cuda::stream_ref stream,
+                                     rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(num_rows >= 0, std::string{__func__} + ": row count must be non-negative");
   auto [mask, null_count] = cudf::detail::valid_if(
@@ -69,7 +69,7 @@ inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_parent
     [parent_locs] __device__(cudf::size_type row) { return parent_locs[row].offset >= 0; },
     stream,
     mr);
-  if (null_count == 0) { mask = rmm::device_buffer{}; }
+  if (null_count == 0) { mask = cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED); }
   return {std::move(mask), null_count};
 }
 
@@ -134,8 +134,11 @@ std::unique_ptr<cudf::column> make_list_column_with_input_nulls(
                                    input_null_count,
                                    cudf::copy_bitmask(binary_input, stream, mr));
   }
-  return cudf::make_lists_column(
-    num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+  return cudf::make_lists_column(num_rows,
+                                 std::move(offsets_col),
+                                 std::move(child_col),
+                                 0,
+                                 cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 std::unique_ptr<cudf::column> make_null_column(cudf::data_type dtype,
@@ -191,19 +194,30 @@ std::unique_ptr<cudf::column> make_empty_column_safe(cudf::data_type dtype,
         std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
                                        1,
                                        rmm::device_buffer(sizeof(int32_t), stream, mr),
-                                       rmm::device_buffer{},
+                                       cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
                                        0);
       CUDF_CUDA_TRY(cudaMemsetAsync(
         offsets_col->mutable_view().data<int32_t>(), 0, sizeof(int32_t), stream.get()));
-      auto child_col = std::make_unique<cudf::column>(
-        cudf::data_type{cudf::type_id::UINT8}, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
-      return cudf::make_lists_column(
-        0, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+      auto child_col =
+        std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},
+                                       0,
+                                       rmm::device_buffer{},
+                                       cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                       0);
+      return cudf::make_lists_column(0,
+                                     std::move(offsets_col),
+                                     std::move(child_col),
+                                     0,
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
     }
     case cudf::type_id::STRUCT: {
       std::vector<std::unique_ptr<cudf::column>> empty_children;
-      return cudf::make_structs_column(
-        0, std::move(empty_children), 0, rmm::device_buffer{}, stream, mr);
+      return cudf::make_structs_column(0,
+                                       std::move(empty_children),
+                                       0,
+                                       cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                       stream,
+                                       mr);
     }
     default: return cudf::make_empty_column(dtype);
   }
@@ -227,15 +241,19 @@ std::unique_ptr<cudf::column> make_empty_list_column(std::unique_ptr<cudf::colum
                                                      cuda::stream_ref stream,
                                                      rmm::device_async_resource_ref mr)
 {
-  auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
-                                                    1,
-                                                    rmm::device_buffer(sizeof(int32_t), stream, mr),
-                                                    rmm::device_buffer{},
-                                                    0);
+  auto offsets_col =
+    std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                   1,
+                                   rmm::device_buffer(sizeof(int32_t), stream, mr),
+                                   cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                   0);
   CUDF_CUDA_TRY(
     cudaMemsetAsync(offsets_col->mutable_view().data<int32_t>(), 0, sizeof(int32_t), stream.get()));
-  return cudf::make_lists_column(
-    0, std::move(offsets_col), std::move(element_col), 0, rmm::device_buffer{});
+  return cudf::make_lists_column(0,
+                                 std::move(offsets_col),
+                                 std::move(element_col),
+                                 0,
+                                 cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 // ============================================================================
@@ -450,13 +468,23 @@ std::unique_ptr<cudf::column> build_repeated_string_column(cudf::column_view con
   if (is_bytes) {
     // Transfer ownership of the chars buffer instead of copying — the strings path below uses
     // `chars.release()` for the same reason.
-    auto bytes_child = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT8}, total_chars, chars.release(), rmm::device_buffer{}, 0);
-    child_col = cudf::make_lists_column(
-      total_count, std::move(str_offsets_col), std::move(bytes_child), 0, rmm::device_buffer{});
+    auto bytes_child =
+      std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},
+                                     total_chars,
+                                     chars.release(),
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                     0);
+    child_col = cudf::make_lists_column(total_count,
+                                        std::move(str_offsets_col),
+                                        std::move(bytes_child),
+                                        0,
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   } else {
-    child_col = cudf::make_strings_column(
-      total_count, std::move(str_offsets_col), chars.release(), 0, rmm::device_buffer{});
+    child_col = cudf::make_strings_column(total_count,
+                                          std::move(str_offsets_col),
+                                          chars.release(),
+                                          0,
+                                          cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   }
 
   auto offsets_col = make_offsets_column(input.num_rows, std::move(work.offsets));

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,7 +211,7 @@ inline std::unique_ptr<cudf::column> make_offsets_column(cudf::size_type num_row
   return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
                                         num_rows + 1,
                                         offsets.release(),
-                                        rmm::device_buffer{},
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
                                         0);
 }
 
@@ -414,7 +414,12 @@ std::unique_ptr<cudf::column> make_empty_struct_column_from_children(
     children.push_back(std::move(child_col));
   }
 
-  return cudf::make_structs_column(0, std::move(children), 0, rmm::device_buffer{}, stream, mr);
+  return cudf::make_structs_column(0,
+                                   std::move(children),
+                                   0,
+                                   cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                   stream,
+                                   mr);
 }
 
 template <typename SchemaT>

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -430,7 +430,7 @@ void launch_compute_grandchild_parent_locations(nested_location_provider loc_pro
 
 // Build a row-aligned null mask from `valid[row]` boolean flags.
 template <typename T>
-inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_valid(
+inline std::pair<cuda::device_buffer<std::byte>, cudf::size_type> make_null_mask_from_valid(
   rmm::device_uvector<T> const& valid,
   cudf::size_type num_rows,
   cuda::stream_ref stream,
@@ -446,7 +446,7 @@ inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_valid(
   };
   auto [mask, null_count] = cudf::detail::valid_if(begin, end, pred, stream, mr);
   // Discarding an all-valid mask keeps the resulting column non-nullable.
-  if (null_count == 0) { mask = rmm::device_buffer{}; }
+  if (null_count == 0) { mask = cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED); }
   return {std::move(mask), null_count};
 }
 
@@ -587,13 +587,23 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
 
   if (num_rows == 0) {
     if (as_bytes) {
-      auto bytes_child = std::make_unique<cudf::column>(
-        cudf::data_type{cudf::type_id::UINT8}, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
-      return cudf::make_lists_column(
-        0, std::move(offsets_col), std::move(bytes_child), 0, rmm::device_buffer{});
+      auto bytes_child =
+        std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},
+                                       0,
+                                       rmm::device_buffer{},
+                                       cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                       0);
+      return cudf::make_lists_column(0,
+                                     std::move(offsets_col),
+                                     std::move(bytes_child),
+                                     0,
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
     }
-    return cudf::make_strings_column(
-      0, std::move(offsets_col), chars.release(), 0, rmm::device_buffer{});
+    return cudf::make_strings_column(0,
+                                     std::move(offsets_col),
+                                     chars.release(),
+                                     0,
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   }
 
   rmm::device_uvector<bool> valid(num_rows, stream, scratch_mr);
@@ -604,8 +614,12 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
                     validity_fn);
   auto [mask, null_count] = make_null_mask_from_valid(valid, num_rows, stream, mr);
   if (as_bytes) {
-    auto bytes_child = std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::UINT8}, total_size, chars.release(), rmm::device_buffer{}, 0);
+    auto bytes_child =
+      std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},
+                                     total_size,
+                                     chars.release(),
+                                     cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                     0);
     return cudf::make_lists_column(
       num_rows, std::move(offsets_col), std::move(bytes_child), null_count, std::move(mask));
   }
@@ -774,8 +788,12 @@ inline std::unique_ptr<cudf::column> build_repeated_scalar_column(
     stream);
 
   auto offsets_col = make_offsets_column(input.num_rows, std::move(work.offsets));
-  auto child_col   = std::make_unique<cudf::column>(
-    field.output_type, work.total_count, values.release(), rmm::device_buffer{}, 0);
+  auto child_col =
+    std::make_unique<cudf::column>(field.output_type,
+                                   work.total_count,
+                                   values.release(),
+                                   cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                   0);
 
   return make_list_column_with_input_nulls(
     input.num_rows, std::move(offsets_col), std::move(child_col), binary_input, stream, mr);

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1303,11 +1303,12 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
     input_nm.data(),
     data->mutable_view().data<int8_t>());
 
-  return make_lists_column(num_rows,
-                           std::move(offsets),
-                           std::move(data),
-                           0,
-                           rmm::device_buffer{0, cudf::get_default_stream(), mr});
+  return make_lists_column(
+    num_rows,
+    std::move(offsets),
+    std::move(data),
+    0,
+    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, cudf::get_default_stream(), mr));
 }
 
 /**
@@ -2027,29 +2028,31 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   std::vector<std::unique_ptr<column>> ret;
   ret.reserve(batch_info.row_batches.size());
   auto counting_iter = cuda::make_counting_iterator(0);
-  std::transform(counting_iter,
-                 counting_iter + batch_info.row_batches.size(),
-                 std::back_inserter(ret),
-                 [&](auto batch) {
-                   auto const offset_count = batch_info.row_batches[batch].row_offsets.size();
-                   auto offsets =
-                     std::make_unique<column>(data_type{type_id::INT32},
-                                              (size_type)offset_count,
-                                              batch_info.row_batches[batch].row_offsets.release(),
-                                              rmm::device_buffer{},
-                                              0);
-                   auto data = std::make_unique<column>(data_type{type_id::INT8},
-                                                        batch_info.row_batches[batch].num_bytes,
-                                                        std::move(output_buffers[batch]),
-                                                        rmm::device_buffer{},
-                                                        0);
+  std::transform(
+    counting_iter,
+    counting_iter + batch_info.row_batches.size(),
+    std::back_inserter(ret),
+    [&](auto batch) {
+      auto const offset_count = batch_info.row_batches[batch].row_offsets.size();
+      auto offsets =
+        std::make_unique<column>(data_type{type_id::INT32},
+                                 (size_type)offset_count,
+                                 batch_info.row_batches[batch].row_offsets.release(),
+                                 cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                 0);
+      auto data = std::make_unique<column>(data_type{type_id::INT8},
+                                           batch_info.row_batches[batch].num_bytes,
+                                           std::move(output_buffers[batch]),
+                                           cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                           0);
 
-                   return make_lists_column(batch_info.row_batches[batch].row_count,
-                                            std::move(offsets),
-                                            std::move(data),
-                                            0,
-                                            rmm::device_buffer{0, cudf::get_default_stream(), mr});
-                 });
+      return make_lists_column(
+        batch_info.row_batches[batch].row_count,
+        std::move(offsets),
+        std::move(data),
+        0,
+        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, cudf::get_default_stream(), mr));
+    });
 
   // Drain the async H2D uploads above before input_data, input_nm, output_data and
   // validity_tile_infos go out of scope: CUDA 13+ may read the host source only when the stream
@@ -2560,14 +2563,15 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     for (int i = 0; i < static_cast<int>(schema.size()); ++i) {
       if (schema[i].id() == type_id::STRING) {
         // stuff real string column
-        auto string_data = string_row_offset_columns[string_idx].release()->release();
-        output_columns[i] =
-          make_strings_column(num_rows,
-                              std::make_unique<cudf::column>(
-                                std::move(string_col_offsets[string_idx]), rmm::device_buffer{}, 0),
-                              string_data_cols[string_idx].release(),
-                              0,
-                              std::move(*string_data.null_mask.release()));
+        auto string_data  = string_row_offset_columns[string_idx].release()->release();
+        output_columns[i] = make_strings_column(
+          num_rows,
+          std::make_unique<cudf::column>(std::move(string_col_offsets[string_idx]),
+                                         cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                         0),
+          string_data_cols[string_idx].release(),
+          0,
+          std::move(*string_data.null_mask.release()));
         // Null count set to 0, temporarily. Will be fixed up before return.
         string_idx++;
       }

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,12 +223,13 @@ std::unique_ptr<column> convert_to_utc_with_multiple_timezones(
     transitions.column(1), stream, cudf::get_current_device_resource_ref());
   auto const dst_rules = cudf::lists_column_device_view{*dst_cdv_ptr};
 
-  auto result = cudf::make_timestamp_column(cudf::data_type{cudf::type_to_id<cudf::timestamp_us>()},
-                                            input_seconds.size(),
-                                            rmm::device_buffer{},
-                                            0,
-                                            stream,
-                                            mr);
+  auto result =
+    cudf::make_timestamp_column(cudf::data_type{cudf::type_to_id<cudf::timestamp_us>()},
+                                input_seconds.size(),
+                                cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                0,
+                                stream,
+                                mr);
   auto null_mask = cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
                                                  input_seconds.size(),
                                                  cudf::mask_state::UNALLOCATED,

--- a/src/main/cpp/src/utilities.cu
+++ b/src/main/cpp/src/utilities.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -27,6 +28,8 @@
 #include <cuda/functional>
 #include <cuda/stream>
 
+#include <climits>
+
 namespace spark_rapids_jni {
 
 bool is_basic_spark_numeric(cudf::data_type type)
@@ -36,7 +39,7 @@ bool is_basic_spark_numeric(cudf::data_type type)
          type.id() == cudf::type_id::FLOAT32 || type.id() == cudf::type_id::FLOAT64;
 }
 
-std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
+std::unique_ptr<cuda::device_buffer<std::byte>> bitmask_bitwise_or(
   std::vector<cudf::device_span<cudf::bitmask_type const>> const& input,
   cuda::stream_ref stream,
   rmm::device_async_resource_ref mr)
@@ -48,7 +51,8 @@ std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
       input.begin(), input.end(), [mask_size](auto mask) { return mask.size() == mask_size; }),
     "Encountered size mismatch in inputs");
   if (mask_size == 0) {
-    return std::make_unique<rmm::device_buffer>(rmm::device_buffer{0, stream, mr});
+    return std::make_unique<cuda::device_buffer<std::byte>>(
+      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED, stream, mr));
   }
 
   // move the pointers to the gpu
@@ -58,12 +62,16 @@ std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   auto d_input = cudf::detail::make_device_uvector_async(
     h_input, stream, rmm::mr::get_current_device_resource_ref());
 
-  std::unique_ptr<rmm::device_buffer> out =
-    std::make_unique<rmm::device_buffer>(mask_size * sizeof(cudf::bitmask_type), stream, mr);
+  std::unique_ptr<cuda::device_buffer<std::byte>> out =
+    std::make_unique<cuda::device_buffer<std::byte>>(
+      cudf::create_null_mask(mask_size * sizeof(cudf::bitmask_type) * CHAR_BIT,
+                             cudf::mask_state::UNINITIALIZED,
+                             stream,
+                             mr));
   thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     thrust::make_counting_iterator(0),
                     thrust::make_counting_iterator(0) + mask_size,
-                    static_cast<cudf::bitmask_type*>(out->data()),
+                    reinterpret_cast<cudf::bitmask_type*>(out->data()),
                     cuda::proclaim_return_type<cudf::bitmask_type>(
                       [buffers     = d_input.data(),
                        num_buffers = input.size()] __device__(cudf::size_type word_index) {

--- a/src/main/cpp/src/utilities.hpp
+++ b/src/main/cpp/src/utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/buffer>
 #include <cuda/stream>
 
 namespace spark_rapids_jni {
@@ -46,7 +47,7 @@ bool is_basic_spark_numeric(cudf::data_type type);
  * @param mr Device memory resource used to allocate the returned bloom filter's memory.
  *
  */
-std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
+std::unique_ptr<cuda::device_buffer<std::byte>> bitmask_bitwise_or(
   std::vector<cudf::device_span<cudf::bitmask_type const>> const& input,
   cuda::stream_ref stream           = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());

--- a/src/main/cpp/src/uuid.cu
+++ b/src/main/cpp/src/uuid.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,10 +176,11 @@ std::unique_ptr<cudf::column> generate_uuids(cudf::size_type row_count,
 
   return cudf::make_strings_column(
     row_count,
-    std::make_unique<cudf::column>(std::move(offsets), rmm::device_buffer{}, 0),
+    std::make_unique<cudf::column>(
+      std::move(offsets), cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED), 0),
     chars.release(),
-    0,                    // null count
-    rmm::device_buffer{}  // all UUIDs are non-null
+    0,                                                        // null count
+    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED)  // all UUIDs are non-null
   );
 }
 

--- a/src/main/cpp/src/zorder.cu
+++ b/src/main/cpp/src/zorder.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,8 +214,11 @@ std::unique_ptr<cudf::column> interleave_bits(cudf::table_view const& tbl,
   auto offsets_column = std::get<0>(
     cudf::detail::make_offsets_child_column(offset_begin, offset_begin + num_rows, stream, mr));
 
-  return cudf::make_lists_column(
-    num_rows, std::move(offsets_column), std::move(output_data_col), 0, rmm::device_buffer());
+  return cudf::make_lists_column(num_rows,
+                                 std::move(offsets_column),
+                                 std::move(output_data_col),
+                                 0,
+                                 cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 std::unique_ptr<cudf::column> hilbert_index(int32_t const num_bits_per_entry,

--- a/src/main/cpp/tests/bloom_filter.cu
+++ b/src/main/cpp/tests/bloom_filter.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,8 +169,12 @@ TEST_F(BloomFilterTest, ProbeMergedV1)
     thrust::make_counting_iterator(0) + 4,
     premerge_offsets->mutable_view().begin<cudf::size_type>(),
     bloom_filter_stride_transform{bloom_filter_a->view().size()});
-  auto premerged = cudf::make_lists_column(
-    3, std::move(premerge_offsets), std::move(premerge_children), 0, rmm::device_buffer{});
+  auto premerged =
+    cudf::make_lists_column(3,
+                            std::move(premerge_offsets),
+                            std::move(premerge_children),
+                            0,
+                            cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   // merged bloom filter
   auto bloom_filter_merged = spark_rapids_jni::bloom_filter_merge(*premerged);
@@ -325,8 +329,12 @@ TEST_F(BloomFilterTest, ProbeMergedV2)
     thrust::make_counting_iterator(0) + 4,
     premerge_offsets->mutable_view().begin<cudf::size_type>(),
     bloom_filter_stride_transform{bloom_filter_a->view().size()});
-  auto premerged = cudf::make_lists_column(
-    3, std::move(premerge_offsets), std::move(premerge_children), 0, rmm::device_buffer{});
+  auto premerged =
+    cudf::make_lists_column(3,
+                            std::move(premerge_offsets),
+                            std::move(premerge_children),
+                            0,
+                            cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   auto bloom_filter_merged = spark_rapids_jni::bloom_filter_merge(*premerged);
 

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,8 +255,11 @@ TYPED_TEST(StringToIntegerTests, Overflow)
 
 TYPED_TEST(StringToIntegerTests, Empty)
 {
-  auto empty = std::make_unique<column>(
-    data_type{type_id::STRING}, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
+  auto empty = std::make_unique<column>(data_type{type_id::STRING},
+                                        0,
+                                        rmm::device_buffer{},
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                        0);
 
   auto result = spark_rapids_jni::string_to_integer(data_type{type_to_id<TypeParam>()},
                                                     strings_column_view{empty->view()},
@@ -591,8 +594,11 @@ TEST_F(StringToDecimalTests, Edges)
 
 TEST_F(StringToDecimalTests, Empty)
 {
-  auto empty = std::make_unique<column>(
-    data_type{type_id::STRING}, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
+  auto empty = std::make_unique<column>(data_type{type_id::STRING},
+                                        0,
+                                        rmm::device_buffer{},
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                        0);
 
   auto const result = spark_rapids_jni::string_to_decimal(
     8, 2, strings_column_view{empty->view()}, false, true, cudf::get_default_stream());
@@ -808,8 +814,11 @@ TYPED_TEST(StringToFloatTests, TrickyValues)
 
 TYPED_TEST(StringToFloatTests, Empty)
 {
-  auto empty = std::make_unique<column>(
-    data_type{type_id::STRING}, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
+  auto empty = std::make_unique<column>(data_type{type_id::STRING},
+                                        0,
+                                        rmm::device_buffer{},
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),
+                                        0);
 
   auto const result = spark_rapids_jni::string_to_float(data_type{type_to_id<TypeParam>()},
                                                         strings_column_view{empty->view()},

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,9 @@ std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>>
                                  std::move(offsets_col),
                                  std::move(structs_child),
                                  null_count,
-                                 null_count > 0 ? std::move(*null_mask) : rmm::device_buffer{});
+                                 null_count > 0
+                                   ? std::move(*null_mask)
+                                   : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 // Convenience: every row valid.
@@ -685,18 +687,22 @@ std::unique_ptr<cudf::column> make_expected_raw_map_array(std::vector<std::vecto
   auto [inner_mask, inner_null_count] = cudf::bools_to_mask(
     cudf::test::fixed_width_column_wrapper<bool>(inner_valid.begin(), inner_valid.end()));
 
-  auto inner_list =
-    cudf::make_lists_column(num_pairs,
-                            std::move(inner_offsets_col),
-                            elements_child.release(),
-                            inner_null_count,
-                            inner_null_count > 0 ? std::move(*inner_mask) : rmm::device_buffer{});
+  auto inner_list = cudf::make_lists_column(
+    num_pairs,
+    std::move(inner_offsets_col),
+    elements_child.release(),
+    inner_null_count,
+    inner_null_count > 0 ? std::move(*inner_mask)
+                         : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   std::vector<std::unique_ptr<cudf::column>> struct_children;
   struct_children.emplace_back(keys_child.release());
   struct_children.emplace_back(std::move(inner_list));
   auto structs_child =
-    cudf::make_structs_column(num_pairs, std::move(struct_children), 0, rmm::device_buffer{});
+    cudf::make_structs_column(num_pairs,
+                              std::move(struct_children),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   auto outer_offsets_col = cudf::test::fixed_width_column_wrapper<cudf::size_type>(
                              outer_offsets.begin(), outer_offsets.end())
@@ -705,12 +711,13 @@ std::unique_ptr<cudf::column> make_expected_raw_map_array(std::vector<std::vecto
   auto [outer_mask, outer_null_count] = cudf::bools_to_mask(
     cudf::test::fixed_width_column_wrapper<bool>(row_valid.begin(), row_valid.end()));
 
-  return cudf::make_lists_column(
-    static_cast<cudf::size_type>(num_rows),
-    std::move(outer_offsets_col),
-    std::move(structs_child),
-    outer_null_count,
-    outer_null_count > 0 ? std::move(*outer_mask) : rmm::device_buffer{});
+  return cudf::make_lists_column(static_cast<cudf::size_type>(num_rows),
+                                 std::move(outer_offsets_col),
+                                 std::move(structs_child),
+                                 outer_null_count,
+                                 outer_null_count > 0
+                                   ? std::move(*outer_mask)
+                                   : cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 }
 
 // Convenience builders for `array_value` literals.

--- a/src/main/cpp/tests/hyper_log_log_plus_plus.cu
+++ b/src/main/cpp/tests/hyper_log_log_plus_plus.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,11 +128,12 @@ std::unique_ptr<cudf::column> make_struct_column_from_scalars(
     d_col_ptrs, scalars.size(), num_longs_in_scalar, d_output);
 
   // create struct column
-  return cudf::make_structs_column(scalars.size(),  // num_rows
-                                   std::move(children),
-                                   0,                     // null count
-                                   rmm::device_buffer{},  // null mask
-                                   stream);
+  return cudf::make_structs_column(
+    scalars.size(),  // num_rows
+    std::move(children),
+    0,                                                         // null count
+    cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED),  // null mask
+    stream);
 }
 
 /**

--- a/src/main/cpp/tests/map_utils.cpp
+++ b/src/main/cpp/tests/map_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,11 @@ TEST_F(MapUtilsTests, ListOfNonStructThrows)
   // LIST<INT32> — child is not STRUCT.
   auto offsets  = size_col{0, 2, 3}.release();
   auto children = int_col{1, 2, 3}.release();
-  auto list =
-    cudf::make_lists_column(2, std::move(offsets), std::move(children), 0, rmm::device_buffer{});
+  auto list     = cudf::make_lists_column(2,
+                                      std::move(offsets),
+                                      std::move(children),
+                                      0,
+                                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   EXPECT_THROW(static_cast<void>(spark_rapids_jni::map_from_entries(list->view(), true)),
                cudf::logic_error);
 }
@@ -56,8 +59,11 @@ TEST_F(MapUtilsTests, StructWithWrongArityThrows)
   auto keys    = int_col{1, 2, 3};
   auto structs = cudf::test::structs_column_wrapper({keys}).release();
   auto offsets = size_col{0, 2, 3}.release();
-  auto list =
-    cudf::make_lists_column(2, std::move(offsets), std::move(structs), 0, rmm::device_buffer{});
+  auto list    = cudf::make_lists_column(2,
+                                      std::move(offsets),
+                                      std::move(structs),
+                                      0,
+                                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   EXPECT_THROW(static_cast<void>(spark_rapids_jni::map_from_entries(list->view(), true)),
                cudf::logic_error);
 }
@@ -82,12 +88,15 @@ TEST_F(MapUtilsTests, EmptyNonListInputStillThrows)
 TEST_F(MapUtilsTests, StringKeyNullThrows)
 {
   // row 0: {"a", 10}, {null_key, 20}  →  must throw (null key in valid struct).
-  auto keys    = cudf::test::strings_column_wrapper({"a", "x"}, {1, 0});
-  auto values  = int_col{10, 20};
-  auto structs = cudf::test::structs_column_wrapper({keys, values}).release();
-  auto offsets = size_col{0, 2}.release();
-  auto list_col =
-    cudf::make_lists_column(1, std::move(offsets), std::move(structs), 0, rmm::device_buffer{});
+  auto keys     = cudf::test::strings_column_wrapper({"a", "x"}, {1, 0});
+  auto values   = int_col{10, 20};
+  auto structs  = cudf::test::structs_column_wrapper({keys, values}).release();
+  auto offsets  = size_col{0, 2}.release();
+  auto list_col = cudf::make_lists_column(1,
+                                          std::move(offsets),
+                                          std::move(structs),
+                                          0,
+                                          cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   EXPECT_THROW(static_cast<void>(spark_rapids_jni::map_from_entries(list_col->view(), true)),
                cudf::logic_error);
 }
@@ -96,12 +105,15 @@ TEST_F(MapUtilsTests, StringKeyNonNullIsValidMap)
 {
   // All-valid string keys: input is already a valid map.  is_valid_map returns true;
   // map_from_entries returns a non-null deep copy of input.
-  auto keys    = cudf::test::strings_column_wrapper({"a", "b", "c"});
-  auto values  = int_col{10, 20, 30};
-  auto structs = cudf::test::structs_column_wrapper({keys, values}).release();
-  auto offsets = size_col{0, 2, 3}.release();
-  auto list_col =
-    cudf::make_lists_column(2, std::move(offsets), std::move(structs), 0, rmm::device_buffer{});
+  auto keys     = cudf::test::strings_column_wrapper({"a", "b", "c"});
+  auto values   = int_col{10, 20, 30};
+  auto structs  = cudf::test::structs_column_wrapper({keys, values}).release();
+  auto offsets  = size_col{0, 2, 3}.release();
+  auto list_col = cudf::make_lists_column(2,
+                                          std::move(offsets),
+                                          std::move(structs),
+                                          0,
+                                          cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   EXPECT_TRUE(spark_rapids_jni::is_valid_map(list_col->view(), true));
 
   std::unique_ptr<cudf::column> result;
@@ -120,8 +132,11 @@ TEST_F(MapUtilsTests, EmptyListOfNonStructStillThrows)
 {
   auto offsets  = size_col{0}.release();
   auto children = int_col{}.release();
-  auto list_col =
-    cudf::make_lists_column(0, std::move(offsets), std::move(children), 0, rmm::device_buffer{});
+  auto list_col = cudf::make_lists_column(0,
+                                          std::move(offsets),
+                                          std::move(children),
+                                          0,
+                                          cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   EXPECT_THROW(static_cast<void>(spark_rapids_jni::map_from_entries(list_col->view(), true)),
                cudf::logic_error);
 }
@@ -137,12 +152,15 @@ TEST_F(MapUtilsTests, NullStructEntryMasksRowSlowPath)
   //   index 0: null_struct (struct validity = false)
   //   index 1: {2, 20}     (struct validity = true)
   //   index 2: {3, 30}     (struct validity = true)
-  auto keys    = int_col{-1, 2, 3};  // index-0 key is don't-care because the struct is null
-  auto values  = int_col{-1, 20, 30};
-  auto structs = cudf::test::structs_column_wrapper({keys, values}, {0, 1, 1}).release();
-  auto offsets = size_col{0, 2, 3}.release();
-  auto list_col =
-    cudf::make_lists_column(2, std::move(offsets), std::move(structs), 0, rmm::device_buffer{});
+  auto keys     = int_col{-1, 2, 3};  // index-0 key is don't-care because the struct is null
+  auto values   = int_col{-1, 20, 30};
+  auto structs  = cudf::test::structs_column_wrapper({keys, values}, {0, 1, 1}).release();
+  auto offsets  = size_col{0, 2, 3}.release();
+  auto list_col = cudf::make_lists_column(2,
+                                          std::move(offsets),
+                                          std::move(structs),
+                                          0,
+                                          cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   // is_valid_map sees the null struct entry and returns false.
   EXPECT_FALSE(spark_rapids_jni::is_valid_map(list_col->view(), true));
@@ -165,12 +183,15 @@ TEST_F(MapUtilsTests, IsValidMapNonListInputThrows)
 // and returns true under throw_on_null_key=false.
 TEST_F(MapUtilsTests, IsValidMapNullKeyPolicyVariants)
 {
-  auto keys    = cudf::test::strings_column_wrapper({"a", "x"}, {1, 0});
-  auto values  = int_col{10, 20};
-  auto structs = cudf::test::structs_column_wrapper({keys, values}).release();
-  auto offsets = size_col{0, 2}.release();
-  auto list_col =
-    cudf::make_lists_column(1, std::move(offsets), std::move(structs), 0, rmm::device_buffer{});
+  auto keys     = cudf::test::strings_column_wrapper({"a", "x"}, {1, 0});
+  auto values   = int_col{10, 20};
+  auto structs  = cudf::test::structs_column_wrapper({keys, values}).release();
+  auto offsets  = size_col{0, 2}.release();
+  auto list_col = cudf::make_lists_column(1,
+                                          std::move(offsets),
+                                          std::move(structs),
+                                          0,
+                                          cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   EXPECT_THROW(static_cast<void>(spark_rapids_jni::is_valid_map(list_col->view(), true)),
                cudf::logic_error);

--- a/src/main/cpp/tests/map_zip_with_utils.cpp
+++ b/src/main/cpp/tests/map_zip_with_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,12 @@ TEST_F(MapZipWithUtilsTests, BasicMapZipTest)
     auto list_offsets_column =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 3, 5, 6}.release();
     auto num_list_rows = list_offsets_column->size() - 1;
-    auto list_col1     = cudf::make_lists_column(
-      num_list_rows, std::move(list_offsets_column), std::move(struct_col1), 0, {});
+    auto list_col1 =
+      cudf::make_lists_column(num_list_rows,
+                              std::move(list_offsets_column),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2 = cudf::test::fixed_width_column_wrapper<int32_t>{7, 8, 9, 10, 11, 12};
     auto vals2 = cudf::test::fixed_width_column_wrapper<int32_t>{{12, 35, 25, 31, 351, 351},
@@ -54,8 +58,12 @@ TEST_F(MapZipWithUtilsTests, BasicMapZipTest)
     auto list_offsets_column2 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 3, 5, 6}.release();
     auto num_list_rows2 = list_offsets_column2->size() - 1;
-    auto list_col2      = cudf::make_lists_column(
-      num_list_rows2, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+    auto list_col2 =
+      cudf::make_lists_column(num_list_rows2,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto const k =
       cudf::test::fixed_width_column_wrapper<size_type>{1, 2, 7, 8, 3, 9, 4, 5, 10, 11, 6, 12};
@@ -87,7 +95,7 @@ TEST_F(MapZipWithUtilsTests, NullMapTest)
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 3, 5, 6}.release();
     auto num_list_rows = list_offsets_column->size() - 1;
     auto mask          = cudf::create_null_mask(4, cudf::mask_state::ALL_VALID);
-    cudf::set_null_mask(static_cast<cudf::bitmask_type*>(mask.data()), 1, 2, false);
+    cudf::set_null_mask(reinterpret_cast<cudf::bitmask_type*>(mask.data()), 1, 2, false);
     auto list_col1 = cudf::make_lists_column(
       num_list_rows, std::move(list_offsets_column), std::move(struct_col1), 1, std::move(mask));
 
@@ -100,8 +108,12 @@ TEST_F(MapZipWithUtilsTests, NullMapTest)
     auto list_offsets_column2 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 3, 5, 6}.release();
     auto num_list_rows2 = list_offsets_column2->size() - 1;
-    auto list_col2      = cudf::make_lists_column(
-      num_list_rows2, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+    auto list_col2 =
+      cudf::make_lists_column(num_list_rows2,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto const k = cudf::test::fixed_width_column_wrapper<size_type>{
       {1, 2, 7, 8, 4, 5, 10, 11, 6, 12}, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}};
@@ -134,8 +146,12 @@ TEST_F(MapZipWithUtilsTests, CharKeysTest)
     auto list_offsets_column =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 3, 5, 6}.release();
     auto num_list_rows = list_offsets_column->size() - 1;
-    auto list_col1     = cudf::make_lists_column(
-      num_list_rows, std::move(list_offsets_column), std::move(struct_col1), 0, {});
+    auto list_col1 =
+      cudf::make_lists_column(num_list_rows,
+                              std::move(list_offsets_column),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     std::initializer_list<std::string> names2 = {"g", "h", "i", "j", "k", "l"};
     auto keys2 = cudf::test::strings_column_wrapper{names2.begin(), names2.end()};
@@ -147,8 +163,12 @@ TEST_F(MapZipWithUtilsTests, CharKeysTest)
     auto list_offsets_column2 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 3, 5, 6}.release();
     auto num_list_rows2 = list_offsets_column2->size() - 1;
-    auto list_col2      = cudf::make_lists_column(
-      num_list_rows2, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+    auto list_col2 =
+      cudf::make_lists_column(num_list_rows2,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto const k = cudf::test::strings_column_wrapper{
       "a", "b", "g", "h", "c", "i", "d", "e", "j", "k", "f", "l"};
@@ -181,8 +201,12 @@ TEST_F(MapZipWithUtilsTests, StringKeysTest)
     auto list_offsets_column1 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 4, 7}.release();
     auto num_list_rows1 = list_offsets_column1->size() - 1;
-    auto list_col1      = cudf::make_lists_column(
-      num_list_rows1, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+    auto list_col1 =
+      cudf::make_lists_column(num_list_rows1,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     std::initializer_list<std::string> names2 = {
       "banana", "cherry", "date", "fig", "grape", "honeydew", "kiwi"};
@@ -194,8 +218,12 @@ TEST_F(MapZipWithUtilsTests, StringKeysTest)
     auto list_offsets_column2 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 3, 5, 7}.release();
     auto num_list_rows2 = list_offsets_column2->size() - 1;
-    auto list_col2      = cudf::make_lists_column(
-      num_list_rows2, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+    auto list_col2 =
+      cudf::make_lists_column(num_list_rows2,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results  = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));
@@ -237,7 +265,11 @@ TEST_F(MapZipWithUtilsTests, OneEmptyMapTest)
     auto list_offsets_column1 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 3}.release();
     auto list_col1 =
-      cudf::make_lists_column(2, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+      cudf::make_lists_column(2,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2       = cudf::test::fixed_width_column_wrapper<int32_t>{};
     auto vals2       = cudf::test::fixed_width_column_wrapper<int32_t>{};
@@ -245,7 +277,11 @@ TEST_F(MapZipWithUtilsTests, OneEmptyMapTest)
     auto list_offsets_column2 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 0, 0}.release();
     auto list_col2 =
-      cudf::make_lists_column(2, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+      cudf::make_lists_column(2,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));
@@ -272,7 +308,11 @@ TEST_F(MapZipWithUtilsTests, OverlappingKeysTest)
     auto struct_col1 = cudf::test::structs_column_wrapper({keys1, vals1}, {1, 1, 1, 1}).release();
     auto list_offsets_column1 = cudf::test::fixed_width_column_wrapper<size_type>{0, 4}.release();
     auto list_col1 =
-      cudf::make_lists_column(1, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2 = cudf::test::fixed_width_column_wrapper<int32_t>{2, 3, 5, 6};
     auto vals2 =
@@ -280,7 +320,11 @@ TEST_F(MapZipWithUtilsTests, OverlappingKeysTest)
     auto struct_col2 = cudf::test::structs_column_wrapper({keys2, vals2}, {1, 1, 1, 1}).release();
     auto list_offsets_column2 = cudf::test::fixed_width_column_wrapper<size_type>{0, 4}.release();
     auto list_col2 =
-      cudf::make_lists_column(1, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));
@@ -308,14 +352,22 @@ TEST_F(MapZipWithUtilsTests, NonOverlappingKeysTest)
     auto struct_col1 = cudf::test::structs_column_wrapper({keys1, vals1}, {1, 1, 1}).release();
     auto list_offsets_column1 = cudf::test::fixed_width_column_wrapper<size_type>{0, 3}.release();
     auto list_col1 =
-      cudf::make_lists_column(1, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2       = cudf::test::fixed_width_column_wrapper<int32_t>{4, 5, 6};
     auto vals2       = cudf::test::fixed_width_column_wrapper<int32_t>{{40, 50, 60}, {1, 1, 1}};
     auto struct_col2 = cudf::test::structs_column_wrapper({keys2, vals2}, {1, 1, 1}).release();
     auto list_offsets_column2 = cudf::test::fixed_width_column_wrapper<size_type>{0, 3}.release();
     auto list_col2 =
-      cudf::make_lists_column(1, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));
@@ -346,7 +398,11 @@ TEST_F(MapZipWithUtilsTests, MultipleRowsTest)
     auto list_offsets_column1 = cudf::test::fixed_width_column_wrapper<size_type>{0, 2, 5}
                                   .release();  // 2 rows: [1,2], [3,4,5]
     auto list_col1 =
-      cudf::make_lists_column(2, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+      cudf::make_lists_column(2,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2 = cudf::test::fixed_width_column_wrapper<int32_t>{2, 3, 4, 6, 7};
     auto vals2 =
@@ -356,7 +412,11 @@ TEST_F(MapZipWithUtilsTests, MultipleRowsTest)
     auto list_offsets_column2 = cudf::test::fixed_width_column_wrapper<size_type>{0, 3, 5}
                                   .release();  // 2 rows: [2,3,4], [6,7]
     auto list_col2 =
-      cudf::make_lists_column(2, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+      cudf::make_lists_column(2,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));
@@ -384,14 +444,22 @@ TEST_F(MapZipWithUtilsTests, SingleElementMapsTest)
     auto struct_col1          = cudf::test::structs_column_wrapper({keys1, vals1}, {1}).release();
     auto list_offsets_column1 = cudf::test::fixed_width_column_wrapper<size_type>{0, 1}.release();
     auto list_col1 =
-      cudf::make_lists_column(1, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2                = cudf::test::fixed_width_column_wrapper<int32_t>{2};
     auto vals2                = cudf::test::fixed_width_column_wrapper<int32_t>{{200}, {1}};
     auto struct_col2          = cudf::test::structs_column_wrapper({keys2, vals2}, {1}).release();
     auto list_offsets_column2 = cudf::test::fixed_width_column_wrapper<size_type>{0, 1}.release();
     auto list_col2 =
-      cudf::make_lists_column(1, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));
@@ -417,14 +485,22 @@ TEST_F(MapZipWithUtilsTests, IdenticalKeysTest)
     auto struct_col1 = cudf::test::structs_column_wrapper({keys1, vals1}, {1, 1, 1}).release();
     auto list_offsets_column1 = cudf::test::fixed_width_column_wrapper<size_type>{0, 3}.release();
     auto list_col1 =
-      cudf::make_lists_column(1, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2       = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
     auto vals2       = cudf::test::fixed_width_column_wrapper<int32_t>{{150, 250, 350}, {1, 1, 1}};
     auto struct_col2 = cudf::test::structs_column_wrapper({keys2, vals2}, {1, 1, 1}).release();
     auto list_offsets_column2 = cudf::test::fixed_width_column_wrapper<size_type>{0, 3}.release();
     auto list_col2 =
-      cudf::make_lists_column(1, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+      cudf::make_lists_column(1,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));
@@ -452,7 +528,11 @@ TEST_F(MapZipWithUtilsTests, LargeMapsTest)
     auto list_offsets_column1 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 3, 4, 6, 6, 10}.release();
     auto list_col1 =
-      cudf::make_lists_column(5, std::move(list_offsets_column1), std::move(struct_col1), 0, {});
+      cudf::make_lists_column(5,
+                              std::move(list_offsets_column1),
+                              std::move(struct_col1),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto keys2 =
       cudf::test::fixed_width_column_wrapper<int32_t>{3, 11, 12, 13, 4, 5, 6, 7, 9, 8, 14, 15};
@@ -462,7 +542,11 @@ TEST_F(MapZipWithUtilsTests, LargeMapsTest)
     auto list_offsets_column2 =
       cudf::test::fixed_width_column_wrapper<size_type>{0, 4, 5, 8, 8, 12}.release();
     auto list_col2 =
-      cudf::make_lists_column(5, std::move(list_offsets_column2), std::move(struct_col2), 0, {});
+      cudf::make_lists_column(5,
+                              std::move(list_offsets_column2),
+                              std::move(struct_col2),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     auto results = spark_rapids_jni::map_zip(cudf::lists_column_view(*list_col1),
                                              cudf::lists_column_view(*list_col2));

--- a/src/main/cpp/tests/shuffle_split.cu
+++ b/src/main/cpp/tests/shuffle_split.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -298,12 +298,20 @@ TEST_F(ShuffleSplitTests, Lists)
     cudf::test::strings_column_wrapper strings0{{"*", "*", "****", "", "*", ""},
                                                 {1, 1, 1, 1, 1, 0}};
     cudf::test::fixed_width_column_wrapper<int> offsets0{0, 1, 2, 3, 6};
-    auto col0 = cudf::make_lists_column(4, offsets0.release(), strings0.release(), 0, {});
+    auto col0 = cudf::make_lists_column(4,
+                                        offsets0.release(),
+                                        strings0.release(),
+                                        0,
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     cudf::test::strings_column_wrapper strings1{{"", "", "", "", "", "", ""},
                                                 {0, 0, 0, 0, 0, 0, 0}};
     cudf::test::fixed_width_column_wrapper<int> offsets1{0, 4, 4, 7, 7};
-    auto col1 = cudf::make_lists_column(4, offsets1.release(), strings1.release(), 0, {});
+    auto col1 = cudf::make_lists_column(4,
+                                        offsets1.release(),
+                                        strings1.release(),
+                                        0,
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     cudf::table_view tbl{{*col0, *col1}};
     run_split(tbl, {});
@@ -423,9 +431,11 @@ TEST_F(ShuffleSplitTests, PurgeNulls)
   // non-nullable outputs at assemble side.
 
   // manually construct a column with a non-null validity buffer to force it to appear nullable
-  auto validity_buffer =
-    rmm::device_buffer{1, cudf::get_default_stream(), rmm::mr::get_current_device_resource_ref()};
-  auto col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_to_id<float>()},
+  auto validity_buffer = cudf::create_null_mask(1,
+                                                cudf::mask_state::UNINITIALIZED,
+                                                cudf::get_default_stream(),
+                                                rmm::mr::get_current_device_resource_ref());
+  auto col             = std::make_unique<cudf::column>(cudf::data_type{cudf::type_to_id<float>()},
                                             0,
                                             rmm::device_buffer{},
                                             std::move(validity_buffer),
@@ -448,14 +458,22 @@ TEST_F(ShuffleSplitTests, EmptyOffsets)
   // list<string> with empty strings
   cudf::test::strings_column_wrapper strings0{};
   cudf::test::fixed_width_column_wrapper<int> offsets0{0, 0, 0};
-  auto col0 = cudf::make_lists_column(2, offsets0.release(), strings0.release(), 0, {});
+  auto col0 = cudf::make_lists_column(2,
+                                      offsets0.release(),
+                                      strings0.release(),
+                                      0,
+                                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
   cudf::lists_column_view lcv(*col0);
   CUDF_EXPECTS(lcv.child().num_children() == 0, "String column is expected to have no offsets");
 
   // list<list<int>> with empty inner list
   cudf::test::lists_column_wrapper<int> list0{};
   cudf::test::fixed_width_column_wrapper<int> offsets1{0, 0, 0};
-  auto col1 = cudf::make_lists_column(2, offsets1.release(), list0.release(), 0, {});
+  auto col1 = cudf::make_lists_column(2,
+                                      offsets1.release(),
+                                      list0.release(),
+                                      0,
+                                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   // list<struct<int, int>>
   cudf::test::fixed_width_column_wrapper<int> ints0{-210, 311};
@@ -465,7 +483,11 @@ TEST_F(ShuffleSplitTests, EmptyOffsets)
   inner_children.push_back(ints1.release());
   cudf::test::structs_column_wrapper inner_struct(std::move(inner_children));
   cudf::test::fixed_width_column_wrapper<int> offsets2{0, 1, 2};
-  auto col2 = cudf::make_lists_column(2, offsets2.release(), inner_struct.release(), 0, {});
+  auto col2 = cudf::make_lists_column(2,
+                                      offsets2.release(),
+                                      inner_struct.release(),
+                                      0,
+                                      cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
   cudf::table_view tbl{{*col0, *col1, *col2, *col1}};
   auto result = run_split(tbl, {});
@@ -591,7 +613,12 @@ TEST_F(ShuffleSplitTests, NestedTypes)
 
     // list<struct<list, list>>
     cudf::test::fixed_width_column_wrapper<int> offsets{0, 2, 4, 6, 7, 9, 9, 12, 16};
-    auto list_col = cudf::make_lists_column(8, offsets.release(), struct_col.release(), 0, {});
+    auto list_col =
+      cudf::make_lists_column(8,
+                              offsets.release(),
+                              struct_col.release(),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     cudf::table_view tbl{{*list_col}};
     run_split(tbl, {});
@@ -701,7 +728,12 @@ TEST_F(ShuffleSplitTests, Reshaping)
 
     // list<struct<list, list>>
     cudf::test::fixed_width_column_wrapper<int> offsets{0, 2, 4, 6, 7, 9, 9, 12, 16};
-    auto list_col = cudf::make_lists_column(8, offsets.release(), struct_col.release(), 0, {});
+    auto list_col =
+      cudf::make_lists_column(8,
+                              offsets.release(),
+                              struct_col.release(),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     cudf::table_view tbl{{*list_col}};
     run_split(tbl, {2, 4}, {2, 0, 1});
@@ -788,7 +820,12 @@ TEST_F(ShuffleSplitTests, NestedTerminatingEmptyPartition)
     cudf::test::structs_column_wrapper str(std::move(children));
 
     cudf::test::fixed_width_column_wrapper<int> inner_offsets{0, 1, 2, 3, 4, 5, 6, 7, 8};
-    auto inner_list = cudf::make_lists_column(8, inner_offsets.release(), str.release(), 0, {});
+    auto inner_list =
+      cudf::make_lists_column(8,
+                              inner_offsets.release(),
+                              str.release(),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
 
     cudf::test::fixed_width_column_wrapper<int> outer_offsets{
       0, 1, 2, 2, 2, 2, 3, 4, 4, 4, 4, 4, 5, 6, 7, 7, 8, 8, 8};
@@ -808,7 +845,11 @@ TEST_F(ShuffleSplitTests, NestedTerminatingEmptyPartition)
   {
     cudf::test::strings_column_wrapper str{};
     cudf::test::fixed_width_column_wrapper<int> offsets{0, 0, 0, 0, 0, 0, 0, 0, 0};
-    auto list = cudf::make_lists_column(8, offsets.release(), str.release(), 0, {});
+    auto list = cudf::make_lists_column(8,
+                                        offsets.release(),
+                                        str.release(),
+                                        0,
+                                        cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
     cudf::table_view tbl{{*list}};
     run_split(tbl, {2, 4, 6});
   }

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,8 +93,12 @@ class TimeZoneTest : public cudf::test::BaseFixture {
     // make empty DST list<int> column, it means all timezones are non-DST
     auto dst_child   = int32_col({});
     auto dst_offsets = cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 0};
-    auto dst_col     = cudf::make_lists_column(
-      2, dst_offsets.release(), dst_child.release(), 0, rmm::device_buffer{});
+    auto dst_col =
+      cudf::make_lists_column(2,
+                              dst_offsets.release(),
+                              dst_child.release(),
+                              0,
+                              cudf::create_null_mask(0, cudf::mask_state::UNALLOCATED));
     columns.push_back(std::move(dst_col));
 
     return std::make_unique<cudf::table>(std::move(columns));

--- a/src/main/cpp/tests/utilities.cpp
+++ b/src/main/cpp/tests/utilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,12 +43,15 @@ TEST_F(UtilitiesTest, BitwiseOr)
     std::vector<cudf::bitmask_type> expect{
       0x11111001, 0xffffffff, 0xffff0000, 0xf101010f, 0xab0100ab};
     auto d_result = spark_rapids_jni::bitmask_bitwise_or({{da}, {db}}, stream);
-    CUDF_EXPECTS(d_result->size() == expect.size() * sizeof(cudf::bitmask_type),
+    CUDF_EXPECTS(d_result->size() >= expect.size() * sizeof(cudf::bitmask_type),
                  "Unexpected output size");
     std::vector<cudf::bitmask_type> result(expect.size());
-    cudaMemcpy(result.data(), d_result->data(), d_result->size(), cudaMemcpyDefault);
+    cudaMemcpy(result.data(),
+               d_result->data(),
+               result.size() * sizeof(cudf::bitmask_type),
+               cudaMemcpyDefault);
     CUDF_EXPECTS(std::equal(result.begin(), result.end(), expect.begin()),
-                 "Unexpected output size");
+                 "Results do not match expected");
   }
 
   // 4 buffers
@@ -72,10 +75,13 @@ TEST_F(UtilitiesTest, BitwiseOr)
     std::vector<cudf::bitmask_type> expect{
       0x10011001, 0x0000ffff, 0xffff0000, 0x01010101, 0xab0000ab};
     auto d_result = spark_rapids_jni::bitmask_bitwise_or({{da}, {db}, {dc}, {dd}}, stream);
-    CUDF_EXPECTS(d_result->size() == expect.size() * sizeof(cudf::bitmask_type),
+    CUDF_EXPECTS(d_result->size() >= expect.size() * sizeof(cudf::bitmask_type),
                  "Unexpected output size");
     std::vector<cudf::bitmask_type> result(expect.size());
-    cudaMemcpy(result.data(), d_result->data(), d_result->size(), cudaMemcpyDefault);
+    cudaMemcpy(result.data(),
+               d_result->data(),
+               result.size() * sizeof(cudf::bitmask_type),
+               cudaMemcpyDefault);
     CUDF_EXPECTS(std::equal(result.begin(), result.end(), expect.begin()),
                  "Results do not match expected");
   }

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -49,7 +49,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "f1b809b15dfd135228ccca401cdd458650e81b8d",
+      "git_tag" : "bbbe461e3ed6579472dd8d0420e5fabcd2bd940b",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
       "version" : "26.12"


### PR DESCRIPTION
## Description

Update usages of cudf's null masks to be
`cuda::device_buffer<std::byte>` while leaving other instances of
`rmm::device_buffer` alone.

Blocked by https://github.com/NVIDIA/cudf/pull/23989.

Issue: https://github.com/rapidsai/build-planning/issues/321

## Notes for Reviewers

Files that contain nontrivial changes that go beyond "replace X with Y" and may be of interest to reviewers:

- `src/main/cpp/tests/utilities.cpp` - changes expectations around padding