### PR TITLE
Fix inner-join deprecation error to allow cudf submodule update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.nvidia</groupId>
   <artifactId>cudf-spark-jni</artifactId>
-  <version>jnibug</version>
+  <version>26.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>NVIDIA cuDF plugin JNI for Apache Spark</name>
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.nvidia</groupId>
   <artifactId>cudf-spark-jni</artifactId>
-  <version>26.10.0-SNAPSHOT</version>
+  <version>jnibug</version>
   <packaging>jar</packaging>
   <name>NVIDIA cuDF plugin JNI for Apache Spark</name>
   <description>

--- a/src/main/cpp/src/JoinPrimitivesJni.cpp
+++ b/src/main/cpp/src/JoinPrimitivesJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,6 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeSortMergeInnerJoin(JNIEnv*
                                                                          jclass,
                                                                          jlong j_left_keys,
                                                                          jlong j_right_keys,
-                                                                         jboolean j_is_left_sorted,
                                                                          jboolean j_is_right_sorted,
                                                                          jboolean j_nulls_equal)
 {
@@ -112,13 +111,12 @@ Java_com_nvidia_spark_rapids_jni_JoinPrimitives_nativeSortMergeInnerJoin(JNIEnv*
     auto const left_keys  = std::bit_cast<cudf::table_view const*>(j_left_keys);
     auto const right_keys = std::bit_cast<cudf::table_view const*>(j_right_keys);
 
-    auto const is_left_sorted  = j_is_left_sorted ? cudf::sorted::YES : cudf::sorted::NO;
     auto const is_right_sorted = j_is_right_sorted ? cudf::sorted::YES : cudf::sorted::NO;
     auto const nulls_equal =
       j_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
 
     auto result = spark_rapids_jni::sort_merge_inner_join(
-      *left_keys, *right_keys, is_left_sorted, is_right_sorted, nulls_equal);
+      *left_keys, *right_keys, is_right_sorted, nulls_equal);
 
     return gather_maps_to_java(env, std::move(result));
   }

--- a/src/main/cpp/src/join_primitives.cu
+++ b/src/main/cpp/src/join_primitives.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,7 +180,6 @@ filter_by_conditional_impl(cudf::device_span<cudf::size_type const> left_indices
 std::pair<rmm::device_uvector<cudf::size_type>, rmm::device_uvector<cudf::size_type>>
 sort_merge_inner_join(cudf::table_view const& left_keys,
                       cudf::table_view const& right_keys,
-                      cudf::sorted is_left_sorted,
                       cudf::sorted is_right_sorted,
                       cudf::null_equality compare_nulls,
                       cuda::stream_ref stream,
@@ -200,7 +199,7 @@ sort_merge_inner_join(cudf::table_view const& left_keys,
 
   // Perform sort-merge inner join
   cudf::sort_merge_join join_obj(right_keys, is_right_sorted, compare_nulls, stream);
-  auto [left_result, right_result] = join_obj.inner_join(left_keys, is_left_sorted, stream, mr);
+  auto [left_result, right_result] = join_obj.inner_join(left_keys, stream, mr);
   return {std::move(*left_result), std::move(*right_result)};
 }
 

--- a/src/main/cpp/src/join_primitives.hpp
+++ b/src/main/cpp/src/join_primitives.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,6 @@ namespace spark_rapids_jni {
  *
  * @param left_keys The left table for equality comparison
  * @param right_keys The right table for equality comparison
- * @param is_left_sorted Whether the left table is pre-sorted
  * @param is_right_sorted Whether the right table is pre-sorted
  * @param compare_nulls Whether null values in equality keys join to each other
  * @param stream CUDA stream for device operations
@@ -65,7 +64,6 @@ namespace spark_rapids_jni {
 std::pair<rmm::device_uvector<cudf::size_type>, rmm::device_uvector<cudf::size_type>>
 sort_merge_inner_join(cudf::table_view const& left_keys,
                       cudf::table_view const& right_keys,
-                      cudf::sorted is_left_sorted       = cudf::sorted::NO,
                       cudf::sorted is_right_sorted      = cudf::sorted::NO,
                       cudf::null_equality compare_nulls = cudf::null_equality::EQUAL,
                       cuda::stream_ref stream           = cudf::get_default_stream(),

--- a/src/main/java/com/nvidia/spark/rapids/jni/JoinPrimitives.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JoinPrimitives.java
@@ -72,8 +72,34 @@ public class JoinPrimitives {
    *
    * @param leftKeys The left table for equality comparison
    * @param rightKeys The right table for equality comparison
-   * @param isLeftSorted Ignored. Retained for source compatibility; the underlying
-   *                     cudf API no longer uses it.
+   * @param isRightSorted Whether the right table is pre-sorted
+   * @param compareNullsEqual Whether nulls in equality keys should be considered equal
+   * @return An array of two GatherMaps: [left_map, right_map]
+   */
+  public static GatherMap[] sortMergeInnerJoin(Table leftKeys,
+                                               Table rightKeys,
+                                               boolean isRightSorted,
+                                               boolean compareNullsEqual) {
+    long[] result = nativeSortMergeInnerJoin(
+      leftKeys.getNativeView(),
+      rightKeys.getNativeView(),
+      isRightSorted,
+      compareNullsEqual);
+
+    return gatherMapsFromJNI(result);
+  }
+
+  /**
+   * Perform an inner join using sort-merge algorithm.
+   * <p>
+   * Use {@link #sortMergeInnerJoin(Table, Table, boolean, boolean)} instead. This
+   * overload remains only so existing callers keep compiling, and will be removed
+   * once they have moved over.
+   * </p>
+   *
+   * @param leftKeys The left table for equality comparison
+   * @param rightKeys The right table for equality comparison
+   * @param isLeftSorted Ignored. The underlying cudf API no longer uses it.
    * @param isRightSorted Whether the right table is pre-sorted
    * @param compareNullsEqual Whether nulls in equality keys should be considered equal
    * @return An array of two GatherMaps: [left_map, right_map]
@@ -83,13 +109,7 @@ public class JoinPrimitives {
                                                boolean isLeftSorted,
                                                boolean isRightSorted,
                                                boolean compareNullsEqual) {
-    long[] result = nativeSortMergeInnerJoin(
-      leftKeys.getNativeView(),
-      rightKeys.getNativeView(),
-      isRightSorted,
-      compareNullsEqual);
-    
-    return gatherMapsFromJNI(result);
+    return sortMergeInnerJoin(leftKeys, rightKeys, isRightSorted, compareNullsEqual);
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/JoinPrimitives.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JoinPrimitives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,8 @@ public class JoinPrimitives {
    *
    * @param leftKeys The left table for equality comparison
    * @param rightKeys The right table for equality comparison
-   * @param isLeftSorted Whether the left table is pre-sorted
+   * @param isLeftSorted Ignored. Retained for source compatibility; the underlying
+   *                     cudf API no longer uses it.
    * @param isRightSorted Whether the right table is pre-sorted
    * @param compareNullsEqual Whether nulls in equality keys should be considered equal
    * @return An array of two GatherMaps: [left_map, right_map]
@@ -85,7 +86,6 @@ public class JoinPrimitives {
     long[] result = nativeSortMergeInnerJoin(
       leftKeys.getNativeView(),
       rightKeys.getNativeView(),
-      isLeftSorted,
       isRightSorted,
       compareNullsEqual);
     
@@ -314,7 +314,6 @@ public class JoinPrimitives {
   private static native long[] nativeSortMergeInnerJoin(
     long leftKeys,
     long rightKeys,
-    boolean isLeftSorted,
     boolean isRightSorted,
     boolean compareNullsEqual);
 


### PR DESCRIPTION
Fixes #5107.

This [cuDF PR](https://github.com/NVIDIA/cudf/pull/23985) removed the `-Wno-error=deprecated-declarations` compile flag so all warnings are errors in C++ builds.  This PR fixes the deprecation error for inner-join, and adds an overloaded function for the java cudf-spark interface that doesn't have the parameter.  That way this doesn't break the cudf-spark build while we change it there, and can come back and delete the extra function here afterwards.  

[This cuDF PR](https://github.com/NVIDIA/cudf/pull/23532) is the inner-join change.  It changes the algorithm such that the probe (left) table no longer needs to be sorted, so this extra parameter is irrelevant. 